### PR TITLE
chore: fix youtube monitor biome findings

### DIFF
--- a/youtube-monitor/src/components/SeatBox.test.tsx
+++ b/youtube-monitor/src/components/SeatBox.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import type { Timestamp } from 'firebase/firestore'
-import type { ImgHTMLAttributes } from 'react'
+import type { ComponentPropsWithoutRef } from 'react'
 import { act } from 'react'
 import type { SeatProps } from './SeatBox'
 
@@ -17,9 +17,17 @@ jest.mock('next/font/google', () => ({
 
 jest.mock('next/image', () => ({
 	__esModule: true,
-	default: (props: ImgHTMLAttributes<HTMLImageElement>) => {
+	default: (props: ComponentPropsWithoutRef<'img'>) => {
 		const { alt, src, ...rest } = props
-		return <img alt={alt} src={src} {...rest} />
+		return (
+			<span
+				role="img"
+				aria-label={alt}
+				data-next-image=""
+				data-src={typeof src === 'string' ? src : ''}
+				{...rest}
+			/>
+		)
 	},
 }))
 

--- a/youtube-monitor/src/components/TickerBoard.tsx
+++ b/youtube-monitor/src/components/TickerBoard.tsx
@@ -23,6 +23,8 @@ const TickerBoard: FC<Props> = ({ workNameTrend }) => {
 					gradient={false}
 				>
 					{workNameTrend.ranking.map((r) => {
+						const exampleKeyCounts = new Map<string, number>()
+
 						return (
 							<span css={styles.genreItem} key={`tb-${r.rank}-${r.genre}`}>
 								<span css={styles.rankBadge}>
@@ -34,11 +36,14 @@ const TickerBoard: FC<Props> = ({ workNameTrend }) => {
 									{t('work_name_trend.count', { value: r.count })}
 								</span>
 								<span css={styles.examplesWrapper}>
-									{r.examples.map((e, exampleIndex) => {
+									{r.examples.map((e) => {
+										const seenCount = exampleKeyCounts.get(e) ?? 0
+										exampleKeyCounts.set(e, seenCount + 1)
+
 										return (
 											<span
 												css={styles.exampleChip}
-												key={`tb-${r.rank}-${exampleIndex}-${e}`}
+												key={`tb-${r.rank}-${e}-${seenCount}`}
 											>
 												{e}
 											</span>


### PR DESCRIPTION
## Summary
- remove array-index-derived keys from the ticker board examples
- replace the next/image test mock with a Biome-safe element stub

## Testing
- pnpm exec biome check .
- pnpm test