### PR TITLE
CDK: Docker アセットの決定性を改善し cdk diff のブレを抑制 (#692)

### DIFF
--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -26,6 +26,17 @@ const SYSTEM_DIR = path.join(__dirname, '../../system/')
 const DOCKERFILE_LAMBDA = 'Dockerfile.lambda'
 const DOCKERFILE_FARGATE = 'Dockerfile.fargate'
 
+// 全 Lambda で同じ build context / Dockerfile / platform を共有しているため、CDK は
+// 既に asset を de-dup している。ヘルパーは宣言の明確化とビルド時間の予測性向上を
+// 目的とし、`entrypoint` だけを差し替える。`entrypoint` は Lambda imageConfig 側の
+// 設定で asset fingerprint には寄与しないので、6 関数分の asset は 1 つに共有される。
+const createLambdaImageCode = (binaryName: string) =>
+	lambda.DockerImageCode.fromImageAsset(SYSTEM_DIR, {
+		file: DOCKERFILE_LAMBDA,
+		platform: Platform.LINUX_AMD64,
+		entrypoint: [`/app/${binaryName}`],
+	})
+
 export class AwsCdkStack extends cdk.Stack {
 	constructor(scope: Construct, id: string, props?: cdk.StackProps) {
 		super(scope, id, props)
@@ -160,12 +171,7 @@ export class AwsCdkStack extends cdk.Stack {
 			'sns_notify_discord',
 			{
 				functionName: 'sns_notify_discord',
-				code: lambda.DockerImageCode.fromImageAsset(SYSTEM_DIR, {
-					file: DOCKERFILE_LAMBDA,
-					buildArgs: { HANDLER: 'main' },
-					platform: Platform.LINUX_AMD64,
-					entrypoint: ['/app/sns_notify_discord'],
-				}),
+				code: createLambdaImageCode('sns_notify_discord'),
 				timeout: cdk.Duration.seconds(30),
 				reservedConcurrentExecutions: 1,
 			},
@@ -526,12 +532,7 @@ export class AwsCdkStack extends cdk.Stack {
 			'start_daily_batch',
 			{
 				functionName: 'start_daily_batch',
-				code: lambda.DockerImageCode.fromImageAsset(SYSTEM_DIR, {
-					file: DOCKERFILE_LAMBDA,
-					buildArgs: { HANDLER: 'main' },
-					platform: Platform.LINUX_AMD64,
-					entrypoint: ['/app/start_daily_batch'],
-				}),
+				code: createLambdaImageCode('start_daily_batch'),
 				timeout: cdk.Duration.seconds(15),
 				reservedConcurrentExecutions: 1,
 				environment: {
@@ -567,14 +568,7 @@ export class AwsCdkStack extends cdk.Stack {
 			'set_desired_max_seats',
 			{
 				functionName: 'set_desired_max_seats',
-				code: lambda.DockerImageCode.fromImageAsset(SYSTEM_DIR, {
-					file: DOCKERFILE_LAMBDA,
-					buildArgs: {
-						HANDLER: 'main',
-					},
-					platform: Platform.LINUX_AMD64,
-					entrypoint: ['/app/set_desired_max_seats'],
-				}),
+				code: createLambdaImageCode('set_desired_max_seats'),
 				timeout: cdk.Duration.seconds(20),
 				reservedConcurrentExecutions: undefined,
 			},
@@ -593,14 +587,7 @@ export class AwsCdkStack extends cdk.Stack {
 			'youtube_organize_database',
 			{
 				functionName: 'youtube_organize_database',
-				code: lambda.DockerImageCode.fromImageAsset(SYSTEM_DIR, {
-					file: DOCKERFILE_LAMBDA,
-					buildArgs: {
-						HANDLER: 'main',
-					},
-					platform: Platform.LINUX_AMD64,
-					entrypoint: ['/app/youtube_organize_database'],
-				}),
+				code: createLambdaImageCode('youtube_organize_database'),
 				timeout: cdk.Duration.seconds(50),
 				reservedConcurrentExecutions: 1,
 			},
@@ -619,14 +606,7 @@ export class AwsCdkStack extends cdk.Stack {
 			'check_live_stream_status',
 			{
 				functionName: 'check_live_stream_status',
-				code: lambda.DockerImageCode.fromImageAsset(SYSTEM_DIR, {
-					file: DOCKERFILE_LAMBDA,
-					buildArgs: {
-						HANDLER: 'main',
-					},
-					platform: Platform.LINUX_AMD64,
-					entrypoint: ['/app/check_live_stream_status'],
-				}),
+				code: createLambdaImageCode('check_live_stream_status'),
 				timeout: cdk.Duration.seconds(20),
 				reservedConcurrentExecutions: undefined,
 			},
@@ -645,14 +625,7 @@ export class AwsCdkStack extends cdk.Stack {
 			'update_work_name_trend',
 			{
 				functionName: 'update_work_name_trend',
-				code: lambda.DockerImageCode.fromImageAsset(SYSTEM_DIR, {
-					file: DOCKERFILE_LAMBDA,
-					buildArgs: {
-						HANDLER: 'main',
-					},
-					platform: Platform.LINUX_AMD64,
-					entrypoint: ['/app/update_work_name_trend'],
-				}),
+				code: createLambdaImageCode('update_work_name_trend'),
 				timeout: cdk.Duration.minutes(5),
 				reservedConcurrentExecutions: 1,
 				environment: {

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -158,9 +158,11 @@ describe('Docker asset determinism (issue #692)', () => {
 
 	// system/ 配下の対象ファイルを一時的に書き換え（または新規作成）して fn を実行し、
 	// finally で必ず原状復帰する。
-	// - 既存ファイル: バイナリセーフにバックアップ → 復元
-	// - 存在しなかったパス: 作成 → 削除
-	// さらに、新規作成時はディレクトリも後片付けするため、作成したディレクトリ一覧を追跡する。
+	// - 既存ファイル: tmp 配下に copyFileSync で退避し、終了時に元の場所へコピーし直す。
+	//   mode（実行ビット等）は `statSync().mode` をキャプチャして `chmodSync` で復元する。
+	//   `system/main` のようなローカル go build 成果物（0o755）が混ざる環境でも、
+	//   テスト後に実行不可にならないよう内容だけでなく mode も明示的に戻す。
+	// - 存在しなかったパス: 作成 → 削除（新規作成で巻き込んだディレクトリも掃除）。
 	const withTemporaryFile = (
 		relPath: string,
 		content: Buffer | string,
@@ -168,9 +170,16 @@ describe('Docker asset determinism (issue #692)', () => {
 	) => {
 		const target = path.join(SYSTEM_DIR, relPath)
 		const existed = fs.existsSync(target)
-		const backup = existed ? fs.readFileSync(target) : null
 		const createdDirs: string[] = []
-		if (!existed) {
+		let backupDir: string | null = null
+		let backupPath: string | null = null
+		let originalMode: number | null = null
+		if (existed) {
+			backupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-692-bak-'))
+			backupPath = path.join(backupDir, 'backup')
+			fs.copyFileSync(target, backupPath)
+			originalMode = fs.statSync(target).mode
+		} else {
 			let dir = path.dirname(target)
 			const stopAt = SYSTEM_DIR
 			while (!fs.existsSync(dir) && dir.startsWith(stopAt)) {
@@ -185,16 +194,28 @@ describe('Docker asset determinism (issue #692)', () => {
 			fs.writeFileSync(target, payload)
 			fn()
 		} finally {
-			if (existed && backup !== null) {
-				fs.writeFileSync(target, backup)
-			} else {
-				if (fs.existsSync(target)) {
-					fs.unlinkSync(target)
-				}
-				for (const dir of createdDirs) {
-					if (fs.existsSync(dir) && fs.readdirSync(dir).length === 0) {
-						fs.rmdirSync(dir)
+			try {
+				if (existed && backupPath !== null) {
+					fs.copyFileSync(backupPath, target)
+					if (originalMode !== null) {
+						fs.chmodSync(target, originalMode)
 					}
+				} else {
+					if (fs.existsSync(target)) {
+						fs.unlinkSync(target)
+					}
+					for (const dir of createdDirs) {
+						if (
+							fs.existsSync(dir) &&
+							fs.readdirSync(dir).length === 0
+						) {
+							fs.rmdirSync(dir)
+						}
+					}
+				}
+			} finally {
+				if (backupDir !== null) {
+					fs.rmSync(backupDir, { recursive: true, force: true })
 				}
 			}
 		}

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -1,3 +1,7 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
 import * as cdk from 'aws-cdk-lib'
 import { Match, Template } from 'aws-cdk-lib/assertions'
 
@@ -120,4 +124,139 @@ describe('AwsCdkStack', () => {
 			expect(logGroup.Properties?.RetentionInDays).toBeUndefined()
 		}
 	})
+})
+
+// Issue #692: Docker アセット決定性テスト
+//
+// 目的: `cdk synth` の `dockerImages` キー（= ECR image tag）が、アプリコードと
+// 無関係なローカル成果物・ドキュメント・エディタ設定の変更で変動しないことを担保する。
+// `system/.dockerignore` が正しく build context から除外している限り、これらの
+// 変更は asset fingerprint に寄与しないはず。
+describe('Docker asset determinism (issue #692)', () => {
+	const SYSTEM_DIR = path.resolve(__dirname, '../../system')
+
+	// `cdk.App` を毎回新しい一時 outdir で synth し、TestStack.assets.json の
+	// `dockerImages` キー集合をソート済み配列で返す。
+	const synthDockerImageKeys = (): string[] => {
+		const outdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-692-'))
+		try {
+			const app = new cdk.App({ outdir })
+			new AwsCdkStack(app, 'TestStack')
+			const assembly = app.synth()
+			const assetsPath = path.join(
+				assembly.directory,
+				'TestStack.assets.json',
+			)
+			const assets = JSON.parse(fs.readFileSync(assetsPath, 'utf-8')) as {
+				dockerImages?: Record<string, unknown>
+			}
+			return Object.keys(assets.dockerImages ?? {}).sort()
+		} finally {
+			fs.rmSync(outdir, { recursive: true, force: true })
+		}
+	}
+
+	// system/ 配下の対象ファイルを一時的に書き換え（または新規作成）して fn を実行し、
+	// finally で必ず原状復帰する。
+	// - 既存ファイル: バイナリセーフにバックアップ → 復元
+	// - 存在しなかったパス: 作成 → 削除
+	// さらに、新規作成時はディレクトリも後片付けするため、作成したディレクトリ一覧を追跡する。
+	const withTemporaryFile = (
+		relPath: string,
+		content: Buffer | string,
+		fn: () => void,
+	) => {
+		const target = path.join(SYSTEM_DIR, relPath)
+		const existed = fs.existsSync(target)
+		const backup = existed ? fs.readFileSync(target) : null
+		const createdDirs: string[] = []
+		if (!existed) {
+			let dir = path.dirname(target)
+			const stopAt = SYSTEM_DIR
+			while (!fs.existsSync(dir) && dir.startsWith(stopAt)) {
+				createdDirs.push(dir)
+				dir = path.dirname(dir)
+			}
+			fs.mkdirSync(path.dirname(target), { recursive: true })
+		}
+		const payload =
+			typeof content === 'string' ? Buffer.from(content, 'utf-8') : content
+		try {
+			fs.writeFileSync(target, payload)
+			fn()
+		} finally {
+			if (existed && backup !== null) {
+				fs.writeFileSync(target, backup)
+			} else {
+				if (fs.existsSync(target)) {
+					fs.unlinkSync(target)
+				}
+				for (const dir of createdDirs) {
+					if (fs.existsSync(dir) && fs.readdirSync(dir).length === 0) {
+						fs.rmdirSync(dir)
+					}
+				}
+			}
+		}
+	}
+
+	// 安全弁: `withTemporaryFile` は `finally` でバックアップ / 削除を行うが、
+	// テストが途中クラッシュした場合でも worktree が汚染されないよう
+	// `afterAll` でも必要最小限の後始末を行えるようにフックだけ用意しておく。
+	afterAll(() => {
+		// 現状のテストは既存ファイルの内容書き換え + 復元のみで、
+		// 新規作成は `withTemporaryFile` 内の try/finally で確実に掃除される。
+	})
+
+	let baselineKeys: string[]
+	beforeAll(() => {
+		baselineKeys = synthDockerImageKeys()
+		// Docker アセットが少なくとも 1 つ存在することの sanity check
+		expect(baselineKeys.length).toBeGreaterThan(0)
+	})
+
+	test('dockerImages keys are identical across two consecutive synths', () => {
+		const second = synthDockerImageKeys()
+		expect(second).toEqual(baselineKeys)
+	})
+
+	test.each<{ name: string; rel: string; content: Buffer | string }>([
+		{
+			name: 'system/main (local go build artifact)',
+			rel: 'main',
+			content: Buffer.from('local-build-artifact-test'),
+		},
+		{
+			name: 'system/README.md',
+			rel: 'README.md',
+			content: '# temporary edit for test\n',
+		},
+		{
+			name: 'system/AI_COLLABORATION_GUIDE.md',
+			rel: 'AI_COLLABORATION_GUIDE.md',
+			content: '# temporary edit for test\n',
+		},
+		{
+			// `**/.cursor` が `.dockerignore` で除外されていることを担保する。
+			// 新規作成はエージェントサンドボックス等で EPERM になる環境があるため、
+			// 既存ファイル（system/.cursor/rules/specification.mdc）の内容を
+			// 一時的に書き換えるアプローチに統一している。
+			name: 'system/.cursor/rules/specification.mdc',
+			rel: path.join('.cursor', 'rules', 'specification.mdc'),
+			content: '// temporary edit for test\n',
+		},
+		{
+			name: 'system/main.go (local-only entrypoint; not built into images)',
+			rel: 'main.go',
+			content: '// temporary edit for test\n',
+		},
+	])(
+		'dockerImages keys unaffected by changes to $name',
+		({ rel, content }) => {
+			withTemporaryFile(rel, content, () => {
+				const keys = synthDockerImageKeys()
+				expect(keys).toEqual(baselineKeys)
+			})
+		},
+	)
 })

--- a/system/.dockerignore
+++ b/system/.dockerignore
@@ -3,10 +3,11 @@
 .github
 .gitignore
 
-# OS / IDE
+# OS / IDE / agent context
 **/.DS_Store
 **/.idea
 **/.vscode
+**/.cursor
 
 # Logs / cache / tmp
 **/*.log
@@ -21,8 +22,31 @@ coverage*
 /dist
 /out
 
+# Local Go build artifacts (host-produced, not required inside container image)
+/main
+/main.exe
+/bootstrap
+/bootstrap.exe
+/batch
+/sns_notify_discord
+/app.modules
+/app.modules.exe
+/aws-lambda/main
+/aws-lambda/main.zip
+/.serverless
+
+# Local-only Go sources (not built into Lambda/Fargate images; excluded to keep
+# build-context fingerprint stable across local edits — see issue #692)
+/main.go
+/main_test.go
+
 # Tests (not needed for container image)
 **/*_test.go
+
+# Docs / lint configs not needed inside container
+README.md
+AI_COLLABORATION_GUIDE.md
+.golangci.yml
 
 # Env files
 .env


### PR DESCRIPTION
## 概要

Closes #692

`cdk diff` でアプリコードに触っていないのに Lambda / ECS の `ImageUri` タグだけが書き換わる現象（= Docker build context の fingerprint が動いている）を抑制するために、以下を実施しました。

- `system/.dockerignore` を拡充して、ローカル `go build` 成果物・ローカル実行専用 Go ソース・`.cursor`・README などを build context から除外。
- `aws-cdk/lib/aws-cdk-stack.ts` の Lambda 6 本分の `DockerImageCode.fromImageAsset(...)` 呼び出しを `createLambdaImageCode(binaryName)` ヘルパーに統一し、`Dockerfile.lambda` に対応する `ARG HANDLER` が存在しない未使用 `buildArgs: { HANDLER: 'main' }` を削除。
- `aws-cdk/test/aws-cdk.test.ts` に Docker アセット決定性テスト（`describe('Docker asset determinism (issue #692)')`）を追加。

## 変更詳細

### 1. `system/.dockerignore` 拡充

追加したカテゴリ:

- ローカル Go ビルド成果物: `/main`, `/main.exe`, `/bootstrap`, `/bootstrap.exe`, `/batch`, `/sns_notify_discord`, `/app.modules`, `/app.modules.exe`, `/aws-lambda/main`, `/aws-lambda/main.zip`, `/.serverless`
- ローカル実行専用 Go ソース: `/main.go`, `/main_test.go`（`Dockerfile.lambda` / `Dockerfile.fargate` のどちらのビルドターゲットにも含まれない）
- エディタ / AI アシスタントのコンテキスト: `**/.cursor`
- コンテナ実行時に不要な docs / 設定: `README.md`, `AI_COLLABORATION_GUIDE.md`, `.golangci.yml`

### 2. `aws-cdk/lib/aws-cdk-stack.ts` 整理

```typescript
const createLambdaImageCode = (binaryName: string) =>
	lambda.DockerImageCode.fromImageAsset(SYSTEM_DIR, {
		file: DOCKERFILE_LAMBDA,
		platform: Platform.LINUX_AMD64,
		entrypoint: [`/app/${binaryName}`],
	})
```

- Lambda 6 本（`sns_notify_discord`, `start_daily_batch`, `set_desired_max_seats`, `youtube_organize_database`, `check_live_stream_status`, `update_work_name_trend`）を上記ヘルパーに集約。
- `entrypoint` は Lambda の `imageConfig` に乗るだけで asset fingerprint には寄与しないため、CDK の asset de-dup 挙動は現状と同じ（= Lambda 6 本は 1 つの image を共有する）。
- 未使用 `buildArgs` の削除で初回デプロイ時に ImageUri が 1 度だけ更新される可能性があります（意図した変更）。以降は stable。

### 3. 決定性テスト追加

`aws-cdk/test/aws-cdk.test.ts` に以下を追加:

- `synthDockerImageKeys()`: `cdk.App({ outdir })` を temp dir で synth し、`TestStack.assets.json` の `dockerImages` キーを sort して返す。
- `withTemporaryFile(rel, content, fn)`: `system/` 配下のファイルを一時書き換え（or 新規作成）し、`try/finally` でバイナリセーフに原状復帰。新規作成時は作ったディレクトリまで掃除する。
- テストケース:
  1. 2 連続 synth で `dockerImages` キー集合が完全一致する
  2. `system/main` を一時書き換えてもキーが変化しない
  3. `system/README.md` を一時書き換えてもキーが変化しない
  4. `system/AI_COLLABORATION_GUIDE.md` を一時書き換えてもキーが変化しない
  5. `system/.cursor/rules/specification.mdc` を一時書き換えてもキーが変化しない（`**/.cursor` の denylist 担保）
  6. `system/main.go` を一時書き換えてもキーが変化しない（AC 外の厳格化）

## 動作確認

### 自動テスト

```
$ pnpm test
PASS test/aws-cdk.test.ts
  AwsCdkStack (6 tests) ✓
  Docker asset determinism (issue #692) (6 tests) ✓

Tests:       12 passed, 12 total
```

### 手動 synth 2 回一致

- `rm -rf cdk.out && pnpm cdk:synth` → `cdk.out/AwsCdkStack.assets.json` の `dockerImages` キー記録
- `mv cdk.out cdk.out.prev && pnpm cdk:synth` → キーが前回と完全一致することを確認
- `system/main.go` を一時書き換えてさらに `pnpm cdk:synth` → キー不変を確認（終了後に元に戻す）

### `pnpm cdk:diff`

SSO プロファイル未設定のためこの worktree では未実行。マージ前に手元で `pnpm cdk:diff` を走らせて「アプリコード非変更時は ImageUri 差分が出ない」ことを手動確認予定（※ 初回だけは未使用 `buildArgs` 削除の影響で 1 度 ImageUri が更新される点に注意）。

## Acceptance Criteria チェック

- [x] `dockerImages` キー集合が 2 連続 `cdk:synth` で完全一致する（テスト 1 / 手動検証で担保）
- [x] `system/main` などローカル成果物の有無で `dockerImages` が変化しない（テスト 2 で担保）
- [x] `system/README.md`, `AI_COLLABORATION_GUIDE.md`, `.cursor/**` の編集で変化しない（テスト 3〜5 で担保）
- [x] `aws-cdk/test/aws-cdk.test.ts` にテスト追加
- [ ] `pnpm cdk:diff` でアプリコード非変更時に ImageUri 差分なし（※ SSO 必須のため merge 前に手動検証）
- [x] （AC 外の厳格化）`system/main.go` 編集でキーが変化しない（テスト 6 で担保）

## スコープ外 / 関連

- 実イメージの再現可能ビルド（`FROM` digest 固定 / toolchain 固定）は #693 で別途対応（本 PR スコープ外）。
- `DockerImageAsset` をスタック外で共有 (a) する案、および Lambda 6 本の build context を分離する案も検討しましたが、現状の Lambda asset は既に de-dup されており改善効果が限定的なため今回は見送り。