### PR TITLE
Refactor WordsReader interface and SpreadsheetReader methods to include context parameter

### DIFF
--- a/system/core/wordsreader/interface.go
+++ b/system/core/wordsreader/interface.go
@@ -1,6 +1,8 @@
 package wordsreader
 
+import "context"
+
 type WordsReader interface {
-	ReadBlockRegexes() (chatRegexes []string, channelRegexes []string, err error)
-	ReadNotificationRegexes() (chatRegexes []string, channelRegexes []string, err error)
+	ReadBlockRegexes(ctx context.Context) (chatRegexes []string, channelRegexes []string, err error)
+	ReadNotificationRegexes(ctx context.Context) (chatRegexes []string, channelRegexes []string, err error)
 }

--- a/system/core/wordsreader/spreadsheet_controller.go
+++ b/system/core/wordsreader/spreadsheet_controller.go
@@ -29,7 +29,7 @@ func NewSpreadsheetReader(
 		return nil, fmt.Errorf("in sheets.NewService: %w", err)
 	}
 
-	ss, err := service.Spreadsheets.Get(spreadsheetId).Do()
+	ss, err := service.Spreadsheets.Get(spreadsheetId).Context(ctx).Do()
 	if err != nil {
 		return nil, fmt.Errorf("in service.Spreadsheets.Get: %w", err)
 	}
@@ -59,9 +59,9 @@ func NewSpreadsheetReader(
 	}, nil
 }
 
-func (sc *SpreadsheetReader) ReadBlockRegexes() (chatRegexes []string, channelRegexes []string, err error) {
+func (sc *SpreadsheetReader) ReadBlockRegexes(ctx context.Context) (chatRegexes []string, channelRegexes []string, err error) {
 	readRange := fmt.Sprintf("%s!A2:C999", sc.blockRegexSheetName) // 「有効, 文字列, チャンネル名にも適用」2行目スタート。999行目まで。
-	resp, err := sc.client.Spreadsheets.Values.Get(sc.spreadsheetId, readRange).Do()
+	resp, err := sc.client.Spreadsheets.Values.Get(sc.spreadsheetId, readRange).Context(ctx).Do()
 	if err != nil {
 		return nil, nil, fmt.Errorf("in sc.client.Spreadsheets.Values.Get: %w", err)
 	}
@@ -101,9 +101,9 @@ func (sc *SpreadsheetReader) ReadBlockRegexes() (chatRegexes []string, channelRe
 	return
 }
 
-func (sc *SpreadsheetReader) ReadNotificationRegexes() (chatRegexes []string, channelRegexes []string, err error) {
+func (sc *SpreadsheetReader) ReadNotificationRegexes(ctx context.Context) (chatRegexes []string, channelRegexes []string, err error) {
 	readRange := fmt.Sprintf("%s!A2:C999", sc.notificationRegexSheetName) // 「有効, 文字列, チャンネル名にも適用」2行目スタート。999行目まで。
-	resp, err := sc.client.Spreadsheets.Values.Get(sc.spreadsheetId, readRange).Do()
+	resp, err := sc.client.Spreadsheets.Values.Get(sc.spreadsheetId, readRange).Context(ctx).Do()
 	if err != nil {
 		return nil, nil, fmt.Errorf("in sc.client.Spreadsheets.Values.Get: %w", err)
 	}

--- a/system/core/workspaceapp/workspace_app.go
+++ b/system/core/workspaceapp/workspace_app.go
@@ -54,18 +54,21 @@ func NewWorkspaceApp(ctx context.Context, interactive bool, clientOption option.
 		return nil, fmt.Errorf("in LoadLocaleFolderFS(): %w", err)
 	}
 
+	slog.InfoContext(ctx, "initializing firestore client...")
 	firestoreController, err := repository.NewFirestoreController(ctx, clientOption)
 	if err != nil {
 		return nil, fmt.Errorf("in NewFirestoreController(): %w", err)
 	}
 
 	// credentials
+	slog.InfoContext(ctx, "reading credentials config...")
 	credentialsDoc, err := firestoreController.ReadCredentialsConfig(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("in ReadCredentialsConfig(): %w", err)
 	}
 
 	// YouTube live chatbot
+	slog.InfoContext(ctx, "initializing youtube live chat bot...")
 	liveChatBot, err := youtubebot.NewYoutubeLiveChatBot(credentialsDoc.YoutubeLiveChatId, firestoreController, ctx)
 	if err != nil {
 		return nil, fmt.Errorf("in NewYoutubeLiveChatBot(): %w", err)
@@ -88,6 +91,7 @@ func NewWorkspaceApp(ctx context.Context, interactive bool, clientOption option.
 	}
 
 	// core constant values
+	slog.InfoContext(ctx, "reading system constants config...")
 	constantsConfig, err := firestoreController.ReadSystemConstantsConfig(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("in ReadSystemConstantsConfig(): %w", err)
@@ -125,19 +129,23 @@ func NewWorkspaceApp(ctx context.Context, interactive bool, clientOption option.
 		}
 	}
 
+	slog.InfoContext(ctx, "initializing spreadsheet reader...")
 	wordsReader, err := wordsreader.NewSpreadsheetReader(ctx, clientOption, configs.Constants.BotConfigSpreadsheetId, "01", "02")
 	if err != nil {
 		return nil, fmt.Errorf("in NewSpreadsheetReader(): %w", err)
 	}
-	blockRegexesForChatMessage, blockRegexesForChannelName, err := wordsReader.ReadBlockRegexes()
+	slog.InfoContext(ctx, "reading block regexes...")
+	blockRegexesForChatMessage, blockRegexesForChannelName, err := wordsReader.ReadBlockRegexes(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("in ReadBlockRegexes(): %w", err)
 	}
-	notificationRegexesForChatMessage, notificationRegexesForChannelName, err := wordsReader.ReadNotificationRegexes()
+	slog.InfoContext(ctx, "reading notification regexes...")
+	notificationRegexesForChatMessage, notificationRegexesForChannelName, err := wordsReader.ReadNotificationRegexes(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("in ReadNotificationRegexes(): %w", err)
 	}
 
+	slog.InfoContext(ctx, "reading menu docs...")
 	sortedMenuItems, err := firestoreController.ReadAllMenuDocsOrderByCode(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("in ReadAllMenuDocsOrderByCode(): %w", err)


### PR DESCRIPTION
This pull request updates the `WordsReader` interface and its `SpreadsheetReader` implementation to require a `context.Context` parameter for all methods that interact with external services. Additionally, it enhances the initialization process in `workspace_app.go` by adding structured logging at key steps, making it easier to trace and debug the application startup sequence.

### Interface and Implementation Updates

* Updated the `WordsReader` interface and `SpreadsheetReader` methods (`ReadBlockRegexes`, `ReadNotificationRegexes`) to require a `context.Context` parameter, ensuring proper context propagation for external API calls. [[1]](diffhunk://#diff-d3811a456495d27494a529ced0d68a4b5b0e68aa622d06d1813ef2db78802406R3-R7) [[2]](diffhunk://#diff-ae0383f1caea4f483a4852a5a8d4446215f7ff43c986fbc95e6eb4fc632989beL62-R64) [[3]](diffhunk://#diff-ae0383f1caea4f483a4852a5a8d4446215f7ff43c986fbc95e6eb4fc632989beL104-R106)
* Modified all Google Sheets API calls in `spreadsheet_controller.go` to use the provided context, improving cancellation and timeout handling. [[1]](diffhunk://#diff-ae0383f1caea4f483a4852a5a8d4446215f7ff43c986fbc95e6eb4fc632989beL32-R32) [[2]](diffhunk://#diff-ae0383f1caea4f483a4852a5a8d4446215f7ff43c986fbc95e6eb4fc632989beL62-R64) [[3]](diffhunk://#diff-ae0383f1caea4f483a4852a5a8d4446215f7ff43c986fbc95e6eb4fc632989beL104-R106)

### Logging and Observability Improvements

* Added structured log statements throughout the `NewWorkspaceApp` initialization process to indicate progress and make troubleshooting easier (e.g., when initializing Firestore, reading configs, and loading regexes and menu docs). [[1]](diffhunk://#diff-e95c57aa3a8df21bbbb21630a95b9fae57da9a8e6115667f6fc3d0e58e72c67aR57-R71) [[2]](diffhunk://#diff-e95c57aa3a8df21bbbb21630a95b9fae57da9a8e6115667f6fc3d0e58e72c67aR94) [[3]](diffhunk://#diff-e95c57aa3a8df21bbbb21630a95b9fae57da9a8e6115667f6fc3d0e58e72c67aR132-R148)
* Updated calls to `ReadBlockRegexes` and `ReadNotificationRegexes` in `workspace_app.go` to pass the context and log each step, aligning with the updated interface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to a breaking interface signature change (`WordsReader` methods now require `context.Context`) and updated Google Sheets calls that may alter request cancellation/timeout behavior.
> 
> **Overview**
> **Propagates `context.Context` through the words/regex loading path.** `WordsReader` and `SpreadsheetReader` now require `ctx` for `ReadBlockRegexes`/`ReadNotificationRegexes`, and all Google Sheets API requests are executed with `.Context(ctx)`.
> 
> **Improves startup observability.** `NewWorkspaceApp` adds `slog.InfoContext` checkpoints during initialization (Firestore/client setup, config reads, spreadsheet regex loads, and menu doc load) and updates call sites to pass the context into the new `WordsReader` API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 692e87f046645a1e1ff452814e25d28027d51620. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->