### PR TITLE
chore: suppress system credential deprecation lint

### DIFF
--- a/system/aws-lambda/lambdautils/credential.go
+++ b/system/aws-lambda/lambdautils/credential.go
@@ -13,5 +13,6 @@ func FirestoreClientOption() (option.ClientOption, error) {
 	if err != nil {
 		return nil, fmt.Errorf("in FetchFirebaseCredentialsAsBytes: %w", err)
 	}
+	//nolint:staticcheck // Credential JSON is fetched from our managed DynamoDB secret and is limited to the Firebase service account payload.
 	return option.WithCredentialsJSON(credentialBytes), nil
 }

--- a/system/main.go
+++ b/system/main.go
@@ -30,6 +30,7 @@ func Init() (option.ClientOption, context.Context, error) {
 	credentialFilePath := os.Getenv("CREDENTIAL_FILE_LOCATION")
 
 	ctx := context.Background()
+	//nolint:staticcheck // Credential file path is repo/operator-controlled and restricted to the service account JSON used for this app.
 	clientOption := option.WithCredentialsFile(credentialFilePath)
 
 	creds, err := transport.Creds(ctx, clientOption)


### PR DESCRIPTION
## Summary
- suppress staticcheck deprecation warnings for the two repo-managed Google credential entrypoints
- keep the current credential loading behavior unchanged so Dependabot system bumps can rebase cleanly

## Testing
- go test -shuffle=on -v ./...