### PR TITLE
chore: fix aws cdk test type resolution

### DIFF
--- a/aws-cdk/tsconfig.json
+++ b/aws-cdk/tsconfig.json
@@ -20,6 +20,10 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    "types": [
+      "node",
+      "jest"
+    ],
     "typeRoots": [
       "./node_modules/@types"
     ]


### PR DESCRIPTION
## Summary
- add explicit node and jest type resolution for aws-cdk tests
- keep the runtime and dependency graph unchanged while making TypeScript upgrades safe

## Testing
- pnpm test