### PR TITLE
fix(seat): 座席の作業名の見切れ修正と表示調整

### DIFF
--- a/youtube-monitor/src/components/SeatBox.tsx
+++ b/youtube-monitor/src/components/SeatBox.tsx
@@ -63,8 +63,7 @@ function generalSeatInnerContentWidthPx(
 	seatWidthPx: number,
 	seatFontSizePx: number,
 ): number {
-	const horizontalPaddingPx =
-		2 * seatBodyHorizontalPaddingEm * seatFontSizePx
+	const horizontalPaddingPx = 2 * seatBodyHorizontalPaddingEm * seatFontSizePx
 	return Math.max(1, seatWidthPx - 2 - horizontalPaddingPx)
 }
 

--- a/youtube-monitor/src/components/SeatBox.tsx
+++ b/youtube-monitor/src/components/SeatBox.tsx
@@ -7,7 +7,7 @@ import { Constants } from '../lib/constants'
 import * as styles from '../styles/SeatBox.styles'
 import {
 	seatDisplayNameFontWeight,
-	seatWorkNameFontWeight,
+	seatWorkNameTextFontWeight,
 } from '../styles/seatBoxFontWeights'
 import type { Seat } from '../types/api'
 import { SeatState } from './SeatsPage'
@@ -63,8 +63,9 @@ function fitGeneralSeatLineFontSizePx(
 	seatFontSizePx: number,
 	seatWidthPx: number,
 	fontWeight: number,
+	baseEm = 0.8,
 ): number {
-	let fontSizePx = seatFontSizePx * 0.8
+	let fontSizePx = seatFontSizePx * baseEm
 	if (text === '') {
 		return fontSizePx
 	}
@@ -164,7 +165,8 @@ const SeatBox: FC<SeatProps> = (props) => {
 					currentWorkName,
 					props.seatFontSizePx,
 					props.seatShape.widthPx,
-					seatWorkNameFontWeight,
+					seatWorkNameTextFontWeight,
+					0.95,
 				)
 			: props.seatFontSizePx * 0.8
 
@@ -270,7 +272,7 @@ const SeatBox: FC<SeatProps> = (props) => {
 										<div css={styles.memberWorkNameFrame}>
 											<div
 												css={styles.memberWorkName}
-												style={{ fontSize: `${props.seatFontSizePx * 0.78}px` }}
+												style={{ fontSize: `${props.seatFontSizePx * 0.93}px` }}
 											>
 												{currentWorkName}
 											</div>

--- a/youtube-monitor/src/components/SeatBox.tsx
+++ b/youtube-monitor/src/components/SeatBox.tsx
@@ -9,6 +9,7 @@ import {
 	seatDisplayNameFontWeight,
 	seatWorkNameTextFontWeight,
 } from '../styles/seatBoxFontWeights'
+import { seatBodyHorizontalPaddingEm } from '../styles/seatBoxMetrics'
 import type { Seat } from '../types/api'
 import { SeatState } from './SeatsPage'
 
@@ -57,13 +58,24 @@ function getMeasureTextContext(): CanvasRenderingContext2D | null {
 	return measureTextContext
 }
 
+/** 座席の border（1px×2）と seatBody の左右 padding を除いた、コンテンツの横幅 */
+function generalSeatInnerContentWidthPx(
+	seatWidthPx: number,
+	seatFontSizePx: number,
+): number {
+	const horizontalPaddingPx =
+		2 * seatBodyHorizontalPaddingEm * seatFontSizePx
+	return Math.max(1, seatWidthPx - 2 - horizontalPaddingPx)
+}
+
 /** 一般席の1行テキストを座席幅に収める（作業名・作業なし時のディスプレイ名で共通） */
 function fitGeneralSeatLineFontSizePx(
 	text: string,
 	seatFontSizePx: number,
-	seatWidthPx: number,
+	lineWidthPx: number,
 	fontWeight: number,
 	baseEm = 0.8,
+	minEm = 0.5,
 ): number {
 	let fontSizePx = seatFontSizePx * baseEm
 	if (text === '') {
@@ -73,11 +85,11 @@ function fitGeneralSeatLineFontSizePx(
 	if (context) {
 		context.font = `${fontWeight} ${fontSizePx.toString()}px ${fontFamily}`
 		const metrics = context.measureText(text)
-		if (metrics.width > seatWidthPx) {
-			fontSizePx *= seatWidthPx / metrics.width
+		if (metrics.width > lineWidthPx) {
+			fontSizePx *= lineWidthPx / metrics.width
 			fontSizePx *= 0.95 // ほんの少し縮めないと，入りきらない
-			if (fontSizePx < seatFontSizePx * 0.5) {
-				fontSizePx = seatFontSizePx * 0.5
+			if (fontSizePx < seatFontSizePx * minEm) {
+				fontSizePx = seatFontSizePx * minEm
 			}
 		}
 	}
@@ -158,15 +170,22 @@ const SeatBox: FC<SeatProps> = (props) => {
 			? `/${props.globalSeatId}`
 			: `!${props.globalSeatId}`
 
-	// 文字幅に応じて作業名または休憩中の作業名のフォントサイズを調整
+	const generalInnerContentWidthPx = generalSeatInnerContentWidthPx(
+		props.seatShape.widthPx,
+		props.seatFontSizePx,
+	)
+
+	// 文字幅に応じて作業名または休憩中の作業名のフォントサイズを調整。
+	// 下限は同席のユーザー名と同じ 0.63 em に揃える（これ以上は縮めず ellipsis に任せる）。
 	const generalWorkNameFontSizePx =
 		props.isUsed && !props.memberOnly && hasWorkName
 			? fitGeneralSeatLineFontSizePx(
 					currentWorkName,
 					props.seatFontSizePx,
-					props.seatShape.widthPx,
+					generalInnerContentWidthPx,
 					seatWorkNameTextFontWeight,
 					0.95,
+					0.63,
 				)
 			: props.seatFontSizePx * 0.8
 
@@ -178,7 +197,7 @@ const SeatBox: FC<SeatProps> = (props) => {
 				: fitGeneralSeatLineFontSizePx(
 						displayName,
 						props.seatFontSizePx,
-						props.seatShape.widthPx,
+						generalInnerContentWidthPx,
 						seatDisplayNameFontWeight,
 					)
 			: 0

--- a/youtube-monitor/src/components/SeatBox.tsx
+++ b/youtube-monitor/src/components/SeatBox.tsx
@@ -9,7 +9,10 @@ import {
 	seatDisplayNameFontWeight,
 	seatWorkNameTextFontWeight,
 } from '../styles/seatBoxFontWeights'
-import { seatBodyHorizontalPaddingEm } from '../styles/seatBoxMetrics'
+import {
+	seatBodyHorizontalPaddingEm,
+	seatBorderWidthPx,
+} from '../styles/seatBoxMetrics'
 import type { Seat } from '../types/api'
 import { SeatState } from './SeatsPage'
 
@@ -58,13 +61,14 @@ function getMeasureTextContext(): CanvasRenderingContext2D | null {
 	return measureTextContext
 }
 
-/** 座席の border（1px×2）と seatBody の左右 padding を除いた、コンテンツの横幅 */
+/** 座席の左右 border と seatBody の左右 padding を除いた、コンテンツの横幅 */
 function generalSeatInnerContentWidthPx(
 	seatWidthPx: number,
 	seatFontSizePx: number,
 ): number {
+	const horizontalBorderPx = 2 * seatBorderWidthPx
 	const horizontalPaddingPx = 2 * seatBodyHorizontalPaddingEm * seatFontSizePx
-	return Math.max(1, seatWidthPx - 2 - horizontalPaddingPx)
+	return Math.max(1, seatWidthPx - horizontalBorderPx - horizontalPaddingPx)
 }
 
 /** 一般席の1行テキストを座席幅に収める（作業名・作業なし時のディスプレイ名で共通） */

--- a/youtube-monitor/src/styles/SeatBox.styles.ts
+++ b/youtube-monitor/src/styles/SeatBox.styles.ts
@@ -3,11 +3,14 @@ import { fontFamily } from '../lib/common'
 import { Constants } from '../lib/constants'
 import {
 	seatDisplayNameFontWeight,
+	seatEmphasisFontWeight,
 	seatIdFontWeight,
-	seatWorkNameFontWeight,
 	seatWorkNameTextFontWeight,
 } from './seatBoxFontWeights'
-import { seatBodyHorizontalPaddingEm } from './seatBoxMetrics'
+import {
+	seatBodyHorizontalPaddingEm,
+	seatBorderWidthPx,
+} from './seatBoxMetrics'
 
 export const seat = css`
     position: absolute;
@@ -16,7 +19,7 @@ export const seat = css`
     transform-origin: top left;
     box-sizing: border-box;
     overflow: hidden;
-    border: 1px solid rgba(84, 75, 62, 0.12);
+    border: ${seatBorderWidthPx}px solid rgba(84, 75, 62, 0.12);
     box-shadow: 0 0.2rem 0.55rem rgba(70, 58, 43, 0.08);
     font-family: ${fontFamily};
 `
@@ -94,7 +97,7 @@ export const starsBadge = css`
     position: absolute;
     top: 0.2rem;
     right: 0.2rem;
-    font-weight: ${seatWorkNameFontWeight};
+    font-weight: ${seatEmphasisFontWeight};
     line-height: 1;
     white-space: nowrap;
     transform: translateY(1px);
@@ -134,7 +137,7 @@ export const emptySeatCommand = css`
     margin: 0;
     color: #4a4338;
     line-height: 1;
-    font-weight: ${seatWorkNameFontWeight};
+    font-weight: ${seatEmphasisFontWeight};
     letter-spacing: 0.02em;
 `
 
@@ -234,7 +237,7 @@ export const timeElapsed = css`
 export const timeRemaining = css`
     color: #2a241d;
     font-size: 0.42em;
-    font-weight: ${seatWorkNameFontWeight};
+    font-weight: ${seatEmphasisFontWeight};
     line-height: 1;
     white-space: nowrap;
     flex-shrink: 0;

--- a/youtube-monitor/src/styles/SeatBox.styles.ts
+++ b/youtube-monitor/src/styles/SeatBox.styles.ts
@@ -7,6 +7,7 @@ import {
 	seatWorkNameFontWeight,
 	seatWorkNameTextFontWeight,
 } from './seatBoxFontWeights'
+import { seatBodyHorizontalPaddingEm } from './seatBoxMetrics'
 
 export const seat = css`
     position: absolute;
@@ -38,7 +39,7 @@ export const seatBody = css`
     flex: 1;
     flex-direction: column;
     min-height: 0;
-    padding: 0.35em 0.5em 0.34em;
+    padding: 0.35em ${seatBodyHorizontalPaddingEm}em 0.34em;
 `
 
 export const headerRow = css`

--- a/youtube-monitor/src/styles/SeatBox.styles.ts
+++ b/youtube-monitor/src/styles/SeatBox.styles.ts
@@ -5,6 +5,7 @@ import {
 	seatDisplayNameFontWeight,
 	seatIdFontWeight,
 	seatWorkNameFontWeight,
+	seatWorkNameTextFontWeight,
 } from './seatBoxFontWeights'
 
 export const seat = css`
@@ -151,7 +152,7 @@ export const memberWorkNameFrame = css`
 export const memberWorkName = css`
     color: #24317e;
     text-overflow: ellipsis;
-    font-weight: ${seatWorkNameFontWeight};
+    font-weight: ${seatWorkNameTextFontWeight};
     line-height: 1.18;
     overflow: hidden;
     word-wrap: break-word;
@@ -174,7 +175,7 @@ export const generalContent = css`
 export const generalWorkName = css`
     width: 100%;
     color: #24317e;
-    font-weight: ${seatWorkNameFontWeight};
+    font-weight: ${seatWorkNameTextFontWeight};
     line-height: 1.15;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/youtube-monitor/src/styles/seatBoxFontWeights.ts
+++ b/youtube-monitor/src/styles/seatBoxFontWeights.ts
@@ -1,8 +1,11 @@
 /** ユーザー表示名（一般席・メンバー席）。canvas の measureText とも一致させる */
 export const seatDisplayNameFontWeight = 700
 
-/** 作業名（一般席・メンバー席）。canvas の measureText とも一致させる */
+/** ★バッジ・空席コマンド・残り時間など */
 export const seatWorkNameFontWeight = 800
+
+/** 作業名テキスト（一般席・メンバー席）。canvas の measureText とも一致させる */
+export const seatWorkNameTextFontWeight = 700
 
 /** 座席番号（!12 / /12 など）。 */
 export const seatIdFontWeight = 800

--- a/youtube-monitor/src/styles/seatBoxFontWeights.ts
+++ b/youtube-monitor/src/styles/seatBoxFontWeights.ts
@@ -1,8 +1,8 @@
 /** ユーザー表示名（一般席・メンバー席）。canvas の measureText とも一致させる */
 export const seatDisplayNameFontWeight = 700
 
-/** ★バッジ・空席コマンド・残り時間など */
-export const seatWorkNameFontWeight = 800
+/** ★バッジ・空席コマンド・残り時間など、視覚的に強調したい要素 */
+export const seatEmphasisFontWeight = 800
 
 /** 作業名テキスト（一般席・メンバー席）。canvas の measureText とも一致させる */
 export const seatWorkNameTextFontWeight = 700

--- a/youtube-monitor/src/styles/seatBoxMetrics.ts
+++ b/youtube-monitor/src/styles/seatBoxMetrics.ts
@@ -1,0 +1,7 @@
+/**
+ * SeatBox の幅計算（SeatBox.tsx）と CSS（SeatBox.styles.ts）で同期が必要な数値定数。
+ * 値を変える場合は CSS 側のテンプレートリテラル埋め込みも経由して反映される。
+ */
+
+/** seatBody の左右 padding（em） */
+export const seatBodyHorizontalPaddingEm = 0.5 as const

--- a/youtube-monitor/src/styles/seatBoxMetrics.ts
+++ b/youtube-monitor/src/styles/seatBoxMetrics.ts
@@ -3,5 +3,8 @@
  * 値を変える場合は CSS 側のテンプレートリテラル埋め込みも経由して反映される。
  */
 
+/** .seat の border（片側、px） */
+export const seatBorderWidthPx = 1 as const
+
 /** seatBody の左右 padding（em） */
 export const seatBodyHorizontalPaddingEm = 0.5 as const


### PR DESCRIPTION
## Summary

- 一般席の作業名・表示名の fit 計算で座席の border（1px×2）と `seatBody` の左右 padding を控除し、幅を過大評価して ellipsis になる不具合を修正（`コーヒー…` のように途中で切れる症状）
- 作業名の下限フォントサイズをユーザー名と同じ `0.63 × seatFontSizePx` に引き上げ（縮小しすぎを防止）
- 作業名の `font-weight` を 700 に揃え、基準サイズも一般席 0.95em / メンバー席 0.93em に拡大して視認性を改善
- padding 値を `seatBoxMetrics.ts` に切り出して JS/CSS で単一ソース化（`seatBoxFontWeights.ts` と同じパターン）

メンバー席の作業名ロジックは従来挙動（固定サイズ + `-webkit-line-clamp: 2` による 2 行折り返し）を維持。

## Test plan

- [ ] Storybook の `SeatBox` 各ストーリーで作業名の表示崩れがないこと
  - [ ] `一般席`（作業名あり/なし、長い作業名）
  - [ ] `メンバー席`（作業名あり/なし、2 行折り返しケース）
- [ ] 休憩中の座席（`休み` バッジあり）で作業名が末尾 `…` で切れていないこと
- [ ] 一般席の作業名が極端に長いケースで、下限サイズ（ユーザー名と同サイズ）で止まり `…` で省略されること

Made with [Cursor](https://cursor.com)