### PR TITLE
Migrating AWS Lambda functions from the Go1.x runtime to the custom runtime on Amazon Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ system/.gcloudignore
 system/app.modules.exe
 system/main.exe
 system/main
+system/bootstrap.exe
+system/bootstrap
 system/.env
 system/aws-lambda/main
 system/aws-lambda/main.zip

--- a/system/aws-lambda/Taskfile_darwin.yml
+++ b/system/aws-lambda/Taskfile_darwin.yml
@@ -10,5 +10,5 @@ tasks:
       GOARCH: amd64
     cmds:
       - echo "Building function {{.FUNCTION_NAME}}"
-      - go build -o main {{.FUNCTION_NAME}}/main.go
-      - zip main.zip main
+      - go build -tags lambda.norpc -o bootstrap {{.FUNCTION_NAME}}/main.go
+      - zip main.zip bootstrap

--- a/system/aws-lambda/Taskfile_windows.yml
+++ b/system/aws-lambda/Taskfile_windows.yml
@@ -11,5 +11,5 @@ tasks:
       CGO_ENABLED: 0
     cmds:
       - echo "Building function {{.FUNCTION_NAME}}"
-      - go build -o main {{.FUNCTION_NAME}}/main.go
-      - ~/Go/bin/build-lambda-zip.exe -o main.zip main
+      - go build -tags lambda.norpc -o bootstrap {{.FUNCTION_NAME}}/main.go
+      - ~/Go/bin/build-lambda-zip.exe -o main.zip bootstrap


### PR DESCRIPTION
https://aws.amazon.com/jp/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/