### PR TITLE
feat(seat): SeatDoc の状態前提を error で強制（StartBreak ほか）

### DIFF
--- a/system/core/repository/seat.go
+++ b/system/core/repository/seat.go
@@ -70,7 +70,7 @@ func (s *SeatDoc) RemainingBreakMin(now time.Time) int {
 // 前提条件: s.State == WorkState
 func (s *SeatDoc) StartBreak(now time.Time, breakWorkName string, breakDurationMin int) error {
 	if s.State != WorkState {
-		return fmt.Errorf("start break requires work state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
+		return fmt.Errorf("StartBreak requires work state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
 	}
 
 	breakUntil := now.Add(time.Duration(breakDurationMin) * time.Minute)
@@ -109,7 +109,11 @@ func (s *SeatDoc) StartBreak(now time.Time, breakWorkName string, breakDurationM
 //   - workName: 設定する作業名（呼び出し側で引継ぎ判定を行う）
 //
 // 前提条件: s.State == BreakState
-func (s *SeatDoc) ResumeWork(now time.Time, workName string) {
+func (s *SeatDoc) ResumeWork(now time.Time, workName string) error {
+	if s.State != BreakState {
+		return fmt.Errorf("ResumeWork requires break state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
+	}
+
 	breakSec := int(timeutil.NoNegativeDuration(now.Sub(s.CurrentStateStartedAt)).Seconds())
 
 	// 日付跨ぎを考慮して当日の累積時間を調整
@@ -124,6 +128,8 @@ func (s *SeatDoc) ResumeWork(now time.Time, workName string) {
 	s.CurrentSegmentStartedAt = now
 	s.DailyCumulativeWorkSec = dailyCumulativeWorkSec
 	s.WorkName = workName
+
+	return nil
 }
 
 // SetWorkDuration は作業時間（入室から退室まで）を変更する。

--- a/system/core/repository/seat.go
+++ b/system/core/repository/seat.go
@@ -68,7 +68,11 @@ func (s *SeatDoc) RemainingBreakMin(now time.Time) int {
 //   - breakDurationMin: 休憩時間（分）
 //
 // 前提条件: s.State == WorkState
-func (s *SeatDoc) StartBreak(now time.Time, breakWorkName string, breakDurationMin int) {
+func (s *SeatDoc) StartBreak(now time.Time, breakWorkName string, breakDurationMin int) error {
+	if s.State != WorkState {
+		return fmt.Errorf("start break requires work state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
+	}
+
 	breakUntil := now.Add(time.Duration(breakDurationMin) * time.Minute)
 	workedSec := int(timeutil.NoNegativeDuration(now.Sub(s.CurrentStateStartedAt)).Seconds())
 	cumulativeWorkSec := s.CumulativeWorkSec + workedSec
@@ -93,6 +97,8 @@ func (s *SeatDoc) StartBreak(now time.Time, breakWorkName string, breakDurationM
 	if breakUntil.After(s.Until) {
 		s.Until = breakUntil
 	}
+
+	return nil
 }
 
 // ResumeWork は休憩状態から作業状態に復帰する。

--- a/system/core/repository/seat.go
+++ b/system/core/repository/seat.go
@@ -139,9 +139,14 @@ func (s *SeatDoc) ResumeWork(now time.Time, workName string) error {
 //   - newUntil: 新しい自動退室予定時刻
 //
 // 前提条件: s.State == WorkState
-func (s *SeatDoc) SetWorkDuration(newUntil time.Time) {
+func (s *SeatDoc) SetWorkDuration(newUntil time.Time) error {
+	if s.State != WorkState {
+		return fmt.Errorf("SetWorkDuration requires work state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
+	}
+
 	s.Until = newUntil
 	s.CurrentStateUntil = newUntil
+	return nil
 }
 
 // ExtendWorkDuration は作業時間を延長する。
@@ -155,9 +160,14 @@ func (s *SeatDoc) SetWorkDuration(newUntil time.Time) {
 // 戻り値:
 //   - actualAddedMin: 実際に延長された時間（分）
 //   - newRemainingMin: 延長後の残り時間（分）
+//   - err: 前提条件を満たさない場合
 //
 // 前提条件: s.State == WorkState
-func (s *SeatDoc) ExtendWorkDuration(now time.Time, requestedAddMin int, maxWorkTimeMin int) (actualAddedMin int, newRemainingMin int) {
+func (s *SeatDoc) ExtendWorkDuration(now time.Time, requestedAddMin int, maxWorkTimeMin int) (actualAddedMin int, newRemainingMin int, err error) {
+	if s.State != WorkState {
+		return 0, 0, fmt.Errorf("ExtendWorkDuration requires work state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
+	}
+
 	newUntil := s.Until.Add(time.Duration(requestedAddMin) * time.Minute)
 	remainingMin := int(timeutil.NoNegativeDuration(newUntil.Sub(now)).Minutes())
 
@@ -171,7 +181,7 @@ func (s *SeatDoc) ExtendWorkDuration(now time.Time, requestedAddMin int, maxWork
 	s.CurrentStateUntil = newUntil
 	newRemainingMin = int(timeutil.NoNegativeDuration(newUntil.Sub(now)).Minutes())
 
-	return actualAddedMin, newRemainingMin
+	return actualAddedMin, newRemainingMin, nil
 }
 
 // ExtendBreakDuration は休憩時間を延長する。
@@ -186,9 +196,14 @@ func (s *SeatDoc) ExtendWorkDuration(now time.Time, requestedAddMin int, maxWork
 //   - actualAddedMin: 実際に延長された時間（分）
 //   - newRemainingBreakMin: 延長後の休憩残り時間（分）
 //   - newRemainingUntilExitMin: 延長後の自動退室までの残り時間（分）
+//   - err: 前提条件を満たさない場合
 //
 // 前提条件: s.State == BreakState
-func (s *SeatDoc) ExtendBreakDuration(now time.Time, requestedAddMin int, maxBreakDurationMin int) (actualAddedMin int, newRemainingBreakMin int, newRemainingUntilExitMin int) {
+func (s *SeatDoc) ExtendBreakDuration(now time.Time, requestedAddMin int, maxBreakDurationMin int) (actualAddedMin int, newRemainingBreakMin int, newRemainingUntilExitMin int, err error) {
+	if s.State != BreakState {
+		return 0, 0, 0, fmt.Errorf("ExtendBreakDuration requires break state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
+	}
+
 	newBreakUntil := s.CurrentStateUntil.Add(time.Duration(requestedAddMin) * time.Minute)
 	newBreakDuration := timeutil.NoNegativeDuration(newBreakUntil.Sub(s.CurrentStateStartedAt))
 
@@ -208,7 +223,7 @@ func (s *SeatDoc) ExtendBreakDuration(now time.Time, requestedAddMin int, maxBre
 	newRemainingBreakMin = int(timeutil.NoNegativeDuration(s.CurrentStateUntil.Sub(now)).Minutes())
 	newRemainingUntilExitMin = int(timeutil.NoNegativeDuration(s.Until.Sub(now)).Minutes())
 
-	return actualAddedMin, newRemainingBreakMin, newRemainingUntilExitMin
+	return actualAddedMin, newRemainingBreakMin, newRemainingUntilExitMin, nil
 }
 
 func (s *SeatDoc) GenerateWorkSegment(now time.Time, isMemberSeat bool) (WorkSegmentDoc, error) {

--- a/system/core/repository/seat.go
+++ b/system/core/repository/seat.go
@@ -67,10 +67,14 @@ func (s *SeatDoc) RemainingBreakMin(now time.Time) int {
 //   - breakWorkName: 休憩中の作業名
 //   - breakDurationMin: 休憩時間（分）
 //
-// 前提条件: s.State == WorkState
+// 前提条件:
+//   - s.State == WorkState
+//
+// 戻り値:
+//   - error: 前提条件を満たさない場合は非 nil。正常に遷移した場合は nil。
 func (s *SeatDoc) StartBreak(now time.Time, breakWorkName string, breakDurationMin int) error {
 	if s.State != WorkState {
-		return fmt.Errorf("StartBreak requires work state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
+		return fmt.Errorf("requires work state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
 	}
 
 	breakUntil := now.Add(time.Duration(breakDurationMin) * time.Minute)
@@ -108,10 +112,14 @@ func (s *SeatDoc) StartBreak(now time.Time, breakWorkName string, breakDurationM
 //   - now: 作業再開時刻（JSTを想定）
 //   - workName: 設定する作業名（呼び出し側で引継ぎ判定を行う）
 //
-// 前提条件: s.State == BreakState
+// 前提条件:
+//   - s.State == BreakState
+//
+// 戻り値:
+//   - error: 前提条件を満たさない場合は非 nil。正常に遷移した場合は nil。
 func (s *SeatDoc) ResumeWork(now time.Time, workName string) error {
 	if s.State != BreakState {
-		return fmt.Errorf("ResumeWork requires break state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
+		return fmt.Errorf("requires break state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
 	}
 
 	breakSec := int(timeutil.NoNegativeDuration(now.Sub(s.CurrentStateStartedAt)).Seconds())
@@ -138,10 +146,14 @@ func (s *SeatDoc) ResumeWork(now time.Time, workName string) error {
 // 引数:
 //   - newUntil: 新しい自動退室予定時刻
 //
-// 前提条件: s.State == WorkState
+// 前提条件:
+//   - s.State == WorkState
+//
+// 戻り値:
+//   - error: 前提条件を満たさない場合は非 nil。更新に成功した場合は nil。
 func (s *SeatDoc) SetWorkDuration(newUntil time.Time) error {
 	if s.State != WorkState {
-		return fmt.Errorf("SetWorkDuration requires work state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
+		return fmt.Errorf("requires work state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
 	}
 
 	s.Until = newUntil
@@ -160,12 +172,13 @@ func (s *SeatDoc) SetWorkDuration(newUntil time.Time) error {
 // 戻り値:
 //   - actualAddedMin: 実際に延長された時間（分）
 //   - newRemainingMin: 延長後の残り時間（分）
-//   - err: 前提条件を満たさない場合
+//   - err: 前提条件を満たさない場合は非 nil（このとき actualAddedMin / newRemainingMin はゼロ値）
 //
-// 前提条件: s.State == WorkState
+// 前提条件:
+//   - s.State == WorkState
 func (s *SeatDoc) ExtendWorkDuration(now time.Time, requestedAddMin int, maxWorkTimeMin int) (actualAddedMin int, newRemainingMin int, err error) {
 	if s.State != WorkState {
-		return 0, 0, fmt.Errorf("ExtendWorkDuration requires work state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
+		return 0, 0, fmt.Errorf("requires work state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
 	}
 
 	newUntil := s.Until.Add(time.Duration(requestedAddMin) * time.Minute)
@@ -196,12 +209,13 @@ func (s *SeatDoc) ExtendWorkDuration(now time.Time, requestedAddMin int, maxWork
 //   - actualAddedMin: 実際に延長された時間（分）
 //   - newRemainingBreakMin: 延長後の休憩残り時間（分）
 //   - newRemainingUntilExitMin: 延長後の自動退室までの残り時間（分）
-//   - err: 前提条件を満たさない場合
+//   - err: 前提条件を満たさない場合は非 nil（このとき他の戻り値はゼロ値）
 //
-// 前提条件: s.State == BreakState
+// 前提条件:
+//   - s.State == BreakState
 func (s *SeatDoc) ExtendBreakDuration(now time.Time, requestedAddMin int, maxBreakDurationMin int) (actualAddedMin int, newRemainingBreakMin int, newRemainingUntilExitMin int, err error) {
 	if s.State != BreakState {
-		return 0, 0, 0, fmt.Errorf("ExtendBreakDuration requires break state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
+		return 0, 0, 0, fmt.Errorf("requires break state: seatID=%d userID=%s state=%s", s.SeatID, s.UserID, s.State)
 	}
 
 	newBreakUntil := s.CurrentStateUntil.Add(time.Duration(requestedAddMin) * time.Minute)

--- a/system/core/repository/seat_test.go
+++ b/system/core/repository/seat_test.go
@@ -43,8 +43,9 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 11:00:00") // 1時間作業
-		seat.StartBreak(now, "休憩中", 15)
+		err := seat.StartBreak(now, "休憩中", 15)
 
+		assert.NoError(t, err)
 		assert.Equal(t, BreakState, seat.State)
 		assert.Equal(t, now, seat.CurrentStateStartedAt)
 		assert.Equal(t, now, seat.CurrentSegmentStartedAt)
@@ -62,8 +63,9 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 11:15:00")
-		seat.StartBreak(now, "休憩中", 15)
+		err := seat.StartBreak(now, "休憩中", 15)
 
+		assert.NoError(t, err)
 		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 11:30:00"), seat.Until)
 		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 11:30:00"), seat.CurrentStateUntil)
 	})
@@ -77,8 +79,9 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 12:00:00") // 3時間作業
-		seat.StartBreak(now, "ランチ", 60)
+		err := seat.StartBreak(now, "ランチ", 60)
 
+		assert.NoError(t, err)
 		assert.Equal(t, 3*3600, seat.CumulativeWorkSec)
 		assert.Equal(t, 3*3600, seat.DailyCumulativeWorkSec)
 	})
@@ -93,8 +96,9 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 
 		// 翌日の午前1時に休憩開始（3時間作業）
 		now := mustParseTime(testTimeLayout, "2026-02-02 01:00:00")
-		seat.StartBreak(now, "深夜休憩", 10)
+		err := seat.StartBreak(now, "深夜休憩", 10)
 
+		assert.NoError(t, err)
 		assert.Equal(t, 3*3600, seat.CumulativeWorkSec)      // CumulativeWorkSecは実際の作業時間
 		assert.Equal(t, 1*3600, seat.DailyCumulativeWorkSec) // DailyCumulativeWorkSecは当日の秒数（1時間分 = 3600秒）
 	})
@@ -107,8 +111,9 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 		})
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 10:00:00") // 同じ時刻
-		seat.StartBreak(now, "即休憩", 5)
+		err := seat.StartBreak(now, "即休憩", 5)
 
+		assert.NoError(t, err)
 		assert.Equal(t, 1800, seat.CumulativeWorkSec) // 変化なし
 		assert.Equal(t, 1800, seat.DailyCumulativeWorkSec)
 	})
@@ -117,9 +122,21 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 		seat := mustSeat(nil)
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 11:00:00")
-		seat.StartBreak(now, "", 15)
+		err := seat.StartBreak(now, "", 15)
 
+		assert.NoError(t, err)
 		assert.Equal(t, "", seat.BreakWorkName)
+	})
+
+	t.Run("WorkState以外はエラー", func(t *testing.T) {
+		seat := SeatDoc{
+			State: BreakState,
+		}
+
+		now := mustParseTime(testTimeLayout, "2026-02-01 10:00:00")
+		err := seat.StartBreak(now, "", 15)
+
+		assert.Error(t, err)
 	})
 }
 

--- a/system/core/repository/seat_test.go
+++ b/system/core/repository/seat_test.go
@@ -279,8 +279,9 @@ func TestSeatDoc_SetWorkDuration(t *testing.T) {
 		seat := mustSeat(nil)
 
 		newUntil := mustParseTime(testTimeLayout, "2026-02-01 20:00:00")
-		seat.SetWorkDuration(newUntil)
+		err := seat.SetWorkDuration(newUntil)
 
+		assert.NoError(t, err)
 		assert.Equal(t, newUntil, seat.Until)
 		assert.Equal(t, newUntil, seat.CurrentStateUntil)
 	})
@@ -293,8 +294,9 @@ func TestSeatDoc_SetWorkDuration(t *testing.T) {
 		})
 
 		extended := mustParseTime(testTimeLayout, "2026-02-01 19:00:00")
-		seat.SetWorkDuration(extended)
+		err := seat.SetWorkDuration(extended)
 
+		assert.NoError(t, err)
 		assert.Equal(t, extended, seat.Until)
 		assert.Equal(t, extended, seat.CurrentStateUntil)
 	})
@@ -307,8 +309,9 @@ func TestSeatDoc_SetWorkDuration(t *testing.T) {
 		})
 
 		shortened := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
-		seat.SetWorkDuration(shortened)
+		err := seat.SetWorkDuration(shortened)
 
+		assert.NoError(t, err)
 		assert.Equal(t, shortened, seat.Until)
 		assert.Equal(t, shortened, seat.CurrentStateUntil)
 	})
@@ -317,9 +320,19 @@ func TestSeatDoc_SetWorkDuration(t *testing.T) {
 		seat := mustSeat(nil)
 
 		newUntil := mustParseTime(testTimeLayout, "2026-02-01 21:00:00")
-		seat.SetWorkDuration(newUntil)
+		err := seat.SetWorkDuration(newUntil)
 
+		assert.NoError(t, err)
 		assert.Equal(t, seat.Until, seat.CurrentStateUntil)
+	})
+
+	t.Run("WorkState以外はエラー", func(t *testing.T) {
+		seat := SeatDoc{
+			State: BreakState,
+		}
+
+		err := seat.SetWorkDuration(mustParseTime(testTimeLayout, "2026-02-01 21:00:00"))
+		assert.Error(t, err)
 	})
 }
 
@@ -335,8 +348,9 @@ func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
 		})
 
 		now := time1600
-		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 60, 180) // 60分延長、最大180分
+		actualAdded, newRemaining, err := seat.ExtendWorkDuration(now, 60, 180) // 60分延長、最大180分
 
+		assert.NoError(t, err)
 		assert.Equal(t, 60, actualAdded)
 		assert.Equal(t, 120, newRemaining) // 元々60分残り + 60分延長 = 120分
 		assert.Equal(t, time1800, seat.Until)
@@ -350,8 +364,9 @@ func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
 		})
 
 		now := time1600
-		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 200, 120) // 200分延長希望、最大120分
+		actualAdded, newRemaining, err := seat.ExtendWorkDuration(now, 200, 120) // 200分延長希望、最大120分
 
+		assert.NoError(t, err)
 		// 最大120分までしか延長できない（現在から120分後 = 18:00）
 		// 元のUntilは17:00だったので、実際の延長は60分
 		assert.Equal(t, 60, actualAdded)
@@ -366,8 +381,9 @@ func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
 		})
 
 		now := time1600
-		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 120, 120) // 120分延長、最大120分
+		actualAdded, newRemaining, err := seat.ExtendWorkDuration(now, 120, 120) // 120分延長、最大120分
 
+		assert.NoError(t, err)
 		assert.Equal(t, 60, actualAdded) // 17:00まで60分残っているので、追加は60分
 		assert.Equal(t, 120, newRemaining)
 		assert.Equal(t, time1800, seat.Until)
@@ -380,8 +396,9 @@ func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
 		})
 
 		now := time1600
-		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 0, 180)
+		actualAdded, newRemaining, err := seat.ExtendWorkDuration(now, 0, 180)
 
+		assert.NoError(t, err)
 		assert.Equal(t, 0, actualAdded)
 		assert.Equal(t, 60, newRemaining) // 元々60分残り
 		assert.Equal(t, time1700, seat.Until)
@@ -394,8 +411,9 @@ func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
 		})
 
 		now := time1600 // ちょうどUntilの時間
-		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 60, 180)
+		actualAdded, newRemaining, err := seat.ExtendWorkDuration(now, 60, 180)
 
+		assert.NoError(t, err)
 		assert.Equal(t, 60, actualAdded)
 		assert.Equal(t, 60, newRemaining)
 		assert.Equal(t, time1700, seat.Until)
@@ -408,8 +426,9 @@ func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
 		})
 
 		now := time1700 // 既に過ぎている
-		actualAdded, newRemaining := seat.ExtendWorkDuration(now, 60, 180)
+		actualAdded, newRemaining, err := seat.ExtendWorkDuration(now, 60, 180)
 
+		assert.NoError(t, err)
 		// 60分延長されるので17:00になる
 		assert.Equal(t, 60, actualAdded) // 16:00 → 17:00なので60分
 		assert.Equal(t, 0, newRemaining) // 17:00 → 17:00なので0分
@@ -423,9 +442,20 @@ func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
 		})
 
 		now := time1600
-		seat.ExtendWorkDuration(now, 30, 180)
+		_, _, err := seat.ExtendWorkDuration(now, 30, 180)
 
+		assert.NoError(t, err)
 		assert.Equal(t, seat.Until, seat.CurrentStateUntil)
+	})
+
+	t.Run("WorkState以外はエラー", func(t *testing.T) {
+		seat := SeatDoc{
+			State: BreakState,
+		}
+
+		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
+		_, _, err := seat.ExtendWorkDuration(now, 60, 180)
+		assert.Error(t, err)
 	})
 }
 
@@ -533,8 +563,9 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 12:30:00")
-		actualAdded, remainingBreak, remainingExit := seat.ExtendBreakDuration(now, 30, 120)
+		actualAdded, remainingBreak, remainingExit, err := seat.ExtendBreakDuration(now, 30, 120)
 
+		assert.NoError(t, err)
 		assert.Equal(t, 30, actualAdded)
 		assert.Equal(t, 60, remainingBreak) // 12:30 → 13:30 = 60分
 		assert.Equal(t, 330, remainingExit) // 12:30 → 18:00 = 330分
@@ -551,8 +582,9 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 17:15:00")
-		actualAdded, remainingBreak, remainingExit := seat.ExtendBreakDuration(now, 60, 120)
+		actualAdded, remainingBreak, remainingExit, err := seat.ExtendBreakDuration(now, 60, 120)
 
+		assert.NoError(t, err)
 		// 休憩が18:30まで延長される（Untilの18:00を超える）
 		assert.Equal(t, 60, actualAdded)
 		assert.Equal(t, 75, remainingBreak) // 17:15 → 18:30 = 75分
@@ -570,8 +602,9 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 12:15:00")
-		actualAdded, remainingBreak, remainingExit := seat.ExtendBreakDuration(now, 200, 60) // 200分延長希望、最大60分
+		actualAdded, remainingBreak, remainingExit, err := seat.ExtendBreakDuration(now, 200, 60) // 200分延長希望、最大60分
 
+		assert.NoError(t, err)
 		// 休憩開始から最大60分（13:00まで）
 		assert.Equal(t, 30, actualAdded)    // 12:30 → 13:00 = 30分
 		assert.Equal(t, 45, remainingBreak) // 12:15 → 13:00 = 45分
@@ -591,8 +624,9 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 12:30:00")
-		actualAdded, remainingBreak, remainingExit := seat.ExtendBreakDuration(now, 0, 120)
+		actualAdded, remainingBreak, remainingExit, err := seat.ExtendBreakDuration(now, 0, 120)
 
+		assert.NoError(t, err)
 		assert.Equal(t, 0, actualAdded)
 		assert.Equal(t, 30, remainingBreak) // 12:30 → 13:00 = 30分
 		assert.Equal(t, 330, remainingExit) // 12:30 → 18:00 = 330分
@@ -609,8 +643,9 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 12:15:00")
-		actualAdded, _, _ := seat.ExtendBreakDuration(now, 30, 60) // 開始から60分ちょうど
+		actualAdded, _, _, err := seat.ExtendBreakDuration(now, 30, 60) // 開始から60分ちょうど
 
+		assert.NoError(t, err)
 		assert.Equal(t, 30, actualAdded)
 		assert.Equal(t, mustParseTime(testTimeLayout, "2026-02-01 13:00:00"), seat.CurrentStateUntil)
 	})
@@ -624,8 +659,9 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 17:15:00")
-		_, remainingBreak, remainingExit := seat.ExtendBreakDuration(now, 30, 120)
+		_, remainingBreak, remainingExit, err := seat.ExtendBreakDuration(now, 30, 120)
 
+		assert.NoError(t, err)
 		// 休憩は18:00まで（Untilと同じ）
 		assert.Equal(t, 45, remainingBreak) // 17:15 → 18:00
 		assert.Equal(t, 45, remainingExit)
@@ -642,8 +678,9 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 17:30:00")
-		_, remainingBreak, remainingExit := seat.ExtendBreakDuration(now, 30, 120)
+		_, remainingBreak, remainingExit, err := seat.ExtendBreakDuration(now, 30, 120)
 
+		assert.NoError(t, err)
 		assert.Equal(t, 30, remainingBreak)
 		assert.Equal(t, 30, remainingExit)
 		assert.Equal(t, time1800, seat.CurrentStateUntil)
@@ -659,14 +696,25 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 17:40:00")
-		actualAdded, remainingBreak, remainingExit := seat.ExtendBreakDuration(now, 100, 60) // 100分希望、最大60分
+		actualAdded, remainingBreak, remainingExit, err := seat.ExtendBreakDuration(now, 100, 60) // 100分希望、最大60分
 
+		assert.NoError(t, err)
 		// 開始から60分 = 18:30
 		assert.Equal(t, 45, actualAdded)    // 17:45 → 18:30 = 45分
 		assert.Equal(t, 50, remainingBreak) // 17:40 → 18:30 = 50分
 		assert.Equal(t, 50, remainingExit)  // Untilも18:30
 		assert.Equal(t, time1830, seat.CurrentStateUntil)
 		assert.Equal(t, time1830, seat.Until)
+	})
+
+	t.Run("BreakState以外はエラー", func(t *testing.T) {
+		seat := SeatDoc{
+			State: WorkState,
+		}
+
+		now := mustParseTime(testTimeLayout, "2026-02-01 12:30:00")
+		_, _, _, err := seat.ExtendBreakDuration(now, 30, 120)
+		assert.Error(t, err)
 	})
 }
 

--- a/system/core/repository/seat_test.go
+++ b/system/core/repository/seat_test.go
@@ -152,8 +152,9 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 13:00:00") // 1時間休憩
-		seat.ResumeWork(now, "新しい作業")
+		err := seat.ResumeWork(now, "新しい作業")
 
+		assert.NoError(t, err)
 		assert.Equal(t, WorkState, seat.State)
 		assert.Equal(t, now, seat.CurrentStateStartedAt)
 		assert.Equal(t, now, seat.CurrentSegmentStartedAt)
@@ -174,8 +175,9 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 12:30:00")
 		// 呼び出し側で既存の作業名を渡す
-		seat.ResumeWork(now, seat.WorkName)
+		err := seat.ResumeWork(now, seat.WorkName)
 
+		assert.NoError(t, err)
 		assert.Equal(t, "既存の作業名", seat.WorkName)
 	})
 
@@ -189,8 +191,9 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 12:30:00")
-		seat.ResumeWork(now, "") // 空文字列で明示的にクリア
+		err := seat.ResumeWork(now, "") // 空文字列で明示的にクリア
 
+		assert.NoError(t, err)
 		assert.Equal(t, "", seat.WorkName) // クリアされる
 	})
 
@@ -203,8 +206,9 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 13:00:00") // 1時間休憩
-		seat.ResumeWork(now, "再開")
+		err := seat.ResumeWork(now, "再開")
 
+		assert.NoError(t, err)
 		assert.Equal(t, 10800, seat.DailyCumulativeWorkSec) // 変化なし
 	})
 
@@ -220,8 +224,9 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 
 		// 翌日の午前2時に再開（4時間休憩）
 		now := mustParseTime(testTimeLayout, "2026-02-02 02:00:00")
-		seat.ResumeWork(now, "翌日再開")
+		err := seat.ResumeWork(now, "翌日再開")
 
+		assert.NoError(t, err)
 		assert.Equal(t, 3600, seat.CumulativeWorkSec)   // リセットされない
 		assert.Equal(t, 0, seat.DailyCumulativeWorkSec) // リセットされる
 	})
@@ -236,8 +241,9 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 15:30:00")
-		seat.ResumeWork(now, "作業")
+		err := seat.ResumeWork(now, "作業")
 
+		assert.NoError(t, err)
 		assert.Equal(t, until, seat.CurrentStateUntil)
 	})
 
@@ -250,9 +256,21 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 		}
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 12:00:00") // 同じ時刻
-		seat.ResumeWork(now, "即再開")
+		err := seat.ResumeWork(now, "即再開")
 
+		assert.NoError(t, err)
 		assert.Equal(t, 3600, seat.DailyCumulativeWorkSec) // 変化なし
+	})
+
+	t.Run("BreakState以外はエラー", func(t *testing.T) {
+		seat := SeatDoc{
+			State: WorkState,
+		}
+
+		now := mustParseTime(testTimeLayout, "2026-02-01 12:00:00")
+		err := seat.ResumeWork(now, "")
+
+		assert.Error(t, err)
 	})
 }
 

--- a/system/core/repository/seat_test.go
+++ b/system/core/repository/seat_test.go
@@ -130,13 +130,25 @@ func TestSeatDoc_StartBreak(t *testing.T) {
 
 	t.Run("WorkState以外はエラー", func(t *testing.T) {
 		seat := SeatDoc{
-			State: BreakState,
+			SeatID:                  5,
+			UserID:                  "user-abnormal",
+			State:                   BreakState,
+			WorkName:                "作業",
+			BreakWorkName:           "休憩作業",
+			CurrentStateStartedAt:   mustParseTime(testTimeLayout, "2026-02-01 10:00:00"),
+			CurrentStateUntil:       mustParseTime(testTimeLayout, "2026-02-01 10:30:00"),
+			CurrentSegmentStartedAt: mustParseTime(testTimeLayout, "2026-02-01 10:00:00"),
+			Until:                   mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
+			CumulativeWorkSec:       1234,
+			DailyCumulativeWorkSec:  567,
 		}
+		before := seat
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 10:00:00")
 		err := seat.StartBreak(now, "", 15)
 
 		assert.Error(t, err)
+		assert.Equal(t, before, seat)
 	})
 }
 
@@ -264,13 +276,24 @@ func TestSeatDoc_ResumeWork(t *testing.T) {
 
 	t.Run("BreakState以外はエラー", func(t *testing.T) {
 		seat := SeatDoc{
-			State: WorkState,
+			SeatID:                  7,
+			UserID:                  "user-resume-abnormal",
+			State:                   WorkState,
+			WorkName:                "一覧だけの作業名",
+			BreakWorkName:           "break-label",
+			CurrentStateStartedAt:   mustParseTime(testTimeLayout, "2026-02-01 11:00:00"),
+			CurrentStateUntil:       mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
+			CurrentSegmentStartedAt: mustParseTime(testTimeLayout, "2026-02-01 11:00:00"),
+			Until:                   mustParseTime(testTimeLayout, "2026-02-01 18:00:00"),
+			DailyCumulativeWorkSec:  999,
 		}
+		before := seat
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 12:00:00")
 		err := seat.ResumeWork(now, "")
 
 		assert.Error(t, err)
+		assert.Equal(t, before, seat)
 	})
 }
 
@@ -327,12 +350,22 @@ func TestSeatDoc_SetWorkDuration(t *testing.T) {
 	})
 
 	t.Run("WorkState以外はエラー", func(t *testing.T) {
+		until := mustParseTime(testTimeLayout, "2026-02-01 18:00:00")
+		breakUntil := mustParseTime(testTimeLayout, "2026-02-01 13:00:00")
 		seat := SeatDoc{
-			State: BreakState,
+			SeatID:                11,
+			UserID:                "user-setduration-abnormal",
+			State:                 BreakState,
+			Until:                 until,
+			CurrentStateUntil:     breakUntil,
+			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 12:00:00"),
 		}
+		before := seat
 
 		err := seat.SetWorkDuration(mustParseTime(testTimeLayout, "2026-02-01 21:00:00"))
+
 		assert.Error(t, err)
+		assert.Equal(t, before, seat)
 	})
 }
 
@@ -449,13 +482,23 @@ func TestSeatDoc_ExtendWorkDuration(t *testing.T) {
 	})
 
 	t.Run("WorkState以外はエラー", func(t *testing.T) {
+		time1700 := mustParseTime(testTimeLayout, "2026-02-01 17:00:00")
 		seat := SeatDoc{
-			State: BreakState,
+			SeatID:                13,
+			UserID:                "user-extendwork-abnormal",
+			State:                 BreakState,
+			Until:                 time1700,
+			CurrentStateUntil:     time1700,
+			CurrentStateStartedAt: mustParseTime(testTimeLayout, "2026-02-01 16:00:00"),
+			CumulativeWorkSec:     42,
 		}
+		before := seat
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 16:00:00")
 		_, _, err := seat.ExtendWorkDuration(now, 60, 180)
+
 		assert.Error(t, err)
+		assert.Equal(t, before, seat)
 	})
 }
 
@@ -708,13 +751,25 @@ func TestSeatDoc_ExtendBreakDuration(t *testing.T) {
 	})
 
 	t.Run("BreakState以外はエラー", func(t *testing.T) {
+		time1800 := mustParseTime(testTimeLayout, "2026-02-01 18:00:00")
+		time1300 := mustParseTime(testTimeLayout, "2026-02-01 13:00:00")
+		time1200 := mustParseTime(testTimeLayout, "2026-02-01 12:00:00")
 		seat := SeatDoc{
-			State: WorkState,
+			SeatID:                 17,
+			UserID:                 "user-extendbreak-abnormal",
+			State:                  WorkState,
+			Until:                  time1800,
+			CurrentStateUntil:      time1300,
+			CurrentStateStartedAt:  time1200,
+			DailyCumulativeWorkSec: 777,
 		}
+		before := seat
 
 		now := mustParseTime(testTimeLayout, "2026-02-01 12:30:00")
 		_, _, _, err := seat.ExtendBreakDuration(now, 30, 120)
+
 		assert.Error(t, err)
+		assert.Equal(t, before, seat)
 	})
 }
 

--- a/system/core/workspaceapp/command_seat.go
+++ b/system/core/workspaceapp/command_seat.go
@@ -638,7 +638,7 @@ func (app *WorkspaceApp) More(ctx context.Context, moreOption *utils.MoreOption)
 		}
 
 		if err := app.Repository.UpdateSeat(ctx, tx, *newSeat, isInMemberRoom); err != nil {
-			return fmt.Errorf("in app.Repository.UpdateSeats: %w", err)
+			return fmt.Errorf("in app.Repository.UpdateSeat: %w", err)
 		}
 
 		switch currentSeat.State {
@@ -731,7 +731,7 @@ func (app *WorkspaceApp) Break(ctx context.Context, breakOption *utils.MinWorkOr
 		}
 
 		if err := app.Repository.UpdateSeat(ctx, tx, currentSeat, isInMemberRoom); err != nil {
-			return fmt.Errorf("in app.Repository.UpdateSeats: %w", err)
+			return fmt.Errorf("in app.Repository.UpdateSeat: %w", err)
 		}
 
 		// DEPRECATED: activityログ記録

--- a/system/core/workspaceapp/command_seat.go
+++ b/system/core/workspaceapp/command_seat.go
@@ -243,7 +243,9 @@ func (app *WorkspaceApp) In(ctx context.Context, inOption *utils.InOption) error
 						remainingWorkMin := currentSeat.RemainingWorkMin(jstNow)
 						replyMessage += i18nmsg.CommandChangeWorkDurationAfter(app.Configs.Constants.MaxWorkTimeMin, realtimeEntryDurationMin, remainingWorkMin)
 					} else { // それ以外なら延長
-						currentSeat.SetWorkDuration(requestedUntil)
+						if err := currentSeat.SetWorkDuration(requestedUntil); err != nil {
+							return fmt.Errorf("in SetWorkDuration: %w", err)
+						}
 						remainingWorkMin := currentSeat.RemainingWorkMin(jstNow)
 						replyMessage += i18nmsg.CommandChangeWorkDuration(inOption.MinWorkOrderOption.DurationMin, realtimeEntryDurationMin, remainingWorkMin)
 					}
@@ -503,7 +505,9 @@ func (app *WorkspaceApp) Change(ctx context.Context, changeOption *utils.MinWork
 						RemainingWorkMin:         remainingWorkMin,
 					})
 				} else { // それ以外なら延長
-					currentSeat.SetWorkDuration(requestedUntil)
+					if err := currentSeat.SetWorkDuration(requestedUntil); err != nil {
+						return fmt.Errorf("in SetWorkDuration: %w", err)
+					}
 					remainingWorkMin := currentSeat.RemainingWorkMin(jstNow)
 					result.Add(usecase.ChangeWorkDurationUpdated{
 						RequestedMin:             changeOption.DurationMin,
@@ -594,7 +598,11 @@ func (app *WorkspaceApp) More(ctx context.Context, moreOption *utils.MoreOption)
 
 			// 作業時間を延長
 			expectedUntil := currentSeat.Until.Add(time.Duration(moreOption.DurationMin) * time.Minute)
-			addedMin, remainingUntilExitMin = newSeat.ExtendWorkDuration(jstNow, moreOption.DurationMin, app.Configs.Constants.MaxWorkTimeMin)
+			var err error
+			addedMin, remainingUntilExitMin, err = newSeat.ExtendWorkDuration(jstNow, moreOption.DurationMin, app.Configs.Constants.MaxWorkTimeMin)
+			if err != nil {
+				return fmt.Errorf("in ExtendWorkDuration: %w", err)
+			}
 
 			// 実際にキャップされた場合のみ通知
 			if newSeat.Until.Before(expectedUntil) {
@@ -615,8 +623,11 @@ func (app *WorkspaceApp) More(ctx context.Context, moreOption *utils.MoreOption)
 
 			// 休憩時間を延長
 			expectedBreakUntil := currentSeat.CurrentStateUntil.Add(time.Duration(moreOption.DurationMin) * time.Minute)
-			var newRemainingBreakMin int
-			addedMin, newRemainingBreakMin, remainingUntilExitMin = newSeat.ExtendBreakDuration(jstNow, moreOption.DurationMin, app.Configs.Constants.MaxBreakDurationMin)
+			var err error
+			addedMin, _, remainingUntilExitMin, err = newSeat.ExtendBreakDuration(jstNow, moreOption.DurationMin, app.Configs.Constants.MaxBreakDurationMin)
+			if err != nil {
+				return fmt.Errorf("in ExtendBreakDuration: %w", err)
+			}
 
 			// 実際にキャップされた場合のみ通知
 			if newSeat.CurrentStateUntil.Before(expectedBreakUntil) {
@@ -624,7 +635,6 @@ func (app *WorkspaceApp) More(ctx context.Context, moreOption *utils.MoreOption)
 					MaxBreakDurationMin: app.Configs.Constants.MaxBreakDurationMin,
 				})
 			}
-			_ = newRemainingBreakMin // 使用しないが戻り値として受け取る
 		}
 
 		if err := app.Repository.UpdateSeat(ctx, tx, *newSeat, isInMemberRoom); err != nil {

--- a/system/core/workspaceapp/command_seat.go
+++ b/system/core/workspaceapp/command_seat.go
@@ -716,7 +716,9 @@ func (app *WorkspaceApp) Break(ctx context.Context, breakOption *utils.MinWorkOr
 		}
 
 		// 休憩処理
-		currentSeat.StartBreak(jstNow, breakOption.WorkName, breakOption.DurationMin)
+		if err := currentSeat.StartBreak(jstNow, breakOption.WorkName, breakOption.DurationMin); err != nil {
+			return fmt.Errorf("in StartBreak: %w", err)
+		}
 
 		if err := app.Repository.UpdateSeat(ctx, tx, currentSeat, isInMemberRoom); err != nil {
 			return fmt.Errorf("in app.Repository.UpdateSeats: %w", err)

--- a/system/core/workspaceapp/command_seat.go
+++ b/system/core/workspaceapp/command_seat.go
@@ -801,7 +801,9 @@ func (app *WorkspaceApp) Resume(ctx context.Context, resumeOption *utils.WorkNam
 			workName = currentSeat.WorkName
 		}
 
-		currentSeat.ResumeWork(jstNow, workName)
+		if err := currentSeat.ResumeWork(jstNow, workName); err != nil {
+			return fmt.Errorf("in ResumeWork: %w", err)
+		}
 
 		{
 			if err := app.Repository.UpdateSeat(ctx, tx, currentSeat, isInMemberRoom); err != nil {

--- a/system/core/workspaceapp/command_user.go
+++ b/system/core/workspaceapp/command_user.go
@@ -157,7 +157,7 @@ func (app *WorkspaceApp) My(ctx context.Context, myOptions []utils.MyOption) err
 						}
 						newSeat.Appearance = seatAppearance
 						if err := app.Repository.UpdateSeat(ctx, tx, newSeat, isInMemberRoom); err != nil {
-							return fmt.Errorf("in app.Repository.UpdateSeats: %w", err)
+							return fmt.Errorf("in app.Repository.UpdateSeat: %w", err)
 						}
 					}
 				}


### PR DESCRIPTION
## 概要

`SeatDoc` のうち、コメントで前提条件が明記されているメソッドについて、**状態不整合時はフィールドを変更せず `error` を返す**ようにしました。アプリ層（`WorkspaceApp`）では既存どおり `fmt.Errorf` でラップしてトランザクションエラーとして扱います。

## 対象

- **StartBreak**: `WorkState` 以外で失敗
- **ResumeWork**: `BreakState` 以外で失敗
- **SetWorkDuration** / **ExtendWorkDuration**: `WorkState` 以外で失敗
- **ExtendBreakDuration**: `BreakState` 以外で失敗

## テスト

- 既存テストを `err` 返却に追随
- 各メソッドに異常系（`assert.Error` のみ）を追加

## 確認コマンド

```bash
cd system && go test -shuffle=on ./core/repository/... ./core/workspaceapp/...
```


Made with [Cursor](https://cursor.com)