### PR TITLE
ci: golangci-lint の追加

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, release, dev]
   push:
     branches: [main, release, dev]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -2,17 +2,15 @@ name: GoTest
 
 on:
   pull_request:
-    branches: [ main, release, dev ]
+    branches: [main, release, dev]
   push:
-    branches: [ main, release, dev ]
+    branches: [main, release, dev]
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-
       - name: Set up Go 1.19
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -27,3 +27,18 @@ jobs:
           go mod tidy
           go test -v ./...
 
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.19"
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.54
+          working-directory: system

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -10,18 +10,20 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Set up Go 1.19
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ^1.19
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get dependencies and run tests
+        working-directory: system
         run: |
-          cd system
           go mod tidy
           go test -v ./...
+


### PR DESCRIPTION
go vet 等、必要最低限のリンターを走らせることによって信頼性を向上させるため。 