### PR TITLE
chore: fix menu image generator compatibility

### DIFF
--- a/tools/menu-image-generator/src/components/MenuBoard.tsx
+++ b/tools/menu-image-generator/src/components/MenuBoard.tsx
@@ -225,7 +225,7 @@ export const MenuBoard = ({
 	items,
 	pageNumber,
 	totalPages,
-}: MenuBoardProps): JSX.Element => {
+}: MenuBoardProps) => {
 	// レイアウト計算
 	const columns = calculateColumns(items.length)
 	const layout = calculateLayout(items.length)

--- a/tools/menu-image-generator/src/index.ts
+++ b/tools/menu-image-generator/src/index.ts
@@ -128,7 +128,7 @@ async function main(): Promise<void> {
 	// Puppeteerブラウザを起動
 	console.log('ブラウザを起動中...')
 	const browser = await puppeteer.launch({
-		headless: 'new', // v21系では新しいHeadlessモードを明示的に指定
+		headless: true, // Puppeteer 21/24 の両方で扱える設定に固定する
 		args: ['--no-sandbox', '--disable-setuid-sandbox'],
 	})
 	console.log('ブラウザ起動完了')


### PR DESCRIPTION
## Summary
- remove the explicit JSX.Element return type from MenuBoard so React type upgrades can rebase cleanly
- use a boolean Puppeteer headless setting that works across the currently open majors

## Testing
- pnpm lint
- pnpm build