### PR TITLE
docs(aws-cdk): AWS SSO認証手順をREADMEに追加

### DIFF
--- a/aws-cdk/README.md
+++ b/aws-cdk/README.md
@@ -1,3 +1,17 @@
+## AWS SSO（認証）
+
+プロファイルが IAM Identity Center（旧 AWS SSO）経由（`~/.aws/config` に `sso_session` などがある）のときは、**トークンの期限切れで CDK や AWS CLI が失敗する**。その場合は再ログインする。
+
+```bash
+aws sso login --profile プロファイル名
+```
+
+動作確認:
+
+```bash
+aws sts get-caller-identity --profile プロファイル名
+```
+
 ## Useful commands
 
 それぞれ`--profile プロファイル名`を付加する。（場合によっては region 指定も）
@@ -17,3 +31,4 @@
 - Lambdaの Errors>0 と Step Functions ExecutionsFailed>0 のアラームをSNSに連携。
 - 主要出力（CfnOutput）:
   - `BatchClusterArn`, `DailyBatchTaskDefinitionArn`, `BatchSecurityGroupId`, `BatchPublicSubnetIds`, `BatchVpcId`, `DailyBatchStateMachineArn`
+


### PR DESCRIPTION
## 変更内容
- `aws-cdk/README.md` に IAM Identity Center（SSO）利用時の `aws sso login` と `sts get-caller-identity` による確認手順を追記

## 背景
SSO トークン期限切れ時に CDK/CLI が失敗する点を README で案内するため。

Made with [Cursor](https://cursor.com)