### PR TITLE
chore: bump docs-site docusaurus types

### DIFF
--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -33,7 +33,7 @@
 		"@biomejs/biome": "2.4.12",
 		"@docusaurus/module-type-aliases": "^3.10.0",
 		"@docusaurus/tsconfig": "^3.10.0",
-		"@docusaurus/types": "^3.9.2",
+		"@docusaurus/types": "^3.10.0",
 		"typescript": "~5.2.2"
 	},
 	"browserslist": {

--- a/docs-site/pnpm-lock.yaml
+++ b/docs-site/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^3.10.0
         version: 3.10.0
       '@docusaurus/types':
-        specifier: ^3.9.2
-        version: 3.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^3.10.0
+        version: 3.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       typescript:
         specifier: ~5.2.2
         version: 5.2.2


### PR DESCRIPTION
## Summary
- recreate Dependabot PR #736 on top of the latest dev because the original branch stayed in a conflicting state
- bump @docusaurus/types in docs-site only

## Testing
- pnpm build