### PR TITLE
メンバールームに恒常ルームを追加

### DIFF
--- a/youtube-monitor/src/rooms/rooms-config.ts
+++ b/youtube-monitor/src/rooms/rooms-config.ts
@@ -14,6 +14,7 @@ import { Freepik8Room } from './layouts/freepik8-room'
 import { MemberBoxRooms2 } from './layouts/member-box-rooms-2'
 import { MemberBoxRooms3 } from './layouts/member-box-rooms-3'
 import { MemberIllustratedRoomSpring } from './layouts/member-illustrated-room-spring'
+import { MemberIllustratedRoom1 } from './layouts/member-illustrated-room1'
 import { ResortSeaRoom } from './layouts/resort-sea-room'
 
 type AllRoomsConfig = {
@@ -45,12 +46,14 @@ const prodAllRooms: AllRoomsConfig = {
 		MemberBoxRooms3,
 		ResortSeaRoom,
 		MemberIllustratedRoomSpring,
+		MemberIllustratedRoom1,
 	],
 	memberTemporaryRooms: [
 		MemberBoxRooms2,
 		MemberBoxRooms3,
 		ResortSeaRoom,
 		MemberIllustratedRoomSpring,
+		MemberIllustratedRoom1,
 	],
 }
 


### PR DESCRIPTION
This pull request adds a new room layout, `MemberIllustratedRoom1`, to the rooms configuration in the `youtube-monitor` project. The new layout is now included in both the `memberRooms` and `memberTemporaryRooms` arrays, making it available for use in production.

Room layout additions:

* Imported the new `MemberIllustratedRoom1` component in `rooms-config.ts`.
* Added `MemberIllustratedRoom1` to the `memberRooms` and `memberTemporaryRooms` configuration arrays in `rooms-config.ts`.