### PR TITLE
updateWorkNameTrendFunction の実行間隔を5分から15分に変更

### DIFF
--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -748,8 +748,8 @@ export class AwsCdkStack extends cdk.Stack {
 			],
 		})
 
-		new events.Rule(this, '5minutes', {
-			schedule: events.Schedule.rate(cdk.Duration.minutes(5)),
+		new events.Rule(this, '15minutes', {
+			schedule: events.Schedule.rate(cdk.Duration.minutes(15)),
 			targets: [new targets.LambdaFunction(updateWorkNameTrendFunction)],
 		})
 	}


### PR DESCRIPTION
This pull request updates the schedule for a periodic AWS event trigger in the `AwsCdkStack` class. The event rule now runs every 15 minutes instead of every 5 minutes.

* Changed the event rule identifier from `'5minutes'` to `'15minutes'` and updated its schedule to trigger every 15 minutes instead of every 5 minutes in `aws-cdk/lib/aws-cdk-stack.ts`.