### PR TITLE
SeatDoc の DTO / ドメインモデル分離に向けたフェーズ1として、`seat.go` の現行仕様をテストで固定

### DIFF
--- a/system/core/repository/seat.go
+++ b/system/core/repository/seat.go
@@ -56,6 +56,11 @@ func (s *SeatDoc) StartBreak(now time.Time, breakWorkName string, breakDurationM
 	s.CumulativeWorkSec = cumulativeWorkSec
 	s.DailyCumulativeWorkSec = dailyCumulativeWorkSec
 	s.BreakWorkName = breakWorkName
+
+	// 休憩終了時刻がUntilを超えるときはUntilも延長する
+	if breakUntil.After(s.Until) {
+		s.Until = breakUntil
+	}
 }
 
 // ResumeWork は休憩状態から作業状態に復帰する。

--- a/system/core/repository/seat_test.go
+++ b/system/core/repository/seat_test.go
@@ -18,14 +18,27 @@ func mustParseTime(layout, value string) time.Time {
 	return t
 }
 
+func mustSeat(mutate func(doc *SeatDoc)) SeatDoc {
+	seat := SeatDoc{
+		State:                   WorkState,
+		WorkName:                "作業",
+		CurrentStateStartedAt:   mustParseTime(testTimeLayout, "2026-02-01 10:00:00"),
+		CurrentSegmentStartedAt: mustParseTime(testTimeLayout, "2026-02-01 10:00:00"),
+		CurrentStateUntil:       mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
+		Until:                   mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
+	}
+	if mutate != nil {
+		mutate(&seat)
+	}
+	return seat
+}
+
 func TestSeatDoc_StartBreak(t *testing.T) {
 	t.Run("通常の休憩開始", func(t *testing.T) {
-		seat := SeatDoc{
-			State:                  WorkState,
-			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 10:00:00"),
-			CumulativeWorkSec:      3600, // 既に1時間分累積
-			DailyCumulativeWorkSec: 3600,
-		}
+		seat := mustSeat(func(s *SeatDoc) {
+			s.CumulativeWorkSec = 3600 // 既に1時間分累積
+			s.DailyCumulativeWorkSec = 3600
+		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 11:00:00") // 1時間作業
 		seat.StartBreak(now, "休憩中", 15)
@@ -39,13 +52,12 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 	})
 
 	t.Run("日付跨ぎなし_当日中の作業後に休憩", func(t *testing.T) {
-		seat := SeatDoc{
-			State:                   WorkState,
-			CurrentStateStartedAt:   mustParseTime(testTimeLayout, "2026-02-01 09:00:00"),
-			CurrentSegmentStartedAt: mustParseTime(testTimeLayout, "2026-02-01 09:00:00"),
-			CumulativeWorkSec:       0,
-			DailyCumulativeWorkSec:  0,
-		}
+		seat := mustSeat(func(s *SeatDoc) {
+			s.CurrentStateStartedAt = mustParseTime(testTimeLayout, "2026-02-01 09:00:00")
+			s.CurrentSegmentStartedAt = mustParseTime(testTimeLayout, "2026-02-01 09:00:00")
+			s.CumulativeWorkSec = 0
+			s.DailyCumulativeWorkSec = 0
+		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 12:00:00") // 3時間作業
 		seat.StartBreak(now, "ランチ", 60)
@@ -55,12 +67,11 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 	})
 
 	t.Run("日付跨ぎあり_作業時間が当日の秒数を超える", func(t *testing.T) {
-		seat := SeatDoc{
-			State:                  WorkState,
-			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 00:00:00"),
-			CumulativeWorkSec:      0,
-			DailyCumulativeWorkSec: 0,
-		}
+		seat := mustSeat(func(s *SeatDoc) {
+			s.CurrentStateStartedAt = mustParseTime(testTimeLayout, "2026-02-01 00:00:00")
+			s.CumulativeWorkSec = 0
+			s.DailyCumulativeWorkSec = 0
+		})
 
 		// 翌日の午前1時に休憩開始（25時間作業）
 		now := mustParseTime(testTimeLayout, "2026-02-02 01:00:00")
@@ -73,12 +84,11 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 	})
 
 	t.Run("0分作業後の休憩", func(t *testing.T) {
-		seat := SeatDoc{
-			State:                  WorkState,
-			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 10:00:00"),
-			CumulativeWorkSec:      1800,
-			DailyCumulativeWorkSec: 1800,
-		}
+		seat := mustSeat(func(s *SeatDoc) {
+			s.CurrentStateStartedAt = mustParseTime(testTimeLayout, "2026-02-01 10:00:00")
+			s.CumulativeWorkSec = 1800
+			s.DailyCumulativeWorkSec = 1800
+		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 10:00:00") // 同じ時刻
 		seat.StartBreak(now, "即休憩", 5)
@@ -214,11 +224,7 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 
 func TestSeatDoc_SetWorkDuration(t *testing.T) {
 	t.Run("通常の作業時間変更", func(t *testing.T) {
-		seat := SeatDoc{
-			State:             WorkState,
-			Until:             mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
-			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
-		}
+		seat := mustSeat(nil)
 
 		newUntil := mustParseTime(testTimeLayout, "2026-02-01 20:00:00")
 		seat.SetWorkDuration(newUntil)
@@ -229,11 +235,10 @@ func TestSeatDoc_SetWorkDuration(t *testing.T) {
 
 	t.Run("延長ケース", func(t *testing.T) {
 		original := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
-		seat := SeatDoc{
-			State:             WorkState,
-			Until:             original,
-			CurrentStateUntil: original,
-		}
+		seat := mustSeat(func(s *SeatDoc) {
+			s.Until = original
+			s.CurrentStateUntil = original
+		})
 
 		extended := mustParseTime(testTimeLayout, "2026-02-01 19:00:00")
 		seat.SetWorkDuration(extended)
@@ -244,11 +249,10 @@ func TestSeatDoc_SetWorkDuration(t *testing.T) {
 
 	t.Run("短縮ケース", func(t *testing.T) {
 		original := mustParseTime(testTimeLayout, "2026-02-01 19:00:00")
-		seat := SeatDoc{
-			State:             WorkState,
-			Until:             original,
-			CurrentStateUntil: original,
-		}
+		seat := mustSeat(func(s *SeatDoc) {
+			s.Until = original
+			s.CurrentStateUntil = original
+		})
 
 		shortened := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
 		seat.SetWorkDuration(shortened)
@@ -258,11 +262,7 @@ func TestSeatDoc_SetWorkDuration(t *testing.T) {
 	})
 
 	t.Run("UntilとCurrentStateUntilの同期確認", func(t *testing.T) {
-		seat := SeatDoc{
-			State:             WorkState,
-			Until:             mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
-			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
-		}
+		seat := mustSeat(nil)
 
 		newUntil := mustParseTime(testTimeLayout, "2026-02-01 21:00:00")
 		seat.SetWorkDuration(newUntil)
@@ -272,12 +272,13 @@ func TestSeatDoc_SetWorkDuration(t *testing.T) {
 }
 
 func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
+	until1700 := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
+
 	t.Run("通常の延長", func(t *testing.T) {
-		seat := SeatDoc{
-			State:             WorkState,
-			Until:             mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
-			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
-		}
+		seat := mustSeat(func(s *SeatDoc) {
+			s.Until = until1700
+			s.CurrentStateUntil = until1700
+		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
 		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 60, 180) // 60分延長、最大180分
@@ -289,11 +290,10 @@ func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
 	})
 
 	t.Run("最大値超過_maxWorkTimeMinで制限", func(t *testing.T) {
-		seat := SeatDoc{
-			State:             WorkState,
-			Until:             mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
-			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
-		}
+		seat := mustSeat(func(s *SeatDoc) {
+			s.Until = until1700
+			s.CurrentStateUntil = until1700
+		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
 		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 200, 120) // 200分延長希望、最大120分
@@ -306,11 +306,10 @@ func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
 	})
 
 	t.Run("最大値ギリギリ", func(t *testing.T) {
-		seat := SeatDoc{
-			State:             WorkState,
-			Until:             mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
-			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
-		}
+		seat := mustSeat(func(s *SeatDoc) {
+			s.Until = until1700
+			s.CurrentStateUntil = until1700
+		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
 		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 120, 120) // 120分延長、最大120分
@@ -321,12 +320,11 @@ func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
 	})
 
 	t.Run("延長なし_0分", func(t *testing.T) {
-		original := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
-		seat := SeatDoc{
-			State:             WorkState,
-			Until:             original,
-			CurrentStateUntil: original,
-		}
+		original := until1700
+		seat := mustSeat(func(s *SeatDoc) {
+			s.Until = original
+			s.CurrentStateUntil = original
+		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
 		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 0, 180)
@@ -337,11 +335,11 @@ func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
 	})
 
 	t.Run("現在時刻がUntilを過ぎている場合", func(t *testing.T) {
-		seat := SeatDoc{
-			State:             WorkState,
-			Until:             mustParseTime(testTimeLayout, "2026-02-01 16:00:00"),
-			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 16:00:00"),
-		}
+		until1600 := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
+		seat := mustSeat(func(s *SeatDoc) {
+			s.Until = until1600
+			s.CurrentStateUntil = until1600
+		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 17:00:00") // 既に過ぎている
 		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 60, 180)
@@ -353,11 +351,10 @@ func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
 	})
 
 	t.Run("UntilとCurrentStateUntilの同期確認", func(t *testing.T) {
-		seat := SeatDoc{
-			State:             WorkState,
-			Until:             mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
-			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
-		}
+		seat := mustSeat(func(s *SeatDoc) {
+			s.Until = until1700
+			s.CurrentStateUntil = until1700
+		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
 		seat.ExtendWorkDuration(now, 30, 180)
@@ -368,9 +365,7 @@ func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
 
 func TestSeatDoc_RemainingWorkMin(t *testing.T) {
 	t.Run("正の残り時間", func(t *testing.T) {
-		seat := SeatDoc{
-			Until: mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
-		}
+		seat := mustSeat(nil)
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
 		remaining := seat.RemainingWorkMin(now)
@@ -379,9 +374,9 @@ func TestSeatDoc_RemainingWorkMin(t *testing.T) {
 	})
 
 	t.Run("負の残り時間は0", func(t *testing.T) {
-		seat := SeatDoc{
-			Until: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
-		}
+		seat := mustSeat(func(s *SeatDoc) {
+			s.Until = mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
+		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 18:00:00") // 既に過ぎている
 		remaining := seat.RemainingWorkMin(now)
@@ -390,9 +385,9 @@ func TestSeatDoc_RemainingWorkMin(t *testing.T) {
 	})
 
 	t.Run("0分残り", func(t *testing.T) {
-		seat := SeatDoc{
-			Until: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
-		}
+		seat := mustSeat(func(s *SeatDoc) {
+			s.Until = mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
+		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
 		remaining := seat.RemainingWorkMin(now)
@@ -401,9 +396,9 @@ func TestSeatDoc_RemainingWorkMin(t *testing.T) {
 	})
 
 	t.Run("数秒残りは切り捨て", func(t *testing.T) {
-		seat := SeatDoc{
-			Until: mustParseTime(testTimeLayout, "2026-02-01 17:00:30"),
-		}
+		seat := mustSeat(func(s *SeatDoc) {
+			s.Until = mustParseTime(testTimeLayout, "2026-02-01 17:00:30")
+		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
 		remaining := seat.RemainingWorkMin(now)

--- a/system/core/repository/seat_test.go
+++ b/system/core/repository/seat_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"app.modules/core/timeutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,7 +12,7 @@ const testTimeLayout = "2006-01-02 15:04:05"
 
 // テスト用のヘルパー関数
 func mustParseTime(layout, value string) time.Time {
-	t, err := time.Parse(layout, value)
+	t, err := time.ParseInLocation(layout, value, timeutil.JapanLocation())
 	if err != nil {
 		panic(err)
 	}
@@ -84,16 +85,16 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 
 	t.Run("日付跨ぎあり_作業時間が当日の秒数を超える", func(t *testing.T) {
 		seat := mustSeat(func(s *SeatDoc) {
-			s.CurrentStateStartedAt = mustParseTime(testTimeLayout, "2026-02-01 00:00:00")
+			s.CurrentStateStartedAt = mustParseTime(testTimeLayout, "2026-02-01 22:00:00")
 			s.CumulativeWorkSec = 0
 			s.DailyCumulativeWorkSec = 0
 		})
 
-		// 翌日の午前1時に休憩開始（25時間作業）
+		// 翌日の午前1時に休憩開始（3時間作業）
 		now := mustParseTime(testTimeLayout, "2026-02-02 01:00:00")
 		seat.StartBreak(now, "深夜休憩", 10)
 
-		assert.Equal(t, 25*3600, seat.CumulativeWorkSec)     // CumulativeWorkSecは実際の作業時間
+		assert.Equal(t, 3*3600, seat.CumulativeWorkSec)      // CumulativeWorkSecは実際の作業時間
 		assert.Equal(t, 1*3600, seat.DailyCumulativeWorkSec) // DailyCumulativeWorkSecは当日の秒数（1時間分 = 3600秒）
 	})
 
@@ -477,7 +478,7 @@ func TestSeatDoc_RemainingBreakMin(t *testing.T) {
 
 	t.Run("数秒残りは切り捨て", func(t *testing.T) {
 		seat := mustSeat(func(s *SeatDoc) {
-			s.CurrentStateUntil = mustParseTime(testTimeLayout, "2026-02-01 13:00:00")
+			s.CurrentStateUntil = mustParseTime(testTimeLayout, "2026-02-01 13:00:30")
 		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 13:00:00")

--- a/system/core/repository/seat_test.go
+++ b/system/core/repository/seat_test.go
@@ -114,12 +114,7 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 	})
 
 	t.Run("BreakWorkNameの空文字列", func(t *testing.T) {
-		seat := SeatDoc{
-			State:                  WorkState,
-			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 10:00:00"),
-			CumulativeWorkSec:      0,
-			DailyCumulativeWorkSec: 0,
-		}
+		seat := mustSeat(nil)
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 11:00:00")
 		seat.StartBreak(now, "", 15)

--- a/system/core/repository/seat_test.go
+++ b/system/core/repository/seat_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const testTimeLayout = "2006-01-02 15:04:05"
+
 // テスト用のヘルパー関数
 func mustParseTime(layout, value string) time.Time {
 	t, err := time.Parse(layout, value)
@@ -17,22 +19,20 @@ func mustParseTime(layout, value string) time.Time {
 }
 
 func TestSeatDoc_StartBreak(t *testing.T) {
-	layout := "2006-01-02 15:04:05"
-
 	t.Run("通常の休憩開始", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                  WorkState,
-			CurrentStateStartedAt:  mustParseTime(layout, "2026-02-01 10:00:00"),
+			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 10:00:00"),
 			CumulativeWorkSec:      3600, // 既に1時間分累積
 			DailyCumulativeWorkSec: 3600,
 		}
 
-		now := mustParseTime(layout, "2026-02-01 11:00:00") // 1時間作業
+		now := mustParseTime(testTimeLayout, "2026-02-01 11:00:00") // 1時間作業
 		seat.StartBreak(now, "休憩中", 15)
 
 		assert.Equal(t, BreakState, seat.State)
 		assert.Equal(t, now, seat.CurrentStateStartedAt)
-		assert.Equal(t, mustParseTime(layout, "2026-02-01 11:15:00"), seat.CurrentStateUntil)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 11:15:00"), seat.CurrentStateUntil)
 		assert.Equal(t, 3600+3600, seat.CumulativeWorkSec) // 1時間+1時間
 		assert.Equal(t, 3600+3600, seat.DailyCumulativeWorkSec)
 		assert.Equal(t, "休憩中", seat.BreakWorkName)
@@ -41,13 +41,13 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 	t.Run("日付跨ぎなし_当日中の作業後に休憩", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                   WorkState,
-			CurrentStateStartedAt:   mustParseTime(layout, "2026-02-01 09:00:00"),
-			CurrentSegmentStartedAt: mustParseTime(layout, "2026-02-01 09:00:00"),
+			CurrentStateStartedAt:   mustParseTime(testTimeLayout, "2026-02-01 09:00:00"),
+			CurrentSegmentStartedAt: mustParseTime(testTimeLayout, "2026-02-01 09:00:00"),
 			CumulativeWorkSec:       0,
 			DailyCumulativeWorkSec:  0,
 		}
 
-		now := mustParseTime(layout, "2026-02-01 12:00:00") // 3時間作業
+		now := mustParseTime(testTimeLayout, "2026-02-01 12:00:00") // 3時間作業
 		seat.StartBreak(now, "ランチ", 60)
 
 		assert.Equal(t, 3*3600, seat.CumulativeWorkSec)
@@ -57,13 +57,13 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 	t.Run("日付跨ぎあり_作業時間が当日の秒数を超える", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                  WorkState,
-			CurrentStateStartedAt:  mustParseTime(layout, "2026-02-01 00:00:00"),
+			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 00:00:00"),
 			CumulativeWorkSec:      0,
 			DailyCumulativeWorkSec: 0,
 		}
 
 		// 翌日の午前1時に休憩開始（25時間作業）
-		now := mustParseTime(layout, "2026-02-02 01:00:00")
+		now := mustParseTime(testTimeLayout, "2026-02-02 01:00:00")
 		seat.StartBreak(now, "深夜休憩", 10)
 
 		// CumulativeWorkSecは実際の作業時間
@@ -75,12 +75,12 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 	t.Run("0分作業後の休憩", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                  WorkState,
-			CurrentStateStartedAt:  mustParseTime(layout, "2026-02-01 10:00:00"),
+			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 10:00:00"),
 			CumulativeWorkSec:      1800,
 			DailyCumulativeWorkSec: 1800,
 		}
 
-		now := mustParseTime(layout, "2026-02-01 10:00:00") // 同じ時刻
+		now := mustParseTime(testTimeLayout, "2026-02-01 10:00:00") // 同じ時刻
 		seat.StartBreak(now, "即休憩", 5)
 
 		assert.Equal(t, 1800, seat.CumulativeWorkSec) // 変化なし
@@ -90,12 +90,12 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 	t.Run("BreakWorkNameの空文字列", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                  WorkState,
-			CurrentStateStartedAt:  mustParseTime(layout, "2026-02-01 10:00:00"),
+			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 10:00:00"),
 			CumulativeWorkSec:      0,
 			DailyCumulativeWorkSec: 0,
 		}
 
-		now := mustParseTime(layout, "2026-02-01 11:00:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 11:00:00")
 		seat.StartBreak(now, "", 15)
 
 		assert.Equal(t, "", seat.BreakWorkName)
@@ -103,18 +103,16 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 }
 
 func TestSeatDoc_ResumeWork(t *testing.T) {
-	layout := "2006-01-02 15:04:05"
-
 	t.Run("通常の作業再開_作業名変更", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                  BreakState,
-			CurrentStateStartedAt:  mustParseTime(layout, "2026-02-01 12:00:00"),
-			Until:                  mustParseTime(layout, "2026-02-01 18:00:00"),
+			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
+			Until:                  mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
 			WorkName:               "既存の作業",
 			DailyCumulativeWorkSec: 7200, // 2時間分
 		}
 
-		now := mustParseTime(layout, "2026-02-01 13:00:00") // 1時間休憩
+		now := mustParseTime(testTimeLayout, "2026-02-01 13:00:00") // 1時間休憩
 		seat.ResumeWork(now, "新しい作業")
 
 		assert.Equal(t, WorkState, seat.State)
@@ -127,13 +125,13 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 	t.Run("WorkName引継ぎ_呼び出し側で既存の作業名を渡す", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                  BreakState,
-			CurrentStateStartedAt:  mustParseTime(layout, "2026-02-01 12:00:00"),
-			Until:                  mustParseTime(layout, "2026-02-01 18:00:00"),
+			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
+			Until:                  mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
 			WorkName:               "既存の作業名",
 			DailyCumulativeWorkSec: 3600,
 		}
 
-		now := mustParseTime(layout, "2026-02-01 12:30:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 12:30:00")
 		// 呼び出し側で既存の作業名を渡す
 		seat.ResumeWork(now, seat.WorkName)
 
@@ -143,13 +141,13 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 	t.Run("WorkNameクリア_空文字列を明示的に設定", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                  BreakState,
-			CurrentStateStartedAt:  mustParseTime(layout, "2026-02-01 12:00:00"),
-			Until:                  mustParseTime(layout, "2026-02-01 18:00:00"),
+			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
+			Until:                  mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
 			WorkName:               "クリアする作業名",
 			DailyCumulativeWorkSec: 3600,
 		}
 
-		now := mustParseTime(layout, "2026-02-01 12:30:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 12:30:00")
 		seat.ResumeWork(now, "") // 空文字列で明示的にクリア
 
 		assert.Equal(t, "", seat.WorkName) // クリアされる
@@ -158,12 +156,12 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 	t.Run("日付跨ぎなし_当日中の休憩後に再開", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                  BreakState,
-			CurrentStateStartedAt:  mustParseTime(layout, "2026-02-01 12:00:00"),
-			Until:                  mustParseTime(layout, "2026-02-01 18:00:00"),
+			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
+			Until:                  mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
 			DailyCumulativeWorkSec: 10800, // 3時間分
 		}
 
-		now := mustParseTime(layout, "2026-02-01 13:00:00") // 1時間休憩
+		now := mustParseTime(testTimeLayout, "2026-02-01 13:00:00") // 1時間休憩
 		seat.ResumeWork(now, "再開")
 
 		assert.Equal(t, 10800, seat.DailyCumulativeWorkSec) // 変化なし
@@ -172,28 +170,28 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 	t.Run("日付跨ぎあり_休憩時間が当日の秒数を超える", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                  BreakState,
-			CurrentStateStartedAt:  mustParseTime(layout, "2026-02-01 00:00:00"),
-			Until:                  mustParseTime(layout, "2026-02-02 18:00:00"),
+			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 00:00:00"),
+			Until:                  mustParseTime(testTimeLayout, "2026-02-02 18:00:00"),
 			DailyCumulativeWorkSec: 5400, // 1.5時間分
 		}
 
 		// 翌日の午前2時に再開（26時間休憩）
-		now := mustParseTime(layout, "2026-02-02 02:00:00")
+		now := mustParseTime(testTimeLayout, "2026-02-02 02:00:00")
 		seat.ResumeWork(now, "翌日再開")
 
 		assert.Equal(t, 0, seat.DailyCumulativeWorkSec) // リセット
 	})
 
 	t.Run("Untilの引継ぎ確認", func(t *testing.T) {
-		until := mustParseTime(layout, "2026-02-01 20:00:00")
+		until := mustParseTime(testTimeLayout, "2026-02-01 20:00:00")
 		seat := SeatDoc{
 			State:                  BreakState,
-			CurrentStateStartedAt:  mustParseTime(layout, "2026-02-01 15:00:00"),
+			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 15:00:00"),
 			Until:                  until,
 			DailyCumulativeWorkSec: 0,
 		}
 
-		now := mustParseTime(layout, "2026-02-01 15:30:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 15:30:00")
 		seat.ResumeWork(now, "作業")
 
 		assert.Equal(t, until, seat.CurrentStateUntil)
@@ -202,12 +200,12 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 	t.Run("0分休憩後の再開", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                  BreakState,
-			CurrentStateStartedAt:  mustParseTime(layout, "2026-02-01 12:00:00"),
-			Until:                  mustParseTime(layout, "2026-02-01 18:00:00"),
+			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
+			Until:                  mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
 			DailyCumulativeWorkSec: 3600,
 		}
 
-		now := mustParseTime(layout, "2026-02-01 12:00:00") // 同じ時刻
+		now := mustParseTime(testTimeLayout, "2026-02-01 12:00:00") // 同じ時刻
 		seat.ResumeWork(now, "即再開")
 
 		assert.Equal(t, 3600, seat.DailyCumulativeWorkSec) // 変化なし
@@ -215,16 +213,14 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 }
 
 func TestSeatDoc_SetWorkDuration(t *testing.T) {
-	layout := "2006-01-02 15:04:05"
-
 	t.Run("通常の作業時間変更", func(t *testing.T) {
 		seat := SeatDoc{
 			State:             WorkState,
-			Until:             mustParseTime(layout, "2026-02-01 18:00:00"),
-			CurrentStateUntil: mustParseTime(layout, "2026-02-01 18:00:00"),
+			Until:             mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
+			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
 		}
 
-		newUntil := mustParseTime(layout, "2026-02-01 20:00:00")
+		newUntil := mustParseTime(testTimeLayout, "2026-02-01 20:00:00")
 		seat.SetWorkDuration(newUntil)
 
 		assert.Equal(t, newUntil, seat.Until)
@@ -232,14 +228,14 @@ func TestSeatDoc_SetWorkDuration(t *testing.T) {
 	})
 
 	t.Run("延長ケース", func(t *testing.T) {
-		original := mustParseTime(layout, "2026-02-01 17:00:00")
+		original := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
 		seat := SeatDoc{
 			State:             WorkState,
 			Until:             original,
 			CurrentStateUntil: original,
 		}
 
-		extended := mustParseTime(layout, "2026-02-01 19:00:00")
+		extended := mustParseTime(testTimeLayout, "2026-02-01 19:00:00")
 		seat.SetWorkDuration(extended)
 
 		assert.Equal(t, extended, seat.Until)
@@ -247,14 +243,14 @@ func TestSeatDoc_SetWorkDuration(t *testing.T) {
 	})
 
 	t.Run("短縮ケース", func(t *testing.T) {
-		original := mustParseTime(layout, "2026-02-01 19:00:00")
+		original := mustParseTime(testTimeLayout, "2026-02-01 19:00:00")
 		seat := SeatDoc{
 			State:             WorkState,
 			Until:             original,
 			CurrentStateUntil: original,
 		}
 
-		shortened := mustParseTime(layout, "2026-02-01 17:00:00")
+		shortened := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
 		seat.SetWorkDuration(shortened)
 
 		assert.Equal(t, shortened, seat.Until)
@@ -264,11 +260,11 @@ func TestSeatDoc_SetWorkDuration(t *testing.T) {
 	t.Run("UntilとCurrentStateUntilの同期確認", func(t *testing.T) {
 		seat := SeatDoc{
 			State:             WorkState,
-			Until:             mustParseTime(layout, "2026-02-01 18:00:00"),
-			CurrentStateUntil: mustParseTime(layout, "2026-02-01 18:00:00"),
+			Until:             mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
+			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
 		}
 
-		newUntil := mustParseTime(layout, "2026-02-01 21:00:00")
+		newUntil := mustParseTime(testTimeLayout, "2026-02-01 21:00:00")
 		seat.SetWorkDuration(newUntil)
 
 		assert.Equal(t, seat.Until, seat.CurrentStateUntil)
@@ -276,65 +272,63 @@ func TestSeatDoc_SetWorkDuration(t *testing.T) {
 }
 
 func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
-	layout := "2006-01-02 15:04:05"
-
 	t.Run("通常の延長", func(t *testing.T) {
 		seat := SeatDoc{
 			State:             WorkState,
-			Until:             mustParseTime(layout, "2026-02-01 17:00:00"),
-			CurrentStateUntil: mustParseTime(layout, "2026-02-01 17:00:00"),
+			Until:             mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
+			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 16:00:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
 		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 60, 180) // 60分延長、最大180分
 
 		assert.Equal(t, 60, actualAdded)
 		assert.Equal(t, 120, newRemaining) // 元々60分残り + 60分延長 = 120分
-		assert.Equal(t, mustParseTime(layout, "2026-02-01 18:00:00"), seat.Until)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:00:00"), seat.Until)
 		assert.Equal(t, seat.Until, seat.CurrentStateUntil)
 	})
 
 	t.Run("最大値超過_maxWorkTimeMinで制限", func(t *testing.T) {
 		seat := SeatDoc{
 			State:             WorkState,
-			Until:             mustParseTime(layout, "2026-02-01 17:00:00"),
-			CurrentStateUntil: mustParseTime(layout, "2026-02-01 17:00:00"),
+			Until:             mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
+			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 16:00:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
 		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 200, 120) // 200分延長希望、最大120分
 
 		// 最大120分までしか延長できない（現在から120分後 = 18:00）
 		// 元のUntilは17:00だったので、実際の延長は60分
 		assert.Equal(t, 60, actualAdded)
 		assert.Equal(t, 120, newRemaining)
-		assert.Equal(t, mustParseTime(layout, "2026-02-01 18:00:00"), seat.Until)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:00:00"), seat.Until)
 	})
 
 	t.Run("最大値ギリギリ", func(t *testing.T) {
 		seat := SeatDoc{
 			State:             WorkState,
-			Until:             mustParseTime(layout, "2026-02-01 17:00:00"),
-			CurrentStateUntil: mustParseTime(layout, "2026-02-01 17:00:00"),
+			Until:             mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
+			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 16:00:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
 		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 120, 120) // 120分延長、最大120分
 
 		assert.Equal(t, 60, actualAdded) // 17:00まで60分残っているので、追加は60分
 		assert.Equal(t, 120, newRemaining)
-		assert.Equal(t, mustParseTime(layout, "2026-02-01 18:00:00"), seat.Until)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:00:00"), seat.Until)
 	})
 
 	t.Run("延長なし_0分", func(t *testing.T) {
-		original := mustParseTime(layout, "2026-02-01 17:00:00")
+		original := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
 		seat := SeatDoc{
 			State:             WorkState,
 			Until:             original,
 			CurrentStateUntil: original,
 		}
 
-		now := mustParseTime(layout, "2026-02-01 16:00:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
 		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 0, 180)
 
 		assert.Equal(t, 0, actualAdded)
@@ -345,27 +339,27 @@ func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
 	t.Run("現在時刻がUntilを過ぎている場合", func(t *testing.T) {
 		seat := SeatDoc{
 			State:             WorkState,
-			Until:             mustParseTime(layout, "2026-02-01 16:00:00"),
-			CurrentStateUntil: mustParseTime(layout, "2026-02-01 16:00:00"),
+			Until:             mustParseTime(testTimeLayout, "2026-02-01 16:00:00"),
+			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 16:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 17:00:00") // 既に過ぎている
+		now := mustParseTime(testTimeLayout, "2026-02-01 17:00:00") // 既に過ぎている
 		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 60, 180)
 
 		// 60分延長されるので17:00になる
 		assert.Equal(t, 60, actualAdded) // 16:00 → 17:00なので60分
 		assert.Equal(t, 0, newRemaining) // 17:00 → 17:00なので0分
-		assert.Equal(t, mustParseTime(layout, "2026-02-01 17:00:00"), seat.Until)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 17:00:00"), seat.Until)
 	})
 
 	t.Run("UntilとCurrentStateUntilの同期確認", func(t *testing.T) {
 		seat := SeatDoc{
 			State:             WorkState,
-			Until:             mustParseTime(layout, "2026-02-01 17:00:00"),
-			CurrentStateUntil: mustParseTime(layout, "2026-02-01 17:00:00"),
+			Until:             mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
+			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 16:00:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
 		seat.ExtendWorkDuration(now, 30, 180)
 
 		assert.Equal(t, seat.Until, seat.CurrentStateUntil)
@@ -373,14 +367,12 @@ func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
 }
 
 func TestSeatDoc_RemainingWorkMin(t *testing.T) {
-	layout := "2006-01-02 15:04:05"
-
 	t.Run("正の残り時間", func(t *testing.T) {
 		seat := SeatDoc{
-			Until: mustParseTime(layout, "2026-02-01 18:00:00"),
+			Until: mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 17:00:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
 		remaining := seat.RemainingWorkMin(now)
 
 		assert.Equal(t, 60, remaining)
@@ -388,10 +380,10 @@ func TestSeatDoc_RemainingWorkMin(t *testing.T) {
 
 	t.Run("負の残り時間は0", func(t *testing.T) {
 		seat := SeatDoc{
-			Until: mustParseTime(layout, "2026-02-01 17:00:00"),
+			Until: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 18:00:00") // 既に過ぎている
+		now := mustParseTime(testTimeLayout, "2026-02-01 18:00:00") // 既に過ぎている
 		remaining := seat.RemainingWorkMin(now)
 
 		assert.Equal(t, 0, remaining)
@@ -399,10 +391,10 @@ func TestSeatDoc_RemainingWorkMin(t *testing.T) {
 
 	t.Run("0分残り", func(t *testing.T) {
 		seat := SeatDoc{
-			Until: mustParseTime(layout, "2026-02-01 17:00:00"),
+			Until: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 17:00:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
 		remaining := seat.RemainingWorkMin(now)
 
 		assert.Equal(t, 0, remaining)
@@ -410,10 +402,10 @@ func TestSeatDoc_RemainingWorkMin(t *testing.T) {
 
 	t.Run("数秒残りは切り捨て", func(t *testing.T) {
 		seat := SeatDoc{
-			Until: mustParseTime(layout, "2026-02-01 17:00:30"),
+			Until: mustParseTime(testTimeLayout, "2026-02-01 17:00:30"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 17:00:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
 		remaining := seat.RemainingWorkMin(now)
 
 		assert.Equal(t, 0, remaining) // 30秒は0分
@@ -421,14 +413,12 @@ func TestSeatDoc_RemainingWorkMin(t *testing.T) {
 }
 
 func TestSeatDoc_RemainingBreakMin(t *testing.T) {
-	layout := "2006-01-02 15:04:05"
-
 	t.Run("正の残り時間", func(t *testing.T) {
 		seat := SeatDoc{
-			CurrentStateUntil: mustParseTime(layout, "2026-02-01 13:00:00"),
+			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 13:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 12:30:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 12:30:00")
 		remaining := seat.RemainingBreakMin(now)
 
 		assert.Equal(t, 30, remaining)
@@ -436,10 +426,10 @@ func TestSeatDoc_RemainingBreakMin(t *testing.T) {
 
 	t.Run("負の残り時間は0", func(t *testing.T) {
 		seat := SeatDoc{
-			CurrentStateUntil: mustParseTime(layout, "2026-02-01 13:00:00"),
+			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 13:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 14:00:00") // 既に過ぎている
+		now := mustParseTime(testTimeLayout, "2026-02-01 14:00:00") // 既に過ぎている
 		remaining := seat.RemainingBreakMin(now)
 
 		assert.Equal(t, 0, remaining)
@@ -447,10 +437,10 @@ func TestSeatDoc_RemainingBreakMin(t *testing.T) {
 
 	t.Run("0分残り", func(t *testing.T) {
 		seat := SeatDoc{
-			CurrentStateUntil: mustParseTime(layout, "2026-02-01 13:00:00"),
+			CurrentStateUntil: mustParseTime(testTimeLayout, "2026-02-01 13:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 13:00:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 13:00:00")
 		remaining := seat.RemainingBreakMin(now)
 
 		assert.Equal(t, 0, remaining)
@@ -458,75 +448,73 @@ func TestSeatDoc_RemainingBreakMin(t *testing.T) {
 }
 
 func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
-	layout := "2006-01-02 15:04:05"
-
 	t.Run("通常の延長_Untilは延長なし", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                 BreakState,
-			CurrentStateStartedAt: mustParseTime(layout, "2026-02-01 12:00:00"),
-			CurrentStateUntil:     mustParseTime(layout, "2026-02-01 13:00:00"),
-			Until:                 mustParseTime(layout, "2026-02-01 18:00:00"),
+			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
+			CurrentStateUntil:     mustParseTime(testTimeLayout, "2026-02-01 13:00:00"),
+			Until:                 mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 12:30:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 12:30:00")
 		actualAdded, remainingBreak, remainingExit := seat.ExtendBreakDuration(now, 30, 120)
 
 		assert.Equal(t, 30, actualAdded)
 		assert.Equal(t, 60, remainingBreak) // 12:30 → 13:30 = 60分
 		assert.Equal(t, 330, remainingExit) // 12:30 → 18:00 = 330分
-		assert.Equal(t, mustParseTime(layout, "2026-02-01 13:30:00"), seat.CurrentStateUntil)
-		assert.Equal(t, mustParseTime(layout, "2026-02-01 18:00:00"), seat.Until) // 変化なし
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 13:30:00"), seat.CurrentStateUntil)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:00:00"), seat.Until) // 変化なし
 	})
 
 	t.Run("Untilも延長_休憩終了時刻がUntilを超える", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                 BreakState,
-			CurrentStateStartedAt: mustParseTime(layout, "2026-02-01 17:00:00"),
-			CurrentStateUntil:     mustParseTime(layout, "2026-02-01 17:30:00"),
-			Until:                 mustParseTime(layout, "2026-02-01 18:00:00"),
+			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
+			CurrentStateUntil:     mustParseTime(testTimeLayout, "2026-02-01 17:30:00"),
+			Until:                 mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 17:15:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 17:15:00")
 		actualAdded, remainingBreak, remainingExit := seat.ExtendBreakDuration(now, 60, 120)
 
 		// 休憩が18:30まで延長される（Untilの18:00を超える）
 		assert.Equal(t, 60, actualAdded)
 		assert.Equal(t, 75, remainingBreak) // 17:15 → 18:30 = 75分
 		assert.Equal(t, 75, remainingExit)  // Untilも18:30に延長される
-		assert.Equal(t, mustParseTime(layout, "2026-02-01 18:30:00"), seat.CurrentStateUntil)
-		assert.Equal(t, mustParseTime(layout, "2026-02-01 18:30:00"), seat.Until)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:30:00"), seat.CurrentStateUntil)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:30:00"), seat.Until)
 	})
 
 	t.Run("最大値超過_maxBreakDurationMinで制限", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                 BreakState,
-			CurrentStateStartedAt: mustParseTime(layout, "2026-02-01 12:00:00"),
-			CurrentStateUntil:     mustParseTime(layout, "2026-02-01 12:30:00"),
-			Until:                 mustParseTime(layout, "2026-02-01 18:00:00"),
+			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
+			CurrentStateUntil:     mustParseTime(testTimeLayout, "2026-02-01 12:30:00"),
+			Until:                 mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 12:15:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 12:15:00")
 		actualAdded, remainingBreak, remainingExit := seat.ExtendBreakDuration(now, 200, 60) // 200分延長希望、最大60分
 
 		// 休憩開始から最大60分（13:00まで）
 		assert.Equal(t, 30, actualAdded)    // 12:30 → 13:00 = 30分
 		assert.Equal(t, 45, remainingBreak) // 12:15 → 13:00 = 45分
 		assert.Equal(t, 345, remainingExit) // 12:15 → 18:00 = 345分
-		assert.Equal(t, mustParseTime(layout, "2026-02-01 13:00:00"), seat.CurrentStateUntil)
-		assert.Equal(t, mustParseTime(layout, "2026-02-01 18:00:00"), seat.Until)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 13:00:00"), seat.CurrentStateUntil)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:00:00"), seat.Until)
 	})
 
 	t.Run("延長なし_0分", func(t *testing.T) {
-		originalBreakUntil := mustParseTime(layout, "2026-02-01 13:00:00")
-		originalUntil := mustParseTime(layout, "2026-02-01 18:00:00")
+		originalBreakUntil := mustParseTime(testTimeLayout, "2026-02-01 13:00:00")
+		originalUntil := mustParseTime(testTimeLayout, "2026-02-01 18:00:00")
 		seat := SeatDoc{
 			State:                 BreakState,
-			CurrentStateStartedAt: mustParseTime(layout, "2026-02-01 12:00:00"),
+			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
 			CurrentStateUntil:     originalBreakUntil,
 			Until:                 originalUntil,
 		}
 
-		now := mustParseTime(layout, "2026-02-01 12:30:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 12:30:00")
 		actualAdded, remainingBreak, remainingExit := seat.ExtendBreakDuration(now, 0, 120)
 
 		assert.Equal(t, 0, actualAdded)
@@ -539,59 +527,57 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 	t.Run("最大休憩時間ギリギリ", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                 BreakState,
-			CurrentStateStartedAt: mustParseTime(layout, "2026-02-01 12:00:00"),
-			CurrentStateUntil:     mustParseTime(layout, "2026-02-01 12:30:00"),
-			Until:                 mustParseTime(layout, "2026-02-01 18:00:00"),
+			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
+			CurrentStateUntil:     mustParseTime(testTimeLayout, "2026-02-01 12:30:00"),
+			Until:                 mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 12:15:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 12:15:00")
 		actualAdded, _, _ := seat.ExtendBreakDuration(now, 30, 60) // 開始から60分ちょうど
 
 		assert.Equal(t, 30, actualAdded)
-		assert.Equal(t, mustParseTime(layout, "2026-02-01 13:00:00"), seat.CurrentStateUntil)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 13:00:00"), seat.CurrentStateUntil)
 	})
 
 	t.Run("Untilとの関係_休憩がUntilギリギリまで", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                 BreakState,
-			CurrentStateStartedAt: mustParseTime(layout, "2026-02-01 17:00:00"),
-			CurrentStateUntil:     mustParseTime(layout, "2026-02-01 17:30:00"),
-			Until:                 mustParseTime(layout, "2026-02-01 18:00:00"),
+			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
+			CurrentStateUntil:     mustParseTime(testTimeLayout, "2026-02-01 17:30:00"),
+			Until:                 mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 17:15:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 17:15:00")
 		_, remainingBreak, remainingExit := seat.ExtendBreakDuration(now, 30, 120)
 
 		// 休憩は18:00まで（Untilと同じ）
 		assert.Equal(t, 45, remainingBreak) // 17:15 → 18:00
 		assert.Equal(t, 45, remainingExit)
-		assert.Equal(t, mustParseTime(layout, "2026-02-01 18:00:00"), seat.CurrentStateUntil)
-		assert.Equal(t, mustParseTime(layout, "2026-02-01 18:00:00"), seat.Until)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:00:00"), seat.CurrentStateUntil)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:00:00"), seat.Until)
 	})
 
 	t.Run("複雑なケース_最大値制限とUntil延長の両方", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                 BreakState,
-			CurrentStateStartedAt: mustParseTime(layout, "2026-02-01 17:30:00"),
-			CurrentStateUntil:     mustParseTime(layout, "2026-02-01 17:45:00"),
-			Until:                 mustParseTime(layout, "2026-02-01 18:00:00"),
+			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 17:30:00"),
+			CurrentStateUntil:     mustParseTime(testTimeLayout, "2026-02-01 17:45:00"),
+			Until:                 mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 17:40:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 17:40:00")
 		actualAdded, remainingBreak, remainingExit := seat.ExtendBreakDuration(now, 100, 60) // 100分希望、最大60分
 
 		// 開始から60分 = 18:30
 		assert.Equal(t, 45, actualAdded)    // 17:45 → 18:30 = 45分
 		assert.Equal(t, 50, remainingBreak) // 17:40 → 18:30 = 50分
 		assert.Equal(t, 50, remainingExit)  // Untilも18:30
-		assert.Equal(t, mustParseTime(layout, "2026-02-01 18:30:00"), seat.CurrentStateUntil)
-		assert.Equal(t, mustParseTime(layout, "2026-02-01 18:30:00"), seat.Until)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:30:00"), seat.CurrentStateUntil)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:30:00"), seat.Until)
 	})
 }
 
 func TestSeatDoc_GenerateWorkSegment(t *testing.T) {
-	layout := "2006-01-02 15:04:05"
-
 	t.Run("通常の作業セグメントを生成できること", func(t *testing.T) {
 		seat := SeatDoc{
 			UserID:                  "user-1",
@@ -599,10 +585,10 @@ func TestSeatDoc_GenerateWorkSegment(t *testing.T) {
 			SessionID:               "session-1",
 			State:                   WorkState,
 			WorkName:                "数学",
-			CurrentSegmentStartedAt: mustParseTime(layout, "2026-02-01 09:15:00"),
+			CurrentSegmentStartedAt: mustParseTime(testTimeLayout, "2026-02-01 09:15:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 10:45:30")
+		now := mustParseTime(testTimeLayout, "2026-02-01 10:45:30")
 		workSegment, err := seat.GenerateWorkSegment(now, true)
 
 		assert.NoError(t, err)
@@ -613,7 +599,7 @@ func TestSeatDoc_GenerateWorkSegment(t *testing.T) {
 			SessionID:    "session-1",
 			WorkName:     "数学",
 			SegmentType:  WorkState,
-			StartedAt:    mustParseTime(layout, "2026-02-01 09:15:00"),
+			StartedAt:    mustParseTime(testTimeLayout, "2026-02-01 09:15:00"),
 			EndedAt:      now,
 			DurationSec:  5430,
 		}, workSegment)
@@ -627,10 +613,10 @@ func TestSeatDoc_GenerateWorkSegment(t *testing.T) {
 			State:                   BreakState,
 			WorkName:                "英語",
 			BreakWorkName:           "昼休み",
-			CurrentSegmentStartedAt: mustParseTime(layout, "2026-02-01 12:00:00"),
+			CurrentSegmentStartedAt: mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
 		}
 
-		now := mustParseTime(layout, "2026-02-01 12:10:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 12:10:00")
 		workSegment, err := seat.GenerateWorkSegment(now, false)
 
 		assert.NoError(t, err)
@@ -641,7 +627,7 @@ func TestSeatDoc_GenerateWorkSegment(t *testing.T) {
 			SessionID:    "session-2",
 			WorkName:     "昼休み",
 			SegmentType:  BreakState,
-			StartedAt:    mustParseTime(layout, "2026-02-01 12:00:00"),
+			StartedAt:    mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
 			EndedAt:      now,
 			DurationSec:  600,
 		}, workSegment)
@@ -652,7 +638,7 @@ func TestSeatDoc_GenerateWorkSegment(t *testing.T) {
 			State: WorkState,
 		}
 
-		now := mustParseTime(layout, "2026-02-01 12:00:00")
+		now := mustParseTime(testTimeLayout, "2026-02-01 12:00:00")
 		workSegment, err := seat.GenerateWorkSegment(now, false)
 
 		assert.Error(t, err)

--- a/system/core/repository/seat_test.go
+++ b/system/core/repository/seat_test.go
@@ -45,6 +45,7 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 
 		assert.Equal(t, BreakState, seat.State)
 		assert.Equal(t, now, seat.CurrentStateStartedAt)
+		assert.Equal(t, now, seat.CurrentSegmentStartedAt)
 		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 11:15:00"), seat.CurrentStateUntil)
 		assert.Equal(t, 3600+3600, seat.CumulativeWorkSec) // 1時間+1時間
 		assert.Equal(t, 3600+3600, seat.DailyCumulativeWorkSec)
@@ -77,10 +78,8 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 		now := mustParseTime(testTimeLayout, "2026-02-02 01:00:00")
 		seat.StartBreak(now, "深夜休憩", 10)
 
-		// CumulativeWorkSecは実際の作業時間
-		assert.Equal(t, 25*3600, seat.CumulativeWorkSec)
-		// DailyCumulativeWorkSecは当日の秒数（1時間分 = 3600秒）
-		assert.Equal(t, 1*3600, seat.DailyCumulativeWorkSec)
+		assert.Equal(t, 25*3600, seat.CumulativeWorkSec)     // CumulativeWorkSecは実際の作業時間
+		assert.Equal(t, 1*3600, seat.DailyCumulativeWorkSec) // DailyCumulativeWorkSecは当日の秒数（1時間分 = 3600秒）
 	})
 
 	t.Run("0分作業後の休憩", func(t *testing.T) {
@@ -119,6 +118,7 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
 			Until:                  mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
 			WorkName:               "既存の作業",
+			CumulativeWorkSec:      7200, // 2時間分
 			DailyCumulativeWorkSec: 7200, // 2時間分
 		}
 
@@ -127,8 +127,10 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 
 		assert.Equal(t, WorkState, seat.State)
 		assert.Equal(t, now, seat.CurrentStateStartedAt)
+		assert.Equal(t, now, seat.CurrentSegmentStartedAt)
 		assert.Equal(t, seat.Until, seat.CurrentStateUntil)
 		assert.Equal(t, "新しい作業", seat.WorkName)
+		assert.Equal(t, 7200, seat.CumulativeWorkSec)      // 変化なし
 		assert.Equal(t, 7200, seat.DailyCumulativeWorkSec) // 変化なし
 	})
 
@@ -179,17 +181,20 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 
 	t.Run("日付跨ぎあり_休憩時間が当日の秒数を超える", func(t *testing.T) {
 		seat := SeatDoc{
-			State:                  BreakState,
-			CurrentStateStartedAt:  mustParseTime(testTimeLayout, "2026-02-01 00:00:00"),
-			Until:                  mustParseTime(testTimeLayout, "2026-02-02 18:00:00"),
-			DailyCumulativeWorkSec: 5400, // 1.5時間分
+			State:                   BreakState,
+			CurrentStateStartedAt:   mustParseTime(testTimeLayout, "2026-02-01 22:00:00"),
+			CurrentSegmentStartedAt: mustParseTime(testTimeLayout, "2026-02-01 22:00:00"),
+			Until:                   mustParseTime(testTimeLayout, "2026-02-02 18:00:00"),
+			CumulativeWorkSec:       3600, // 1時間分
+			DailyCumulativeWorkSec:  3600, // 1時間分
 		}
 
-		// 翌日の午前2時に再開（26時間休憩）
+		// 翌日の午前2時に再開（4時間休憩）
 		now := mustParseTime(testTimeLayout, "2026-02-02 02:00:00")
 		seat.ResumeWork(now, "翌日再開")
 
-		assert.Equal(t, 0, seat.DailyCumulativeWorkSec) // リセット
+		assert.Equal(t, 3600, seat.CumulativeWorkSec)   // リセットされない
+		assert.Equal(t, 0, seat.DailyCumulativeWorkSec) // リセットされる
 	})
 
 	t.Run("Untilの引継ぎ確認", func(t *testing.T) {

--- a/system/core/repository/seat_test.go
+++ b/system/core/repository/seat_test.go
@@ -86,6 +86,7 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 	t.Run("日付跨ぎあり_作業時間が当日の秒数を超える", func(t *testing.T) {
 		seat := mustSeat(func(s *SeatDoc) {
 			s.CurrentStateStartedAt = mustParseTime(testTimeLayout, "2026-02-01 22:00:00")
+			s.Until = mustParseTime(testTimeLayout, "2026-02-02 10:00:00")
 			s.CumulativeWorkSec = 0
 			s.DailyCumulativeWorkSec = 0
 		})

--- a/system/core/repository/seat_test.go
+++ b/system/core/repository/seat_test.go
@@ -36,6 +36,7 @@ func mustSeat(mutate func(doc *SeatDoc)) SeatDoc {
 func TestSeatDoc_StartBreak(t *testing.T) {
 	t.Run("通常の休憩開始", func(t *testing.T) {
 		seat := mustSeat(func(s *SeatDoc) {
+			s.Until = mustParseTime(testTimeLayout, "2026-02-01 18:00:00")
 			s.CumulativeWorkSec = 3600 // 既に1時間分累積
 			s.DailyCumulativeWorkSec = 3600
 		})
@@ -46,10 +47,24 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 		assert.Equal(t, BreakState, seat.State)
 		assert.Equal(t, now, seat.CurrentStateStartedAt)
 		assert.Equal(t, now, seat.CurrentSegmentStartedAt)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:00:00"), seat.Until) // 変化なし
 		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 11:15:00"), seat.CurrentStateUntil)
 		assert.Equal(t, 3600+3600, seat.CumulativeWorkSec) // 1時間+1時間
 		assert.Equal(t, 3600+3600, seat.DailyCumulativeWorkSec)
 		assert.Equal(t, "休憩中", seat.BreakWorkName)
+	})
+
+	t.Run("休憩終了予定時刻がUntilを超える場合はUntilも延長する", func(t *testing.T) {
+		seat := mustSeat(func(s *SeatDoc) {
+			s.Until = mustParseTime(testTimeLayout, "2026-02-01 11:20:00")
+			s.CurrentStateUntil = mustParseTime(testTimeLayout, "2026-02-01 11:20:00")
+		})
+
+		now := mustParseTime(testTimeLayout, "2026-02-01 11:15:00")
+		seat.StartBreak(now, "休憩中", 15)
+
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 11:30:00"), seat.Until)
+		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 11:30:00"), seat.CurrentStateUntil)
 	})
 
 	t.Run("日付跨ぎなし_当日中の作業後に休憩", func(t *testing.T) {
@@ -277,91 +292,105 @@ func TestSeatDoc_SetWorkDuration(t *testing.T) {
 }
 
 func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
-	until1700 := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
+	time1600 := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
+	time1700 := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
+	time1800 := mustParseTime(testTimeLayout, "2026-02-01 18:00:00")
 
 	t.Run("通常の延長", func(t *testing.T) {
 		seat := mustSeat(func(s *SeatDoc) {
-			s.Until = until1700
-			s.CurrentStateUntil = until1700
+			s.Until = time1700
+			s.CurrentStateUntil = time1700
 		})
 
-		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
+		now := time1600
 		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 60, 180) // 60分延長、最大180分
 
 		assert.Equal(t, 60, actualAdded)
 		assert.Equal(t, 120, newRemaining) // 元々60分残り + 60分延長 = 120分
-		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:00:00"), seat.Until)
-		assert.Equal(t, seat.Until, seat.CurrentStateUntil)
+		assert.Equal(t, time1800, seat.Until)
+		assert.Equal(t, time1800, seat.CurrentStateUntil)
 	})
 
 	t.Run("最大値超過_maxWorkTimeMinで制限", func(t *testing.T) {
 		seat := mustSeat(func(s *SeatDoc) {
-			s.Until = until1700
-			s.CurrentStateUntil = until1700
+			s.Until = time1700
+			s.CurrentStateUntil = time1700
 		})
 
-		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
+		now := time1600
 		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 200, 120) // 200分延長希望、最大120分
 
 		// 最大120分までしか延長できない（現在から120分後 = 18:00）
 		// 元のUntilは17:00だったので、実際の延長は60分
 		assert.Equal(t, 60, actualAdded)
 		assert.Equal(t, 120, newRemaining)
-		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:00:00"), seat.Until)
+		assert.Equal(t, time1800, seat.Until)
 	})
 
 	t.Run("最大値ギリギリ", func(t *testing.T) {
 		seat := mustSeat(func(s *SeatDoc) {
-			s.Until = until1700
-			s.CurrentStateUntil = until1700
+			s.Until = time1700
+			s.CurrentStateUntil = time1700
 		})
 
-		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
+		now := time1600
 		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 120, 120) // 120分延長、最大120分
 
 		assert.Equal(t, 60, actualAdded) // 17:00まで60分残っているので、追加は60分
 		assert.Equal(t, 120, newRemaining)
-		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:00:00"), seat.Until)
+		assert.Equal(t, time1800, seat.Until)
 	})
 
 	t.Run("延長なし_0分", func(t *testing.T) {
-		original := until1700
 		seat := mustSeat(func(s *SeatDoc) {
-			s.Until = original
-			s.CurrentStateUntil = original
+			s.Until = time1700
+			s.CurrentStateUntil = time1700
 		})
 
-		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
+		now := time1600
 		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 0, 180)
 
 		assert.Equal(t, 0, actualAdded)
 		assert.Equal(t, 60, newRemaining) // 元々60分残り
-		assert.Equal(t, original, seat.Until)
+		assert.Equal(t, time1700, seat.Until)
+	})
+
+	t.Run("現在時刻=Until", func(t *testing.T) {
+		seat := mustSeat(func(s *SeatDoc) {
+			s.Until = time1600
+			s.CurrentStateUntil = time1600
+		})
+
+		now := time1600 // ちょうどUntilの時間
+		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 60, 180)
+
+		assert.Equal(t, 60, actualAdded)
+		assert.Equal(t, 60, newRemaining)
+		assert.Equal(t, time1700, seat.Until)
 	})
 
 	t.Run("現在時刻がUntilを過ぎている場合", func(t *testing.T) {
-		until1600 := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
 		seat := mustSeat(func(s *SeatDoc) {
-			s.Until = until1600
-			s.CurrentStateUntil = until1600
+			s.Until = time1600
+			s.CurrentStateUntil = time1600
 		})
 
-		now := mustParseTime(testTimeLayout, "2026-02-01 17:00:00") // 既に過ぎている
+		now := time1700 // 既に過ぎている
 		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 60, 180)
 
 		// 60分延長されるので17:00になる
 		assert.Equal(t, 60, actualAdded) // 16:00 → 17:00なので60分
 		assert.Equal(t, 0, newRemaining) // 17:00 → 17:00なので0分
-		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 17:00:00"), seat.Until)
+		assert.Equal(t, time1700, seat.Until)
 	})
 
 	t.Run("UntilとCurrentStateUntilの同期確認", func(t *testing.T) {
 		seat := mustSeat(func(s *SeatDoc) {
-			s.Until = until1700
-			s.CurrentStateUntil = until1700
+			s.Until = time1700
+			s.CurrentStateUntil = time1700
 		})
 
-		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
+		now := time1600
 		seat.ExtendWorkDuration(now, 30, 180)
 
 		assert.Equal(t, seat.Until, seat.CurrentStateUntil)
@@ -445,15 +474,30 @@ func TestSeatDoc_RemainingBreakMin(t *testing.T) {
 
 		assert.Equal(t, 0, remaining)
 	})
+
+	t.Run("数秒残りは切り捨て", func(t *testing.T) {
+		seat := mustSeat(func(s *SeatDoc) {
+			s.CurrentStateUntil = mustParseTime(testTimeLayout, "2026-02-01 13:00:00")
+		})
+
+		now := mustParseTime(testTimeLayout, "2026-02-01 13:00:00")
+		remaining := seat.RemainingBreakMin(now)
+
+		assert.Equal(t, 0, remaining)
+	})
 }
 
 func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
+	time1300 := mustParseTime(testTimeLayout, "2026-02-01 13:00:00")
+	time1800 := mustParseTime(testTimeLayout, "2026-02-01 18:00:00")
+	time1830 := mustParseTime(testTimeLayout, "2026-02-01 18:30:00")
+
 	t.Run("通常の延長_Untilは延長なし", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                 BreakState,
 			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
 			CurrentStateUntil:     mustParseTime(testTimeLayout, "2026-02-01 13:00:00"),
-			Until:                 mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
+			Until:                 time1800,
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 12:30:00")
@@ -463,7 +507,7 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 		assert.Equal(t, 60, remainingBreak) // 12:30 → 13:30 = 60分
 		assert.Equal(t, 330, remainingExit) // 12:30 → 18:00 = 330分
 		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 13:30:00"), seat.CurrentStateUntil)
-		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:00:00"), seat.Until) // 変化なし
+		assert.Equal(t, time1800, seat.Until) // 変化なし
 	})
 
 	t.Run("Untilも延長_休憩終了時刻がUntilを超える", func(t *testing.T) {
@@ -471,7 +515,7 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 			State:                 BreakState,
 			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
 			CurrentStateUntil:     mustParseTime(testTimeLayout, "2026-02-01 17:30:00"),
-			Until:                 mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
+			Until:                 time1800,
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 17:15:00")
@@ -481,8 +525,8 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 		assert.Equal(t, 60, actualAdded)
 		assert.Equal(t, 75, remainingBreak) // 17:15 → 18:30 = 75分
 		assert.Equal(t, 75, remainingExit)  // Untilも18:30に延長される
-		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:30:00"), seat.CurrentStateUntil)
-		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:30:00"), seat.Until)
+		assert.Equal(t, time1830, seat.CurrentStateUntil)
+		assert.Equal(t, time1830, seat.Until)
 	})
 
 	t.Run("最大値超過_maxBreakDurationMinで制限", func(t *testing.T) {
@@ -490,7 +534,7 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 			State:                 BreakState,
 			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
 			CurrentStateUntil:     mustParseTime(testTimeLayout, "2026-02-01 12:30:00"),
-			Until:                 mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
+			Until:                 time1800,
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 12:15:00")
@@ -500,13 +544,13 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 		assert.Equal(t, 30, actualAdded)    // 12:30 → 13:00 = 30分
 		assert.Equal(t, 45, remainingBreak) // 12:15 → 13:00 = 45分
 		assert.Equal(t, 345, remainingExit) // 12:15 → 18:00 = 345分
-		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 13:00:00"), seat.CurrentStateUntil)
-		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:00:00"), seat.Until)
+		assert.Equal(t, time1300, seat.CurrentStateUntil)
+		assert.Equal(t, time1800, seat.Until)
 	})
 
 	t.Run("延長なし_0分", func(t *testing.T) {
-		originalBreakUntil := mustParseTime(testTimeLayout, "2026-02-01 13:00:00")
-		originalUntil := mustParseTime(testTimeLayout, "2026-02-01 18:00:00")
+		originalBreakUntil := time1300
+		originalUntil := time1800
 		seat := SeatDoc{
 			State:                 BreakState,
 			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
@@ -529,7 +573,7 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 			State:                 BreakState,
 			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
 			CurrentStateUntil:     mustParseTime(testTimeLayout, "2026-02-01 12:30:00"),
-			Until:                 mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
+			Until:                 time1800,
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 12:15:00")
@@ -544,7 +588,7 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 			State:                 BreakState,
 			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
 			CurrentStateUntil:     mustParseTime(testTimeLayout, "2026-02-01 17:30:00"),
-			Until:                 mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
+			Until:                 time1800,
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 17:15:00")
@@ -553,8 +597,25 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 		// 休憩は18:00まで（Untilと同じ）
 		assert.Equal(t, 45, remainingBreak) // 17:15 → 18:00
 		assert.Equal(t, 45, remainingExit)
-		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:00:00"), seat.CurrentStateUntil)
-		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:00:00"), seat.Until)
+		assert.Equal(t, time1800, seat.CurrentStateUntil)
+		assert.Equal(t, time1800, seat.Until)
+	})
+
+	t.Run("Untilとの関係_現在時刻=Until", func(t *testing.T) {
+		seat := SeatDoc{
+			State:                 BreakState,
+			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),
+			CurrentStateUntil:     mustParseTime(testTimeLayout, "2026-02-01 17:30:00"),
+			Until:                 time1800,
+		}
+
+		now := mustParseTime(testTimeLayout, "2026-02-01 17:30:00")
+		_, remainingBreak, remainingExit := seat.ExtendBreakDuration(now, 30, 120)
+
+		assert.Equal(t, 30, remainingBreak)
+		assert.Equal(t, 30, remainingExit)
+		assert.Equal(t, time1800, seat.CurrentStateUntil)
+		assert.Equal(t, time1800, seat.Until)
 	})
 
 	t.Run("複雑なケース_最大値制限とUntil延長の両方", func(t *testing.T) {
@@ -562,7 +623,7 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 			State:                 BreakState,
 			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 17:30:00"),
 			CurrentStateUntil:     mustParseTime(testTimeLayout, "2026-02-01 17:45:00"),
-			Until:                 mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
+			Until:                 time1800,
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 17:40:00")
@@ -572,8 +633,8 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 		assert.Equal(t, 45, actualAdded)    // 17:45 → 18:30 = 45分
 		assert.Equal(t, 50, remainingBreak) // 17:40 → 18:30 = 50分
 		assert.Equal(t, 50, remainingExit)  // Untilも18:30
-		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:30:00"), seat.CurrentStateUntil)
-		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 18:30:00"), seat.Until)
+		assert.Equal(t, time1830, seat.CurrentStateUntil)
+		assert.Equal(t, time1830, seat.Until)
 	})
 }
 
@@ -581,7 +642,7 @@ func TestSeatDoc_GenerateWorkSegment(t *testing.T) {
 	t.Run("通常の作業セグメントを生成できること", func(t *testing.T) {
 		seat := SeatDoc{
 			UserID:                  "user-1",
-			SeatID:                  3,
+			SeatID:                  1,
 			SessionID:               "session-1",
 			State:                   WorkState,
 			WorkName:                "数学",
@@ -594,7 +655,7 @@ func TestSeatDoc_GenerateWorkSegment(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, WorkSegmentDoc{
 			UserID:       "user-1",
-			SeatID:       3,
+			SeatID:       1,
 			IsMemberSeat: true,
 			SessionID:    "session-1",
 			WorkName:     "数学",
@@ -608,7 +669,7 @@ func TestSeatDoc_GenerateWorkSegment(t *testing.T) {
 	t.Run("休憩セグメントではBreakWorkNameを返すこと", func(t *testing.T) {
 		seat := SeatDoc{
 			UserID:                  "user-2",
-			SeatID:                  8,
+			SeatID:                  2,
 			SessionID:               "session-2",
 			State:                   BreakState,
 			WorkName:                "英語",
@@ -622,7 +683,7 @@ func TestSeatDoc_GenerateWorkSegment(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, WorkSegmentDoc{
 			UserID:       "user-2",
-			SeatID:       8,
+			SeatID:       2,
 			IsMemberSeat: false,
 			SessionID:    "session-2",
 			WorkName:     "昼休み",
@@ -630,6 +691,31 @@ func TestSeatDoc_GenerateWorkSegment(t *testing.T) {
 			StartedAt:    mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
 			EndedAt:      now,
 			DurationSec:  600,
+		}, workSegment)
+	})
+
+	t.Run("CurrentSegmentStartedAt = now なら DurationSec = 0", func(t *testing.T) {
+		seat := SeatDoc{
+			UserID:                  "user-3",
+			SeatID:                  3,
+			SessionID:               "session-3",
+			State:                   WorkState,
+			CurrentSegmentStartedAt: mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
+		}
+		now := mustParseTime(testTimeLayout, "2026-02-01 12:00:00")
+		workSegment, err := seat.GenerateWorkSegment(now, false)
+
+		assert.NoError(t, err)
+		assert.Equal(t, WorkSegmentDoc{
+			UserID:       "user-3",
+			SeatID:       3,
+			IsMemberSeat: false,
+			SessionID:    "session-3",
+			WorkName:     "",
+			SegmentType:  WorkState, // StateがWorkStateのまま
+			StartedAt:    now,
+			EndedAt:      now,
+			DurationSec:  0,
 		}, workSegment)
 	})
 

--- a/system/core/repository/seat_test.go
+++ b/system/core/repository/seat_test.go
@@ -602,7 +602,7 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 		assert.Equal(t, time1800, seat.Until)
 	})
 
-	t.Run("Untilとの関係_現在時刻=Until", func(t *testing.T) {
+	t.Run("現在時刻=CurrentStateUntil", func(t *testing.T) {
 		seat := SeatDoc{
 			State:                 BreakState,
 			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 17:00:00"),


### PR DESCRIPTION
## 概要

SeatDoc の DTO / ドメインモデル分離に向けたフェーズ1として、`seat.go` の現行仕様をテストで固定しました。

今回の目的は、構造変更に入る前に `SeatDoc` の状態遷移・境界条件・日付跨ぎ挙動を明確化し、後続のリファクタリングで意図せぬ仕様変更が混ざらないようにすることです。

## 変更内容

- `seat_test.go` を拡充
- `mustSeat` などの薄いテスト helper を追加
- 以下の主要メソッドのテストを整理・追加
  - `StartBreak`
  - `ResumeWork`
  - `SetWorkDuration`
  - `ExtendWorkDuration`
  - `RemainingWorkMin`
  - `RemainingBreakMin`
  - `ExtendBreakDuration`
  - `GenerateWorkSegment`

## テストで固定した主な観点

- 通常系の状態遷移
- 短い日付跨ぎ時の累積作業時間 / 当日作業時間の扱い
- `Until` / `CurrentStateUntil` の連動
- `CurrentSegmentStartedAt` の更新
- 0分・期限ちょうど・期限超過などの境界ケース
- 秒単位の切り捨て
- `CurrentSegmentStartedAt` が zero value の場合の error

## 補足

- 本PRでは実装ロジックの大きな変更は行っていません（StartBreakの挙動は一部変えました）
- DTO / ドメイン分離自体はまだ行っていません
- あくまで後続フェーズのための仕様固定が目的です

## 次フェーズ

フェーズ2では、`command_seat.go` などアプリ層に残っている `SeatDoc` の直接フィールド更新を整理し、更新処理をメソッド経由に寄せていく予定です。