### PR TITLE
[codex] 一般席の作業名表示を dev / Storybook で一致させる

### DIFF
--- a/youtube-monitor/src/components/SeatBox.test.tsx
+++ b/youtube-monitor/src/components/SeatBox.test.tsx
@@ -1,0 +1,316 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import type { Timestamp } from 'firebase/firestore'
+import type { ImgHTMLAttributes } from 'react'
+import { act } from 'react'
+import type { SeatProps } from './SeatBox'
+
+jest.mock('next/font/google', () => ({
+	M_PLUS_Rounded_1c: jest.fn(() => ({
+		style: { fontFamily: 'M PLUS Rounded 1c' },
+		className: 'mock-font-class',
+	})),
+	Source_Code_Pro: jest.fn(() => ({
+		style: { fontFamily: 'mock-source-code-pro' },
+		className: 'mock-source-code-pro-class',
+	})),
+}))
+
+jest.mock('next/image', () => ({
+	__esModule: true,
+	default: (props: ImgHTMLAttributes<HTMLImageElement>) => {
+		const { alt, src, ...rest } = props
+		return <img alt={alt} src={src} {...rest} />
+	},
+}))
+
+process.env.NEXT_PUBLIC_DEBUG = 'true'
+process.env.NEXT_PUBLIC_CHANNEL_GL = 'false'
+process.env.NEXT_PUBLIC_ROOM_CONFIG = 'DEV'
+
+function loadSeatBox() {
+	const seatBoxModule = require('./SeatBox') as typeof import('./SeatBox')
+	seatBoxModule.resetMeasureTextContextForTest()
+	return seatBoxModule.default
+}
+
+const GENERAL_SEAT_FONT_SIZE = 22.8
+const GENERAL_SEAT_WIDTH_PX = 140
+const GENERAL_SEAT_LINE_WIDTH_PX = 115.2
+
+function createDeferredPromise<T>() {
+	let resolve: (value: T | PromiseLike<T>) => void = () => {}
+	const promise = new Promise<T>((innerResolve) => {
+		resolve = innerResolve
+	})
+	return { promise, resolve }
+}
+
+function expectedFontSizePx({
+	text,
+	seatFontSizePx,
+	lineWidthPx,
+	measuredWidthPx,
+	baseEm,
+	minEm,
+}: {
+	text: string
+	seatFontSizePx: number
+	lineWidthPx: number
+	measuredWidthPx: number
+	baseEm: number
+	minEm: number
+}) {
+	let fontSizePx = seatFontSizePx * baseEm
+	if (text === '') {
+		return fontSizePx
+	}
+	if (measuredWidthPx > lineWidthPx) {
+		fontSizePx *= lineWidthPx / measuredWidthPx
+		fontSizePx *= 0.95
+		if (fontSizePx < seatFontSizePx * minEm) {
+			fontSizePx = seatFontSizePx * minEm
+		}
+	}
+	return fontSizePx
+}
+
+function fontSizePxOf(element: HTMLElement) {
+	return Number.parseFloat(element.style.fontSize)
+}
+
+function createBaseProps(overrides: Partial<SeatProps> = {}): SeatProps {
+	const timestamp = {} as Timestamp
+	return {
+		globalSeatId: 123,
+		isUsed: true,
+		memberOnly: false,
+		hoursRemaining: 0,
+		minutesRemaining: 10,
+		hoursElapsed: 1,
+		minutesElapsed: 3,
+		seatFontSizePx: GENERAL_SEAT_FONT_SIZE,
+		processingSeat: {
+			seat_id: 123,
+			user_id: 'user1',
+			user_display_name: 'ユーザー名',
+			work_name: '作業内容',
+			break_work_name: '',
+			entered_at: timestamp,
+			until: timestamp,
+			appearance: {
+				color_code1: '#5BD27D',
+				color_code2: '#008CFF',
+				num_stars: 0,
+				color_gradient_enabled: false,
+			},
+			menu_code: '',
+			state: 'work',
+			current_state_started_at: timestamp,
+			current_state_until: timestamp,
+			cumulative_work_sec: 0,
+			daily_cumulative_work_sec: 0,
+			user_profile_image_url: '',
+		},
+		seatPosition: {
+			x: 0,
+			y: 0,
+			rotate: 0,
+		},
+		seatShape: {
+			widthPx: GENERAL_SEAT_WIDTH_PX,
+			heightPx: 100,
+		},
+		roomShape: {
+			widthPx: 1520,
+			heightPx: 1000,
+		},
+		menuImageMap: new Map<string, string>(),
+		...overrides,
+	}
+}
+
+describe('SeatBox general seat font fitting', () => {
+	const originalGetContext = HTMLCanvasElement.prototype.getContext
+	const originalDocumentFonts = document.fonts
+
+	function mockMeasureTextWithWidths(widths: number[]) {
+		const measureText = jest.fn(() => {
+			const width = widths.shift()
+			if (width === undefined) {
+				throw new Error('measureText width queue is empty')
+			}
+			return { width } as TextMetrics
+		})
+
+		Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+			configurable: true,
+			value: jest.fn(
+				() =>
+					({
+						font: '',
+						measureText,
+					}) as unknown as CanvasRenderingContext2D,
+			),
+		})
+
+		return measureText
+	}
+
+	afterEach(() => {
+		Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+			configurable: true,
+			value: originalGetContext,
+		})
+		Object.defineProperty(document, 'fonts', {
+			configurable: true,
+			value: originalDocumentFonts,
+		})
+		jest.restoreAllMocks()
+	})
+
+	test('remeasures general work name after web fonts are ready', async () => {
+		const fontsReady = createDeferredPromise<void>()
+		Object.defineProperty(document, 'fonts', {
+			configurable: true,
+			value: {
+				ready: fontsReady.promise,
+			},
+		})
+		mockMeasureTextWithWidths([220, 160])
+		const SeatBox = loadSeatBox()
+
+		render(
+			<SeatBox
+				{...createBaseProps({
+					processingSeat: {
+						...createBaseProps().processingSeat,
+						work_name: 'おかえりなさいませ👋',
+					},
+				})}
+			/>,
+		)
+
+		const workName = await screen.findByText('おかえりなさいませ👋')
+		const expectedFallbackFontSizePx = expectedFontSizePx({
+			text: 'おかえりなさいませ👋',
+			seatFontSizePx: GENERAL_SEAT_FONT_SIZE,
+			lineWidthPx: GENERAL_SEAT_LINE_WIDTH_PX,
+			measuredWidthPx: 220,
+			baseEm: 0.95,
+			minEm: 0.63,
+		})
+		const expectedLoadedFontSizePx = expectedFontSizePx({
+			text: 'おかえりなさいませ👋',
+			seatFontSizePx: GENERAL_SEAT_FONT_SIZE,
+			lineWidthPx: GENERAL_SEAT_LINE_WIDTH_PX,
+			measuredWidthPx: 160,
+			baseEm: 0.95,
+			minEm: 0.63,
+		})
+
+		await waitFor(() => {
+			expect(fontSizePxOf(workName)).toBeCloseTo(expectedFallbackFontSizePx, 5)
+		})
+
+		await act(async () => {
+			fontsReady.resolve()
+			await fontsReady.promise
+		})
+
+		await waitFor(() => {
+			expect(fontSizePxOf(workName)).toBeCloseTo(expectedLoadedFontSizePx, 5)
+		})
+	})
+
+	test('remeasures display name when work name is empty', async () => {
+		const fontsReady = createDeferredPromise<void>()
+		Object.defineProperty(document, 'fonts', {
+			configurable: true,
+			value: {
+				ready: fontsReady.promise,
+			},
+		})
+		mockMeasureTextWithWidths([240, 150])
+		const SeatBox = loadSeatBox()
+
+		render(
+			<SeatBox
+				{...createBaseProps({
+					processingSeat: {
+						...createBaseProps().processingSeat,
+						work_name: '',
+						user_display_name: 'おかえりなさいませ👋',
+					},
+				})}
+			/>,
+		)
+
+		const displayName = await screen.findByText('おかえりなさいませ👋')
+		const expectedFallbackFontSizePx = expectedFontSizePx({
+			text: 'おかえりなさいませ👋',
+			seatFontSizePx: GENERAL_SEAT_FONT_SIZE,
+			lineWidthPx: GENERAL_SEAT_LINE_WIDTH_PX,
+			measuredWidthPx: 240,
+			baseEm: 0.8,
+			minEm: 0.5,
+		})
+		const expectedLoadedFontSizePx = expectedFontSizePx({
+			text: 'おかえりなさいませ👋',
+			seatFontSizePx: GENERAL_SEAT_FONT_SIZE,
+			lineWidthPx: GENERAL_SEAT_LINE_WIDTH_PX,
+			measuredWidthPx: 150,
+			baseEm: 0.8,
+			minEm: 0.5,
+		})
+
+		await waitFor(() => {
+			expect(fontSizePxOf(displayName)).toBeCloseTo(
+				expectedFallbackFontSizePx,
+				5,
+			)
+		})
+
+		await act(async () => {
+			fontsReady.resolve()
+			await fontsReady.promise
+		})
+
+		await waitFor(() => {
+			expect(fontSizePxOf(displayName)).toBeCloseTo(expectedLoadedFontSizePx, 5)
+		})
+	})
+
+	test('keeps rendering safely when document.fonts is unavailable', async () => {
+		Object.defineProperty(document, 'fonts', {
+			configurable: true,
+			value: undefined,
+		})
+		mockMeasureTextWithWidths([220])
+		const SeatBox = loadSeatBox()
+
+		render(
+			<SeatBox
+				{...createBaseProps({
+					processingSeat: {
+						...createBaseProps().processingSeat,
+						work_name: 'おかえりなさいませ👋',
+					},
+				})}
+			/>,
+		)
+
+		const workName = await screen.findByText('おかえりなさいませ👋')
+		const expectedFontSize = expectedFontSizePx({
+			text: 'おかえりなさいませ👋',
+			seatFontSizePx: GENERAL_SEAT_FONT_SIZE,
+			lineWidthPx: GENERAL_SEAT_LINE_WIDTH_PX,
+			measuredWidthPx: 220,
+			baseEm: 0.95,
+			minEm: 0.63,
+		})
+
+		await waitFor(() => {
+			expect(fontSizePxOf(workName)).toBeCloseTo(expectedFontSize, 5)
+		})
+	})
+})

--- a/youtube-monitor/src/components/SeatBox.test.tsx
+++ b/youtube-monitor/src/components/SeatBox.test.tsx
@@ -23,9 +23,35 @@ jest.mock('next/image', () => ({
 	},
 }))
 
-process.env.NEXT_PUBLIC_DEBUG = 'true'
-process.env.NEXT_PUBLIC_CHANNEL_GL = 'false'
-process.env.NEXT_PUBLIC_ROOM_CONFIG = 'DEV'
+const originalNextPublicDebug = process.env.NEXT_PUBLIC_DEBUG
+const originalNextPublicChannelGl = process.env.NEXT_PUBLIC_CHANNEL_GL
+const originalNextPublicRoomConfig = process.env.NEXT_PUBLIC_ROOM_CONFIG
+
+beforeAll(() => {
+	process.env.NEXT_PUBLIC_DEBUG = 'true'
+	process.env.NEXT_PUBLIC_CHANNEL_GL = 'false'
+	process.env.NEXT_PUBLIC_ROOM_CONFIG = 'DEV'
+})
+
+afterAll(() => {
+	if (originalNextPublicDebug === undefined) {
+		delete process.env.NEXT_PUBLIC_DEBUG
+	} else {
+		process.env.NEXT_PUBLIC_DEBUG = originalNextPublicDebug
+	}
+
+	if (originalNextPublicChannelGl === undefined) {
+		delete process.env.NEXT_PUBLIC_CHANNEL_GL
+	} else {
+		process.env.NEXT_PUBLIC_CHANNEL_GL = originalNextPublicChannelGl
+	}
+
+	if (originalNextPublicRoomConfig === undefined) {
+		delete process.env.NEXT_PUBLIC_ROOM_CONFIG
+	} else {
+		process.env.NEXT_PUBLIC_ROOM_CONFIG = originalNextPublicRoomConfig
+	}
+})
 
 function loadSeatBox() {
 	const seatBoxModule = require('./SeatBox') as typeof import('./SeatBox')

--- a/youtube-monitor/src/components/SeatBox.tsx
+++ b/youtube-monitor/src/components/SeatBox.tsx
@@ -194,7 +194,7 @@ function useFittedGeneralSeatLineFontSizePx({
 		minEm,
 	])
 
-	return enabled ? measuredFontSizePx ?? initialFontSizePx : initialFontSizePx
+	return enabled ? (measuredFontSizePx ?? initialFontSizePx) : initialFontSizePx
 }
 
 const SeatBox: FC<SeatProps> = (props) => {
@@ -299,12 +299,11 @@ const SeatBox: FC<SeatProps> = (props) => {
 		baseEm: 0.8,
 		minEm: 0.5,
 	})
-	const generalDisplayNameFontSizePx =
-		generalSeatCanAutoFit
-			? hasWorkName
-				? props.seatFontSizePx * 0.63
-				: generalDisplayNameAutoFontSizePx
-			: 0
+	const generalDisplayNameFontSizePx = generalSeatCanAutoFit
+		? hasWorkName
+			? props.seatFontSizePx * 0.63
+			: generalDisplayNameAutoFontSizePx
+		: 0
 
 	return (
 		<div

--- a/youtube-monitor/src/components/SeatBox.tsx
+++ b/youtube-monitor/src/components/SeatBox.tsx
@@ -146,7 +146,6 @@ function useFittedGeneralSeatLineFontSizePx({
 
 	useEffect(() => {
 		if (!enabled) {
-			setMeasurementState({ key: measurementKey, value: null })
 			return
 		}
 

--- a/youtube-monitor/src/components/SeatBox.tsx
+++ b/youtube-monitor/src/components/SeatBox.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css, keyframes } from '@emotion/react'
 import Image from 'next/image'
-import type { FC, SyntheticEvent } from 'react'
+import { type FC, type SyntheticEvent, useEffect, useState } from 'react'
 import { fontFamily, validateString } from '../lib/common'
 import { Constants } from '../lib/constants'
 import * as styles from '../styles/SeatBox.styles'
@@ -50,6 +50,11 @@ const colorGradientKeyframes = keyframes`
 
 let measureTextContext: CanvasRenderingContext2D | null | undefined
 
+/** Test helper: reset the cached canvas context between isolated render checks. */
+export function resetMeasureTextContextForTest(): void {
+	measureTextContext = undefined
+}
+
 function getMeasureTextContext(): CanvasRenderingContext2D | null {
 	if (typeof document === 'undefined') {
 		return null
@@ -97,6 +102,99 @@ function fitGeneralSeatLineFontSizePx(
 		}
 	}
 	return fontSizePx
+}
+
+type GeneralSeatFontMeasurementState = {
+	key: string
+	value: number | null
+}
+
+function useFittedGeneralSeatLineFontSizePx({
+	enabled,
+	text,
+	seatFontSizePx,
+	lineWidthPx,
+	fontWeight,
+	baseEm,
+	minEm,
+}: {
+	enabled: boolean
+	text: string
+	seatFontSizePx: number
+	lineWidthPx: number
+	fontWeight: number
+	baseEm: number
+	minEm: number
+}): number {
+	const initialFontSizePx = seatFontSizePx * baseEm
+	const measurementKey = [
+		enabled ? '1' : '0',
+		text,
+		seatFontSizePx.toString(),
+		lineWidthPx.toString(),
+		fontWeight.toString(),
+		baseEm.toString(),
+		minEm.toString(),
+	].join('|')
+	const [measurementState, setMeasurementState] =
+		useState<GeneralSeatFontMeasurementState>({
+			key: measurementKey,
+			value: null,
+		})
+	const measuredFontSizePx =
+		measurementState.key === measurementKey ? measurementState.value : null
+
+	useEffect(() => {
+		if (!enabled) {
+			setMeasurementState({ key: measurementKey, value: null })
+			return
+		}
+
+		const measureFontSizePx = () =>
+			fitGeneralSeatLineFontSizePx(
+				text,
+				seatFontSizePx,
+				lineWidthPx,
+				fontWeight,
+				baseEm,
+				minEm,
+			)
+		const updateMeasuredFontSize = () => {
+			setMeasurementState({
+				key: measurementKey,
+				value: measureFontSizePx(),
+			})
+		}
+
+		updateMeasuredFontSize()
+
+		if (typeof document === 'undefined' || document.fonts === undefined) {
+			return
+		}
+
+		let cancelled = false
+		void document.fonts.ready.then(() => {
+			if (cancelled) {
+				return
+			}
+			updateMeasuredFontSize()
+		})
+
+		return () => {
+			cancelled = true
+		}
+	}, [
+		enabled,
+		measurementKey,
+		text,
+		seatFontSizePx,
+		lineWidthPx,
+		fontWeight,
+		baseEm,
+		minEm,
+	])
+
+	return enabled ? measuredFontSizePx ?? initialFontSizePx : initialFontSizePx
 }
 
 const SeatBox: FC<SeatProps> = (props) => {
@@ -177,32 +275,35 @@ const SeatBox: FC<SeatProps> = (props) => {
 		props.seatShape.widthPx,
 		props.seatFontSizePx,
 	)
+	const generalSeatCanAutoFit = props.isUsed && !props.memberOnly
 
 	// 文字幅に応じて作業名または休憩中の作業名のフォントサイズを調整。
 	// 下限は同席のユーザー名と同じ 0.63 em に揃える（これ以上は縮めず ellipsis に任せる）。
-	const generalWorkNameFontSizePx =
-		props.isUsed && !props.memberOnly && hasWorkName
-			? fitGeneralSeatLineFontSizePx(
-					currentWorkName,
-					props.seatFontSizePx,
-					generalInnerContentWidthPx,
-					seatWorkNameTextFontWeight,
-					0.95,
-					0.63,
-				)
-			: props.seatFontSizePx * 0.8
+	const generalWorkNameFontSizePx = useFittedGeneralSeatLineFontSizePx({
+		enabled: generalSeatCanAutoFit && hasWorkName,
+		text: currentWorkName,
+		seatFontSizePx: props.seatFontSizePx,
+		lineWidthPx: generalInnerContentWidthPx,
+		fontWeight: seatWorkNameTextFontWeight,
+		baseEm: 0.95,
+		minEm: 0.63,
+	})
 
 	// メンバー席・空席では使わない（一般席ブロック内でのみ参照）。0 は未使用プレースホルダ。
+	const generalDisplayNameAutoFontSizePx = useFittedGeneralSeatLineFontSizePx({
+		enabled: generalSeatCanAutoFit && !hasWorkName,
+		text: displayName,
+		seatFontSizePx: props.seatFontSizePx,
+		lineWidthPx: generalInnerContentWidthPx,
+		fontWeight: seatDisplayNameFontWeight,
+		baseEm: 0.8,
+		minEm: 0.5,
+	})
 	const generalDisplayNameFontSizePx =
-		props.isUsed && !props.memberOnly
+		generalSeatCanAutoFit
 			? hasWorkName
 				? props.seatFontSizePx * 0.63
-				: fitGeneralSeatLineFontSizePx(
-						displayName,
-						props.seatFontSizePx,
-						generalInnerContentWidthPx,
-						seatDisplayNameFontWeight,
-					)
+				: generalDisplayNameAutoFontSizePx
 			: 0
 
 	return (

--- a/youtube-monitor/src/lib/common.test.ts
+++ b/youtube-monitor/src/lib/common.test.ts
@@ -1,26 +1,69 @@
-import {
-	fontClassName,
-	numSeatsOfRoomLayouts,
-	sourceCodeProClassName,
-} from './common'
+function loadCommonModule({
+	mPlusFontFamily,
+	sourceCodeProFontFamily = 'Source Code Pro',
+}: {
+	mPlusFontFamily: string
+	sourceCodeProFontFamily?: string
+}) {
+	jest.resetModules()
+	jest.doMock('next/font/google', () => ({
+		M_PLUS_Rounded_1c: jest.fn(() => ({
+			style: { fontFamily: mPlusFontFamily },
+			className: 'mock-font-class',
+		})),
+		Source_Code_Pro: jest.fn(() => ({
+			style: { fontFamily: sourceCodeProFontFamily },
+			className: 'mock-source-code-pro-class',
+		})),
+	}))
 
-jest.mock('next/font/google', () => ({
-	M_PLUS_Rounded_1c: jest.fn(() => ({
-		style: { fontFamily: 'mock-font-name' },
-		className: 'mock-font-class',
-	})),
-	Source_Code_Pro: jest.fn(() => ({
-		style: { fontFamily: 'mock-font-name' },
-		className: 'mock-source-code-pro-class',
-	})),
-}))
+	return require('./common') as typeof import('./common')
+}
+
+afterEach(() => {
+	jest.resetModules()
+	jest.unmock('next/font/google')
+})
 
 test('font exports return mock classNames from next/font', () => {
+	const { fontClassName, sourceCodeProClassName } = loadCommonModule({
+		mPlusFontFamily: 'M PLUS Rounded 1c',
+	})
+
 	expect(fontClassName).toBe('mock-font-class')
 	expect(sourceCodeProClassName).toBe('mock-source-code-pro-class')
 })
 
+test('fontFamily normalizes an unquoted single family name', () => {
+	const { fontFamily } = loadCommonModule({
+		mPlusFontFamily: 'M PLUS Rounded 1c',
+	})
+
+	expect(fontFamily).toBe('"M PLUS Rounded 1c"')
+})
+
+test('fontFamily preserves an already quoted family list', () => {
+	const { fontFamily } = loadCommonModule({
+		mPlusFontFamily: '"M PLUS Rounded 1c", "M PLUS Rounded 1c Fallback"',
+	})
+
+	expect(fontFamily).toBe('"M PLUS Rounded 1c", "M PLUS Rounded 1c Fallback"')
+})
+
+test('sourceCodeProFontFamily is normalized for canvas and CSS usage', () => {
+	const { sourceCodeProFontFamily } = loadCommonModule({
+		mPlusFontFamily: 'M PLUS Rounded 1c',
+		sourceCodeProFontFamily: 'Source Code Pro',
+	})
+
+	expect(sourceCodeProFontFamily).toBe('"Source Code Pro"')
+})
+
 test('numSeatsOfRoomLayouts', () => {
+	const { numSeatsOfRoomLayouts } = loadCommonModule({
+		mPlusFontFamily: 'M PLUS Rounded 1c',
+	})
+
 	expect(numSeatsOfRoomLayouts([])).toBe(0)
 	expect(
 		numSeatsOfRoomLayouts([

--- a/youtube-monitor/src/lib/common.ts
+++ b/youtube-monitor/src/lib/common.ts
@@ -50,10 +50,7 @@ function normalizeFontFamily(fontFamilyValue: string): string {
 		.map((familyName) => {
 			const firstChar = familyName[0]
 			const lastChar = familyName[familyName.length - 1]
-			if (
-				(firstChar === "'" || firstChar === '"') &&
-				lastChar === firstChar
-			) {
+			if ((firstChar === "'" || firstChar === '"') && lastChar === firstChar) {
 				return familyName
 			}
 			return `"${familyName.replace(/"/g, '\\"')}"`

--- a/youtube-monitor/src/lib/common.ts
+++ b/youtube-monitor/src/lib/common.ts
@@ -42,16 +42,32 @@ export const validateString = (value: string | undefined | null): boolean =>
 
 import { M_PLUS_Rounded_1c, Source_Code_Pro } from 'next/font/google'
 
+function normalizeFontFamily(fontFamilyValue: string): string {
+	return fontFamilyValue
+		.split(',')
+		.map((familyName) => familyName.trim())
+		.filter((familyName) => familyName !== '')
+		.map((familyName) => {
+			const firstChar = familyName[0]
+			const lastChar = familyName[familyName.length - 1]
+			if (
+				(firstChar === "'" || firstChar === '"') &&
+				lastChar === firstChar
+			) {
+				return familyName
+			}
+			return `"${familyName.replace(/"/g, '\\"')}"`
+		})
+		.join(', ')
+}
+
 const mPlusRounded1c = M_PLUS_Rounded_1c({
 	subsets: ['latin'],
 	weight: ['100', '300', '400', '500', '700', '800', '900'],
 	display: 'swap',
 	adjustFontFallback: false,
 })
-const fontFamilyString = mPlusRounded1c.style.fontFamily
-export const fontFamily = fontFamilyString.includes(' ')
-	? `'${fontFamilyString}'`
-	: fontFamilyString
+export const fontFamily = normalizeFontFamily(mPlusRounded1c.style.fontFamily)
 /** Next.js 15ではフォントを有効にするため、ルート要素にこの className を付与する必要がある */
 export const fontClassName = mPlusRounded1c.className
 
@@ -61,6 +77,7 @@ const sourceCodePro = Source_Code_Pro({
 	display: 'swap',
 	adjustFontFallback: false,
 })
-const sourceCodeProFontFamilyString = sourceCodePro.style.fontFamily
-export const sourceCodeProFontFamily = sourceCodeProFontFamilyString
+export const sourceCodeProFontFamily = normalizeFontFamily(
+	sourceCodePro.style.fontFamily,
+)
 export const sourceCodeProClassName = sourceCodePro.className

--- a/youtube-monitor/src/stories/SeatBox.stories.ts
+++ b/youtube-monitor/src/stories/SeatBox.stories.ts
@@ -150,6 +150,16 @@ export const InUseWithLongWorkName: Story = {
 	}),
 }
 
+export const InUseWithGreetingWorkName: Story = {
+	name: '一般席 おかえりなさいませ',
+	args: createBaseArgs({
+		isUsed: true,
+		processingSeat: createSeat({
+			work_name: 'おかえりなさいませ👋',
+		}),
+	}),
+}
+
 export const InUseInBreak: Story = {
 	name: '一般席 休憩中',
 	args: createBaseArgs({


### PR DESCRIPTION
## 概要
一般席の作業名表示が `pnpm dev` と `pnpm storybook` でずれていた問題を修正しました。

## 変更内容
- 一般席の 1 行テキストの幅調整を、初回描画後と Web フォント読込後に再計測するよう変更
- 一般席の作業名だけでなく、作業名なし時の表示名にも同じ再計測ロジックを適用
- `next/font` が返す `fontFamily` を CSS / canvas の両方で安全に使えるよう正規化
- `おかえりなさいませ👋` を再現できる Storybook ストーリーを追加
- 一般席の再計測と `fontFamily` 正規化を検証する Jest テストを追加

## 原因
- 一般席の自動幅調整が render 中の単発 `measureText()` に依存しており、フォント読込タイミングの差で計測結果が変わっていた
- `next/font` の `fontFamily` 文字列をそのまま canvas に渡せておらず、環境によって不正な family 指定になっていた

## 影響
- `pnpm dev` と `pnpm storybook` で一般席の作業名表示が同じ見た目に揃います
- 一般席の表示名も同様のずれを起こしにくくなります

## 確認
- `pnpm test --runInBand`
- `pnpm exec tsc --noEmit`
- headless Chromium で `dev` / `storybook` の対象要素を切り出し、ピクセル差分がないことを確認
