### PR TITLE
ルームの変更

### DIFF
--- a/youtube-monitor/src/rooms/rooms-config.ts
+++ b/youtube-monitor/src/rooms/rooms-config.ts
@@ -5,6 +5,8 @@ import { CafeRainyRoom } from './layouts/cafe-rainy-room'
 import { CampRoom } from './layouts/camp-room'
 import { Chabio1Room } from './layouts/chabio1-room'
 import { Chabio2Room } from './layouts/chabio2-room'
+import { circleRoom } from './layouts/circle-room'
+import { Freepik1Room } from './layouts/freepik1-room'
 import { Freepik3Room } from './layouts/freepik3-room'
 import { Freepik5Room } from './layouts/freepik5-room'
 import { Freepik7Room } from './layouts/freepik7-room'
@@ -38,18 +40,28 @@ const prodAllRooms: AllRoomsConfig = {
 		Freepik8Room,
 		Freepik7Room,
 	],
-	memberBasicRooms: [MemberBoxRooms2, MemberBoxRooms3, ResortSeaRoom],
-	memberTemporaryRooms: [
-		MemberIllustratedRoomSpring,
+	memberBasicRooms: [
 		MemberBoxRooms2,
 		MemberBoxRooms3,
 		ResortSeaRoom,
+		MemberIllustratedRoomSpring,
+	],
+	memberTemporaryRooms: [
+		MemberBoxRooms2,
+		MemberBoxRooms3,
+		ResortSeaRoom,
+		MemberIllustratedRoomSpring,
 	],
 }
 
 const testAllRooms: AllRoomsConfig = {
-	generalBasicRooms: [CampRoom, Freepik8Room],
-	generalTemporaryRooms: [CafeRainyRoom, CampRoom, Freepik8Room],
+	generalBasicRooms: [Freepik1Room],
+	generalTemporaryRooms: [
+		Freepik5Room,
+		circleRoom,
+		Anonymous1Room,
+		Freepik1Room,
+	],
 	memberBasicRooms: [ResortSeaRoom],
 	memberTemporaryRooms: [ResortSeaRoom],
 }


### PR DESCRIPTION
This pull request updates the room configuration in `rooms-config.ts` by introducing new room layouts and reorganizing which rooms are included in the different room categories for both production and test environments.

**Room layout imports:**

* Added imports for `circleRoom` and `Freepik1Room` in `rooms-config.ts` to make these layouts available for use.

**Room configuration updates:**

* Updated the `prodAllRooms` configuration to include `MemberIllustratedRoomSpring` in both `memberBasicRooms` and `memberTemporaryRooms` arrays, ensuring this room is available in both categories.
* Updated the `testAllRooms` configuration:
  - Changed `generalBasicRooms` to only include `Freepik1Room`.
  - Updated `generalTemporaryRooms` to include `Freepik5Room`, `circleRoom`, `Anonymous1Room`, and `Freepik1Room`, expanding the variety of rooms available for testing.