### PR TITLE
fix(youtube-monitor): add darwin-arm64 path for Biome LSP binary

### DIFF
--- a/youtube-monitor/.vscode/settings.json
+++ b/youtube-monitor/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
 	"biome.lsp.bin": {
-		"win32-x64": "node_modules/.pnpm/@biomejs+cli-win32-x64@2.0.6/node_modules/@biomejs/cli-win32-x64/biome.exe"
+		"win32-x64": "node_modules/.pnpm/@biomejs+cli-win32-x64@2.0.6/node_modules/@biomejs/cli-win32-x64/biome.exe",
+		"darwin-arm64": "node_modules/.bin/biome"
 	},
 	"editor.defaultFormatter": "biomejs.biome",
 	"editor.formatOnPaste": false,


### PR DESCRIPTION
## 概要
macOS (Apple Silicon) で Biome VS Code 拡張が「Unable to find the Biome binary」で動作しなかった問題を修正します。

## 変更内容
- `.vscode/settings.json` の `biome.lsp.bin` に `darwin-arm64` 用のパスを追加
- `node_modules/.bin/biome` を指定（バージョンに依存しない簡易パス）

## 関連
- Windows (win32-x64) の既存設定はそのまま維持

Made with [Cursor](https://cursor.com)