### PR TITLE
SeatDoc の DTO / ドメインモデル分離に向けたフェーズ2として、`command_seat.go` に残っていた `SeatDoc` の直接フィールド更新を整理し、更新処理をメソッド経由に寄せ

### DIFF
--- a/system/core/repository/seat.go
+++ b/system/core/repository/seat.go
@@ -7,6 +7,38 @@ import (
 	"app.modules/core/timeutil"
 )
 
+func (s *SeatDoc) SetWorkName(name string) {
+	s.WorkName = name
+}
+
+func (s *SeatDoc) ClearWorkName() {
+	s.WorkName = ""
+}
+
+func (s *SeatDoc) SetBreakWorkName(name string) {
+	s.BreakWorkName = name
+}
+
+func (s *SeatDoc) ClearBreakWorkName() {
+	s.BreakWorkName = ""
+}
+
+func (s *SeatDoc) SetMenuCode(code string) {
+	s.MenuCode = code
+}
+
+func (s *SeatDoc) ClearMenuCode() {
+	s.MenuCode = ""
+}
+
+func (s *SeatDoc) SetCurrentSegmentStartedAt(now time.Time) {
+	s.CurrentSegmentStartedAt = now
+}
+
+func (s *SeatDoc) SetCurrentStateUntil(newUntil time.Time) {
+	s.CurrentStateUntil = newUntil
+}
+
 func (s *SeatDoc) RealtimeEntryDurationMin(now time.Time) time.Duration {
 	return now.Sub(s.EnteredAt)
 }

--- a/system/core/workspaceapp/command_seat.go
+++ b/system/core/workspaceapp/command_seat.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"time"
 
+	"errors"
+
 	i18nmsg "app.modules/core/i18n/typed"
 	"app.modules/core/repository"
 	"app.modules/core/studyspaceerror"
@@ -14,7 +16,6 @@ import (
 	"app.modules/core/workspaceapp/presenter"
 	"app.modules/core/workspaceapp/usecase"
 	"cloud.google.com/go/firestore"
-	"errors"
 )
 
 func (app *WorkspaceApp) In(ctx context.Context, inOption *utils.InOption) error {
@@ -129,7 +130,7 @@ func (app *WorkspaceApp) In(ctx context.Context, inOption *utils.InOption) error
 					return fmt.Errorf("in GetMenuItemByNumber(): %w", err)
 				}
 				if isInRoom {
-					currentSeat.MenuCode = targetMenuItem.Code
+					currentSeat.SetMenuCode(targetMenuItem.Code)
 				}
 			}
 		}
@@ -150,7 +151,7 @@ func (app *WorkspaceApp) In(ctx context.Context, inOption *utils.InOption) error
 				result.Add(usecase.OrderLimitExceeded{MaxDailyOrderCount: app.Configs.Constants.MaxDailyOrderCount})
 			} else {
 				if isInRoom {
-					currentSeat.MenuCode = targetMenuItem.Code
+					currentSeat.SetMenuCode(targetMenuItem.Code)
 				}
 
 				// 注文履歴を作成
@@ -218,13 +219,13 @@ func (app *WorkspaceApp) In(ctx context.Context, inOption *utils.InOption) error
 
 				switch currentSeat.State {
 				case repository.WorkState:
-					currentSeat.WorkName = inOption.MinWorkOrderOption.WorkName
+					currentSeat.SetWorkName(inOption.MinWorkOrderOption.WorkName)
 					replyMessage += i18nmsg.CommandChangeUpdateWork(inOption.MinWorkOrderOption.WorkName, seatIDStr)
 				case repository.BreakState:
-					currentSeat.BreakWorkName = inOption.MinWorkOrderOption.WorkName
+					currentSeat.SetBreakWorkName(inOption.MinWorkOrderOption.WorkName)
 					replyMessage += i18nmsg.CommandChangeUpdateBreak(inOption.MinWorkOrderOption.WorkName, seatIDStr)
 				}
-				currentSeat.CurrentSegmentStartedAt = jstNow
+				currentSeat.SetCurrentSegmentStartedAt(jstNow)
 			}
 
 			if inOption.MinWorkOrderOption.IsDurationMinSet {
@@ -257,7 +258,7 @@ func (app *WorkspaceApp) In(ctx context.Context, inOption *utils.InOption) error
 						remainingBreakDuration := currentSeat.CurrentStateUntil.Sub(jstNow)
 						replyMessage += i18nmsg.CommandChangeBreakDurationBefore(inOption.MinWorkOrderOption.DurationMin, int(realtimeBreakDuration.Minutes()), int(remainingBreakDuration.Minutes()))
 					} else { // それ以外ならuntilを変更
-						currentSeat.CurrentStateUntil = requestedUntil
+						currentSeat.SetCurrentStateUntil(requestedUntil)
 						remainingBreakDuration := requestedUntil.Sub(jstNow)
 						replyMessage += i18nmsg.CommandChangeBreakDuration(inOption.MinWorkOrderOption.DurationMin, int(realtimeBreakDuration.Minutes()), int(remainingBreakDuration.Minutes()))
 					}
@@ -461,17 +462,17 @@ func (app *WorkspaceApp) Change(ctx context.Context, changeOption *utils.MinWork
 			}
 
 			// seatを更新
-			currentSeat.CurrentSegmentStartedAt = jstNow
+			currentSeat.SetCurrentSegmentStartedAt(jstNow)
 			switch currentSeat.State {
 			case repository.WorkState:
-				currentSeat.WorkName = changeOption.WorkName
+				currentSeat.SetWorkName(changeOption.WorkName)
 				result.Add(usecase.ChangeUpdatedWork{
 					WorkName:     changeOption.WorkName,
 					SeatID:       currentSeat.SeatID,
 					IsMemberSeat: isInMemberRoom,
 				})
 			case repository.BreakState:
-				currentSeat.BreakWorkName = changeOption.WorkName
+				currentSeat.SetBreakWorkName(changeOption.WorkName)
 				result.Add(usecase.ChangeUpdatedBreak{
 					WorkName:     changeOption.WorkName,
 					SeatID:       currentSeat.SeatID,
@@ -525,7 +526,7 @@ func (app *WorkspaceApp) Change(ctx context.Context, changeOption *utils.MinWork
 						RemainingBreakMin:        int(remainingBreakDuration.Minutes()),
 					})
 				} else { // それ以外ならuntilを変更
-					currentSeat.CurrentStateUntil = requestedUntil
+					currentSeat.SetCurrentStateUntil(requestedUntil)
 					remainingBreakDuration := requestedUntil.Sub(jstNow)
 					result.Add(usecase.ChangeBreakDurationUpdated{
 						RequestedMin:             changeOption.DurationMin,
@@ -880,7 +881,7 @@ func (app *WorkspaceApp) Order(ctx context.Context, orderOption *utils.OrderOpti
 
 		if orderOption.ClearFlag {
 			// 食器を下げる（注文履歴は削除しない）
-			currentSeat.MenuCode = ""
+			currentSeat.ClearMenuCode()
 			err := app.Repository.UpdateSeat(ctx, tx, currentSeat, isInMemberRoom)
 			if err != nil {
 				return fmt.Errorf("in UpdateSeat: %w", err)
@@ -907,7 +908,7 @@ func (app *WorkspaceApp) Order(ctx context.Context, orderOption *utils.OrderOpti
 		}
 
 		// 座席ドキュメントを更新
-		currentSeat.MenuCode = targetMenuItem.Code
+		currentSeat.SetMenuCode(targetMenuItem.Code)
 		err = app.Repository.UpdateSeat(ctx, tx, currentSeat, isInMemberRoom)
 		if err != nil {
 			return fmt.Errorf("in UpdateSeat: %w", err)
@@ -967,13 +968,13 @@ func (app *WorkspaceApp) Clear(ctx context.Context) error {
 		// 作業内容をクリアする
 		switch seat.State {
 		case repository.WorkState:
-			seat.WorkName = ""
+			seat.ClearWorkName()
 			result.Add(usecase.ClearWork{SeatID: seat.SeatID, IsMemberSeat: isInMemberRoom})
 		case repository.BreakState:
-			seat.BreakWorkName = ""
+			seat.ClearBreakWorkName()
 			result.Add(usecase.ClearBreak{SeatID: seat.SeatID, IsMemberSeat: isInMemberRoom})
 		}
-		seat.CurrentSegmentStartedAt = jstNow
+		seat.SetCurrentSegmentStartedAt(jstNow)
 
 		err = app.Repository.UpdateSeat(ctx, tx, seat, isInMemberRoom)
 		if err != nil {

--- a/system/core/workspaceapp/command_seat.go
+++ b/system/core/workspaceapp/command_seat.go
@@ -2,11 +2,10 @@ package workspaceapp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
-
-	"errors"
 
 	i18nmsg "app.modules/core/i18n/typed"
 	"app.modules/core/repository"


### PR DESCRIPTION
## 概要

SeatDoc の DTO / ドメインモデル分離に向けたフェーズ2として、`command_seat.go` に残っていた `SeatDoc` の直接フィールド更新を整理し、更新処理をメソッド経由に寄せました。

今回の目的は、アプリ層から `SeatDoc` の内部状態を直接書き換える箇所を減らし、後続の DTO / ドメイン分離で差し替えやすい更新入口を先に整えることです。

## 変更内容

- `SeatDoc` に更新用メソッドを追加
  - `SetWorkName`
  - `SetBreakWorkName`
  - `ClearWorkName`
  - `ClearBreakWorkName`
  - `SetCurrentSegmentStartedAt`
  - `SetCurrentStateUntil`
  - `SetMenuCode`
  - `ClearMenuCode`
- `command_seat.go` の主要 write path を修正
  - `Change`
  - `Order`
  - `Clear`
  - `In`
- 上記で行っていた `SeatDoc` の直接代入を、追加したメソッド呼び出しへ置換

## このPRでやっていないこと

- DTO / ドメインモデル分離そのもの
- 状態遷移メソッドの `error` 返却化
- usecase / service の大規模分割
- 振る舞い変更を伴うリファクタリング

## ねらい

- `workspaceapp` からの素手の状態更新を減らす
- `SeatDoc` の更新入口を寄せる
- 後続フェーズで `SeatDoc` からドメインモデルへ責務を移しやすくする
- 今回は挙動を変えず、更新経路だけを整理する

## 次フェーズ

次は、`SeatDoc` を保存用 DTO とドメインモデルに分離しやすくするため、
更新メソッドの責務整理や、DTO / ドメイン変換層の導入を進める予定です。