### PR TITLE
Enhance Dockerfiles for improved dependency management and build efficiency

### DIFF
--- a/system/Dockerfile.fargate
+++ b/system/Dockerfile.fargate
@@ -1,5 +1,11 @@
 FROM golang:1.24 AS build
 WORKDIR /src
+
+# 依存関係キャッシュを効かせるために先に go.mod/go.sum だけコピー
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+# アプリコードをコピー
 COPY . .
 
 # Build for linux/${GOARCH}, static, no cgo

--- a/system/Dockerfile.lambda
+++ b/system/Dockerfile.lambda
@@ -1,14 +1,34 @@
-FROM golang:1.24 as build
+FROM golang:1.24 AS build
 WORKDIR /var/task
-COPY . .
-ENV GOCACHE=/root/.cache/go-build
 
-RUN --mount=type=cache,target="/root/.cache/go-build" go build -tags lambda.norpc,timetzdata -o set_desired_max_seats aws-lambda/set_desired_max_seats/main.go
-RUN --mount=type=cache,target="/root/.cache/go-build" go build -tags lambda.norpc,timetzdata -o youtube_organize_database aws-lambda/youtube_organize_database/main.go
-RUN --mount=type=cache,target="/root/.cache/go-build" go build -tags lambda.norpc,timetzdata -o check_live_stream_status aws-lambda/check_live_stream_status/main.go
-RUN --mount=type=cache,target="/root/.cache/go-build" go build -tags lambda.norpc,timetzdata -o sns_notify_discord aws-lambda/sns_notify_discord/main.go
-RUN --mount=type=cache,target="/root/.cache/go-build" go build -tags lambda.norpc,timetzdata -o start_daily_batch aws-lambda/start_daily_batch/main.go
-RUN --mount=type=cache,target="/root/.cache/go-build" go build -tags lambda.norpc,timetzdata -o update_work_name_trend aws-lambda/update_work_name_trend/main.go
+# 依存関係キャッシュを効かせるために先に go.mod/go.sum だけコピー
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+# アプリコードをコピー
+COPY . .
+
+# Build for linux, static, no cgo
+ENV CGO_ENABLED=0 GOOS=linux GOCACHE=/root/.cache/go-build
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -tags lambda.norpc,timetzdata -trimpath -ldflags="-s -w" -o set_desired_max_seats aws-lambda/set_desired_max_seats/main.go
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -tags lambda.norpc,timetzdata -trimpath -ldflags="-s -w" -o youtube_organize_database aws-lambda/youtube_organize_database/main.go
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -tags lambda.norpc,timetzdata -trimpath -ldflags="-s -w" -o check_live_stream_status aws-lambda/check_live_stream_status/main.go
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -tags lambda.norpc,timetzdata -trimpath -ldflags="-s -w" -o sns_notify_discord aws-lambda/sns_notify_discord/main.go
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -tags lambda.norpc,timetzdata -trimpath -ldflags="-s -w" -o start_daily_batch aws-lambda/start_daily_batch/main.go
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -tags lambda.norpc,timetzdata -trimpath -ldflags="-s -w" -o update_work_name_trend aws-lambda/update_work_name_trend/main.go
 
 # Copy artifacts to a clean image
 FROM public.ecr.aws/lambda/provided:al2023


### PR DESCRIPTION
This pull request updates the Docker build process for both Fargate and Lambda environments to optimize dependency caching and improve build efficiency. The main improvements include separating dependency installation from application code copying, enabling better use of build caches, and streamlining the build commands for Lambda binaries.

**Build cache optimization and dependency management:**

* Added steps to copy only `go.mod` and `go.sum` before application code, and run `go mod download` with a cache mount in both `Dockerfile.fargate` and `Dockerfile.lambda`, improving dependency cache effectiveness. [[1]](diffhunk://#diff-106032bbe9edb27e985355346663a9aa9c0d319e61521b7d7df4e498275d35b2R3-R8) [[2]](diffhunk://#diff-4b62effdba40d9f9901f6b848dbf657b5470c3ebe1aee3b0c8a80c4e8625944bL1-R31)

**Build process improvements for Lambda:**

* Updated environment variables and build flags in `Dockerfile.lambda` to ensure static builds for Linux, disabled cgo, and used `-trimpath` and stripped binaries for smaller output.
* Consolidated build commands for Lambda binaries to use both module and build caches, improving build speed and reproducibility.…ciency

- Updated Dockerfile.fargate and Dockerfile.lambda to copy go.mod and go.sum first for better dependency caching.
- Added cache mounts for Go module downloads and build processes to optimize build times.
- Included the `-trimpath` and `-ldflags="-s -w"` flags in build commands for smaller binary sizes and improved performance.