### PR TITLE
[codex] PR #722 レビュー指摘対応

### DIFF
--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -21,8 +21,11 @@ import * as cw_actions from 'aws-cdk-lib/aws-cloudwatch-actions'
 import * as scheduler from 'aws-cdk-lib/aws-scheduler'
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager'
 
-// Docker asset path constants (can be overridden via context in future PRs)
-const SYSTEM_DIR = path.join(__dirname, '../../system/')
+export type AwsCdkStackProps = cdk.StackProps & {
+	systemDir?: string
+}
+
+const DEFAULT_SYSTEM_DIR = path.resolve(__dirname, '../../system')
 const DOCKERFILE_LAMBDA = 'Dockerfile.lambda'
 const DOCKERFILE_FARGATE = 'Dockerfile.fargate'
 
@@ -30,16 +33,17 @@ const DOCKERFILE_FARGATE = 'Dockerfile.fargate'
 // 既に asset を de-dup している。ヘルパーは宣言の明確化とビルド時間の予測性向上を
 // 目的とし、`entrypoint` だけを差し替える。`entrypoint` は Lambda imageConfig 側の
 // 設定で asset fingerprint には寄与しないので、6 関数分の asset は 1 つに共有される。
-const createLambdaImageCode = (binaryName: string) =>
-	lambda.DockerImageCode.fromImageAsset(SYSTEM_DIR, {
+const createLambdaImageCode = (systemDir: string, binaryName: string) =>
+	lambda.DockerImageCode.fromImageAsset(systemDir, {
 		file: DOCKERFILE_LAMBDA,
 		platform: Platform.LINUX_AMD64,
 		entrypoint: [`/app/${binaryName}`],
 	})
 
 export class AwsCdkStack extends cdk.Stack {
-	constructor(scope: Construct, id: string, props?: cdk.StackProps) {
-		super(scope, id, props)
+	constructor(scope: Construct, id: string, props?: AwsCdkStackProps) {
+		const { systemDir = DEFAULT_SYSTEM_DIR, ...stackProps } = props ?? {}
+		super(scope, id, stackProps)
 
 		// =========================
 		// Secrets Manager
@@ -127,7 +131,7 @@ export class AwsCdkStack extends cdk.Stack {
 			this,
 			'BatchImage',
 			{
-				directory: SYSTEM_DIR,
+				directory: systemDir,
 				file: DOCKERFILE_FARGATE,
 				platform: Platform.LINUX_ARM64,
 			},
@@ -171,7 +175,7 @@ export class AwsCdkStack extends cdk.Stack {
 			'sns_notify_discord',
 			{
 				functionName: 'sns_notify_discord',
-				code: createLambdaImageCode('sns_notify_discord'),
+				code: createLambdaImageCode(systemDir, 'sns_notify_discord'),
 				timeout: cdk.Duration.seconds(30),
 				reservedConcurrentExecutions: 1,
 			},
@@ -532,7 +536,7 @@ export class AwsCdkStack extends cdk.Stack {
 			'start_daily_batch',
 			{
 				functionName: 'start_daily_batch',
-				code: createLambdaImageCode('start_daily_batch'),
+				code: createLambdaImageCode(systemDir, 'start_daily_batch'),
 				timeout: cdk.Duration.seconds(15),
 				reservedConcurrentExecutions: 1,
 				environment: {
@@ -568,7 +572,7 @@ export class AwsCdkStack extends cdk.Stack {
 			'set_desired_max_seats',
 			{
 				functionName: 'set_desired_max_seats',
-				code: createLambdaImageCode('set_desired_max_seats'),
+				code: createLambdaImageCode(systemDir, 'set_desired_max_seats'),
 				timeout: cdk.Duration.seconds(20),
 				reservedConcurrentExecutions: undefined,
 			},
@@ -587,7 +591,7 @@ export class AwsCdkStack extends cdk.Stack {
 			'youtube_organize_database',
 			{
 				functionName: 'youtube_organize_database',
-				code: createLambdaImageCode('youtube_organize_database'),
+				code: createLambdaImageCode(systemDir, 'youtube_organize_database'),
 				timeout: cdk.Duration.seconds(50),
 				reservedConcurrentExecutions: 1,
 			},
@@ -606,7 +610,7 @@ export class AwsCdkStack extends cdk.Stack {
 			'check_live_stream_status',
 			{
 				functionName: 'check_live_stream_status',
-				code: createLambdaImageCode('check_live_stream_status'),
+				code: createLambdaImageCode(systemDir, 'check_live_stream_status'),
 				timeout: cdk.Duration.seconds(20),
 				reservedConcurrentExecutions: undefined,
 			},
@@ -625,7 +629,7 @@ export class AwsCdkStack extends cdk.Stack {
 			'update_work_name_trend',
 			{
 				functionName: 'update_work_name_trend',
-				code: createLambdaImageCode('update_work_name_trend'),
+				code: createLambdaImageCode(systemDir, 'update_work_name_trend'),
 				timeout: cdk.Duration.minutes(5),
 				reservedConcurrentExecutions: 1,
 				environment: {

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -5,11 +5,13 @@ import * as path from 'node:path'
 import * as cdk from 'aws-cdk-lib'
 import { Match, Template } from 'aws-cdk-lib/assertions'
 
-import { AwsCdkStack } from '../lib/aws-cdk-stack'
+import { AwsCdkStack, type AwsCdkStackProps } from '../lib/aws-cdk-stack'
 
-const createTemplate = () => {
+const REPO_SYSTEM_DIR = path.resolve(__dirname, '../../system')
+
+const createTemplate = (props?: AwsCdkStackProps) => {
 	const app = new cdk.App()
-	const stack = new AwsCdkStack(app, 'TestStack')
+	const stack = new AwsCdkStack(app, 'TestStack', props)
 
 	return Template.fromStack(stack)
 }
@@ -133,15 +135,13 @@ describe('AwsCdkStack', () => {
 // `system/.dockerignore` が正しく build context から除外している限り、これらの
 // 変更は asset fingerprint に寄与しないはず。
 describe('Docker asset determinism (issue #692)', () => {
-	const SYSTEM_DIR = path.resolve(__dirname, '../../system')
-
 	// `cdk.App` を毎回新しい一時 outdir で synth し、TestStack.assets.json の
 	// `dockerImages` キー集合をソート済み配列で返す。
-	const synthDockerImageKeys = (): string[] => {
+	const synthDockerImageKeys = (systemDir = REPO_SYSTEM_DIR): string[] => {
 		const outdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-692-'))
 		try {
 			const app = new cdk.App({ outdir })
-			new AwsCdkStack(app, 'TestStack')
+			new AwsCdkStack(app, 'TestStack', { systemDir })
 			const assembly = app.synth()
 			const assetsPath = path.join(
 				assembly.directory,
@@ -156,89 +156,42 @@ describe('Docker asset determinism (issue #692)', () => {
 		}
 	}
 
-	// system/ 配下の対象ファイルを一時的に書き換え（または新規作成）して fn を実行し、
-	// finally で必ず原状復帰する。
-	// - 既存ファイル: tmp 配下に copyFileSync で退避し、終了時に元の場所へコピーし直す。
-	//   mode（実行ビット等）は `statSync().mode` をキャプチャして `chmodSync` で復元する。
-	//   `system/main` のようなローカル go build 成果物（0o755）が混ざる環境でも、
-	//   テスト後に実行不可にならないよう内容だけでなく mode も明示的に戻す。
-	// - 存在しなかったパス: 作成 → 削除（新規作成で巻き込んだディレクトリも掃除）。
-	const withTemporaryFile = (
-		relPath: string,
-		content: Buffer | string,
-		fn: () => void,
-	) => {
-		const target = path.join(SYSTEM_DIR, relPath)
-		const existed = fs.existsSync(target)
-		const createdDirs: string[] = []
-		let backupDir: string | null = null
-		let backupPath: string | null = null
-		let originalMode: number | null = null
-		if (existed) {
-			backupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-692-bak-'))
-			backupPath = path.join(backupDir, 'backup')
-			fs.copyFileSync(target, backupPath)
-			originalMode = fs.statSync(target).mode
-		} else {
-			let dir = path.dirname(target)
-			const stopAt = SYSTEM_DIR
-			while (!fs.existsSync(dir) && dir.startsWith(stopAt)) {
-				createdDirs.push(dir)
-				dir = path.dirname(dir)
-			}
-			fs.mkdirSync(path.dirname(target), { recursive: true })
-		}
-		const payload =
-			typeof content === 'string' ? Buffer.from(content, 'utf-8') : content
+	const withTemporarySystemDir = <T>(fn: (systemDir: string) => T): T => {
+		const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-692-system-'))
+		const tempSystemDir = path.join(tempRoot, 'system')
 		try {
-			fs.writeFileSync(target, payload)
-			fn()
+			fs.cpSync(REPO_SYSTEM_DIR, tempSystemDir, {
+				recursive: true,
+				preserveTimestamps: true,
+			})
+			return fn(tempSystemDir)
 		} finally {
-			try {
-				if (existed && backupPath !== null) {
-					fs.copyFileSync(backupPath, target)
-					if (originalMode !== null) {
-						fs.chmodSync(target, originalMode)
-					}
-				} else {
-					if (fs.existsSync(target)) {
-						fs.unlinkSync(target)
-					}
-					for (const dir of createdDirs) {
-						if (
-							fs.existsSync(dir) &&
-							fs.readdirSync(dir).length === 0
-						) {
-							fs.rmdirSync(dir)
-						}
-					}
-				}
-			} finally {
-				if (backupDir !== null) {
-					fs.rmSync(backupDir, { recursive: true, force: true })
-				}
-			}
+			fs.rmSync(tempRoot, { recursive: true, force: true })
 		}
 	}
 
-	// 安全弁: `withTemporaryFile` は `finally` でバックアップ / 削除を行うが、
-	// テストが途中クラッシュした場合でも worktree が汚染されないよう
-	// `afterAll` でも必要最小限の後始末を行えるようにフックだけ用意しておく。
-	afterAll(() => {
-		// 現状のテストは既存ファイルの内容書き換え + 復元のみで、
-		// 新規作成は `withTemporaryFile` 内の try/finally で確実に掃除される。
-	})
-
-	let baselineKeys: string[]
-	beforeAll(() => {
-		baselineKeys = synthDockerImageKeys()
-		// Docker アセットが少なくとも 1 つ存在することの sanity check
-		expect(baselineKeys.length).toBeGreaterThan(0)
-	})
+	// system/ の一時コピー配下だけを書き換え、リポジトリ実ファイルは一切変更しない。
+	const writeTemporaryFile = (
+		systemDir: string,
+		relPath: string,
+		content: Buffer | string,
+	) => {
+		const target = path.join(systemDir, relPath)
+		const payload =
+			typeof content === 'string' ? Buffer.from(content, 'utf-8') : content
+		fs.mkdirSync(path.dirname(target), { recursive: true })
+		fs.writeFileSync(target, payload)
+	}
 
 	test('dockerImages keys are identical across two consecutive synths', () => {
-		const second = synthDockerImageKeys()
-		expect(second).toEqual(baselineKeys)
+		withTemporarySystemDir((systemDir) => {
+			const baselineKeys = synthDockerImageKeys(systemDir)
+			// Docker アセットが少なくとも 1 つ存在することの sanity check
+			expect(baselineKeys.length).toBeGreaterThan(0)
+
+			const second = synthDockerImageKeys(systemDir)
+			expect(second).toEqual(baselineKeys)
+		})
 	})
 
 	test.each<{ name: string; rel: string; content: Buffer | string }>([
@@ -274,8 +227,13 @@ describe('Docker asset determinism (issue #692)', () => {
 	])(
 		'dockerImages keys unaffected by changes to $name',
 		({ rel, content }) => {
-			withTemporaryFile(rel, content, () => {
-				const keys = synthDockerImageKeys()
+			withTemporarySystemDir((systemDir) => {
+				const baselineKeys = synthDockerImageKeys(systemDir)
+				expect(baselineKeys.length).toBeGreaterThan(0)
+
+				writeTemporaryFile(systemDir, rel, content)
+
+				const keys = synthDockerImageKeys(systemDir)
 				expect(keys).toEqual(baselineKeys)
 			})
 		},

--- a/system/Dockerfile.lambda
+++ b/system/Dockerfile.lambda
@@ -1,3 +1,4 @@
+# Digest is authoritative; this digest was verified against golang:1.25 when pinned.
 FROM golang:1.25@sha256:3760478c76cfe25533e06176e983e7808293895d48d15d0981c0cbb9623834e7 AS build
 WORKDIR /var/task
 
@@ -30,6 +31,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go build -tags lambda.norpc,timetzdata -trimpath -ldflags="-s -w" -o update_work_name_trend aws-lambda/update_work_name_trend/main.go
 
+# Digest is authoritative; this digest was verified against provided:al2023 when pinned.
 # Copy artifacts to a clean image
 FROM public.ecr.aws/lambda/provided:al2023@sha256:28500361cd9906d26fa78b1b2724ab342bf542753db88f77b764afd7f377019e
 WORKDIR /app


### PR DESCRIPTION
## 概要
PR #722 のレビュー指摘に対応しました。

## 変更内容
- Docker asset determinism テストが実リポジトリの `system/` を書き換えないよう、`AwsCdkStack` に `systemDir` 注入を追加し、テストは一時コピーを synth 対象に変更
- `system/Dockerfile.lambda` に tag+digest 併記時の意図を示すコメントを追加
- release PR #722 の本文に frontend UI/layout 変更のスコープを追記済み

## 確認
- `pnpm test`
- `pnpm build`
