### PR TITLE
feat: add lambda error log notification path

### DIFF
--- a/aws-cdk/README.md
+++ b/aws-cdk/README.md
@@ -31,12 +31,8 @@ aws sts get-caller-identity --profile プロファイル名
 - Lambdaの Errors>0 と Step Functions ExecutionsFailed>0 のアラームをSNSに連携。
 - 主要出力（CfnOutput）:
   - `BatchClusterArn`, `DailyBatchTaskDefinitionArn`, `BatchSecurityGroupId`, `BatchPublicSubnetIds`, `BatchVpcId`, `DailyBatchStateMachineArn`
-- `AlarmEmail` パラメータで `AlarmsTopic` に Email subscription を追加する。初回 deploy 後は **SNS の Confirm subscription** が必要。
-  - `cdk diff` は現行 CDK CLI では `AlarmEmail` を付けても change set 作成時に CloudFormation へ値が渡らず、`The following CloudFormation Parameters are missing a value: AlarmEmail` で fallback する。そのため diff 確認は `--no-change-set` を付ける:
-    ```bash
-    pnpm cdk:diff --profile プロファイル名 --parameters AlarmEmail=notify@example.com --no-change-set
-    ```
-  - deploy 時にメールアドレスを渡す例:
+- `AlarmEmail` パラメータにメールアドレスを指定すると、`AlarmsTopic` に Email subscription を追加する。未指定の場合は Email subscription を作らない。
+  - メール通知も有効にして deploy する例:
     ```bash
     pnpm cdk:deploy --profile プロファイル名 --parameters AlarmEmail=notify@example.com
     ```

--- a/aws-cdk/README.md
+++ b/aws-cdk/README.md
@@ -31,4 +31,9 @@ aws sts get-caller-identity --profile プロファイル名
 - Lambdaの Errors>0 と Step Functions ExecutionsFailed>0 のアラームをSNSに連携。
 - 主要出力（CfnOutput）:
   - `BatchClusterArn`, `DailyBatchTaskDefinitionArn`, `BatchSecurityGroupId`, `BatchPublicSubnetIds`, `BatchVpcId`, `DailyBatchStateMachineArn`
-
+- `AlarmEmail` パラメータで `AlarmsTopic` に Email subscription を追加する。初回 deploy 後は **SNS の Confirm subscription** が必要。
+  - deploy 時にメールアドレスを渡す例（`--` 以降が `cdk deploy` に渡る）:
+    ```bash
+    pnpm cdk:deploy -- --parameters AlarmEmail=notify@example.com --profile プロファイル名
+    ```
+  - 初回のみ、指定したメールに AWS から届く **Confirm subscription** のリンクを開いて承認する。コンソールから行う場合は **SNS → Topics → `AlarmsTopic` に相当するトピック → Subscriptions** で Pending を Confirm する。

--- a/aws-cdk/README.md
+++ b/aws-cdk/README.md
@@ -32,8 +32,12 @@ aws sts get-caller-identity --profile プロファイル名
 - 主要出力（CfnOutput）:
   - `BatchClusterArn`, `DailyBatchTaskDefinitionArn`, `BatchSecurityGroupId`, `BatchPublicSubnetIds`, `BatchVpcId`, `DailyBatchStateMachineArn`
 - `AlarmEmail` パラメータで `AlarmsTopic` に Email subscription を追加する。初回 deploy 後は **SNS の Confirm subscription** が必要。
-  - deploy 時にメールアドレスを渡す例（`--` 以降が `cdk deploy` に渡る）:
+  - `cdk diff` は現行 CDK CLI では `AlarmEmail` を付けても change set 作成時に CloudFormation へ値が渡らず、`The following CloudFormation Parameters are missing a value: AlarmEmail` で fallback する。そのため diff 確認は `--no-change-set` を付ける:
     ```bash
-    pnpm cdk:deploy -- --parameters AlarmEmail=notify@example.com --profile プロファイル名
+    pnpm cdk:diff --profile プロファイル名 --parameters AlarmEmail=notify@example.com --no-change-set
+    ```
+  - deploy 時にメールアドレスを渡す例:
+    ```bash
+    pnpm cdk:deploy --profile プロファイル名 --parameters AlarmEmail=notify@example.com
     ```
   - 初回のみ、指定したメールに AWS から届く **Confirm subscription** のリンクを開いて承認する。コンソールから行う場合は **SNS → Topics → `AlarmsTopic` に相当するトピック → Subscriptions** で Pending を Confirm する。

--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -707,6 +707,14 @@ export class AwsCdkStack extends cdk.Stack {
 		}
 
 		addErrorLogSubscriptionFilter(
+			'StartDailyBatchErrorLogSubscription',
+			startDailyBatchFunction,
+		)
+		addErrorLogSubscriptionFilter(
+			'SetDesiredMaxSeatsErrorLogSubscription',
+			setDesiredMaxSeatsFunction,
+		)
+		addErrorLogSubscriptionFilter(
 			'YoutubeOrganizeDatabaseErrorLogSubscription',
 			youtubeOrganizeDatabaseFunction,
 		)
@@ -717,6 +725,10 @@ export class AwsCdkStack extends cdk.Stack {
 		addErrorLogSubscriptionFilter(
 			'UpdateWorkNameTrendErrorLogSubscription',
 			updateWorkNameTrendFunction,
+		)
+		addErrorLogSubscriptionFilter(
+			'SnsNotifyDiscordErrorLogSubscription',
+			snsNotifyDiscordFunction,
 		)
 
 		// API Gateway用ロググループ

--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -14,6 +14,7 @@ import * as events from 'aws-cdk-lib/aws-events'
 import * as targets from 'aws-cdk-lib/aws-events-targets'
 import { PassthroughBehavior } from 'aws-cdk-lib/aws-apigateway'
 import * as logs from 'aws-cdk-lib/aws-logs'
+import { LambdaDestination } from 'aws-cdk-lib/aws-logs-destinations'
 import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch'
 import * as sns from 'aws-cdk-lib/aws-sns'
 import * as subs from 'aws-cdk-lib/aws-sns-subscriptions'
@@ -32,7 +33,7 @@ const DOCKERFILE_FARGATE = 'Dockerfile.fargate'
 // 全 Lambda で同じ build context / Dockerfile / platform を共有しているため、CDK は
 // 既に asset を de-dup している。ヘルパーは宣言の明確化とビルド時間の予測性向上を
 // 目的とし、`entrypoint` だけを差し替える。`entrypoint` は Lambda imageConfig 側の
-// 設定で asset fingerprint には寄与しないので、6 関数分の asset は 1 つに共有される。
+// 設定で asset fingerprint には寄与しないので、複数関数分の asset は 1 つに共有される。
 const createLambdaImageCode = (systemDir: string, binaryName: string) =>
 	lambda.DockerImageCode.fromImageAsset(systemDir, {
 		file: DOCKERFILE_LAMBDA,
@@ -44,6 +45,12 @@ export class AwsCdkStack extends cdk.Stack {
 	constructor(scope: Construct, id: string, props?: AwsCdkStackProps) {
 		const { systemDir = DEFAULT_SYSTEM_DIR, ...stackProps } = props ?? {}
 		super(scope, id, stackProps)
+
+		const alarmEmail = new cdk.CfnParameter(this, 'AlarmEmail', {
+			type: 'String',
+			description:
+				'Email address for SNS subscription on AlarmsTopic (CloudWatch alarms). Confirm the subscription in email after deploy.',
+		})
 
 		// =========================
 		// Secrets Manager
@@ -186,6 +193,9 @@ export class AwsCdkStack extends cdk.Stack {
 		alarmsTopic.addSubscription(
 			new subs.LambdaSubscription(snsNotifyDiscordFunction),
 		)
+		alarmsTopic.addSubscription(
+			new subs.EmailSubscription(alarmEmail.valueAsString),
+		)
 
 		// Helper to create a common Lambda Errors>0 alarm wired to SNS
 		const createLambdaErrorAlarm = (
@@ -208,6 +218,12 @@ export class AwsCdkStack extends cdk.Stack {
 			alarm.addAlarmAction(new cw_actions.SnsAction(alarmsTopic))
 			return alarm
 		}
+
+		createLambdaErrorAlarm(
+			snsNotifyDiscordFunction,
+			'SnsNotifyDiscordErrorsAlarm',
+			'Lambda sns_notify_discord errors > 0',
+		)
 
 		// 参照用の出力（後続PRでStep Functionsから使用）
 		new cdk.CfnOutput(this, 'BatchClusterArn', {
@@ -566,6 +582,12 @@ export class AwsCdkStack extends cdk.Stack {
 			},
 		)
 
+		createLambdaErrorAlarm(
+			startDailyBatchFunction,
+			'StartDailyBatchErrorsAlarm',
+			'Lambda start_daily_batch errors > 0',
+		)
+
 		// Lambda function
 		const setDesiredMaxSeatsFunction = new lambda.DockerImageFunction(
 			this,
@@ -645,6 +667,65 @@ export class AwsCdkStack extends cdk.Stack {
 			updateWorkNameTrendFunction,
 			'UpdateWorkNameTrendErrorsAlarm',
 			'Lambda update_work_name_trend errors > 0',
+		)
+
+		const errorLogNotifyDiscordFunction = new lambda.DockerImageFunction(
+			this,
+			'error_log_notify_discord',
+			{
+				functionName: 'error_log_notify_discord',
+				code: createLambdaImageCode(systemDir, 'error_log_notify_discord'),
+				timeout: cdk.Duration.seconds(30),
+				reservedConcurrentExecutions: 1,
+			},
+		)
+		;(errorLogNotifyDiscordFunction.role as iam.Role).addToPolicy(
+			dynamoDBAccessPolicy,
+		)
+		createLambdaErrorAlarm(
+			errorLogNotifyDiscordFunction,
+			'ErrorLogNotifyDiscordErrorsAlarm',
+			'Lambda error_log_notify_discord errors > 0',
+		)
+
+		const errorLogFilterPattern = logs.FilterPattern.stringValue(
+			'$.level',
+			'=',
+			'ERROR',
+		)
+
+		const addErrorLogSubscriptionFilter = (
+			constructId: string,
+			importedLogGroupId: string,
+			logGroupName: string,
+		) => {
+			const importedLogGroup = logs.LogGroup.fromLogGroupName(
+				this,
+				importedLogGroupId,
+				logGroupName,
+			)
+			new logs.SubscriptionFilter(this, constructId, {
+				logGroup: importedLogGroup,
+				destination: new LambdaDestination(errorLogNotifyDiscordFunction),
+				filterPattern: errorLogFilterPattern,
+				filterName: 'error-level-to-discord',
+			})
+		}
+
+		addErrorLogSubscriptionFilter(
+			'YoutubeOrganizeDatabaseErrorLogSubscription',
+			'ImportedLogGroupYoutubeOrganizeDatabase',
+			`/aws/lambda/${youtubeOrganizeDatabaseFunction.functionName}`,
+		)
+		addErrorLogSubscriptionFilter(
+			'CheckLiveStreamStatusErrorLogSubscription',
+			'ImportedLogGroupCheckLiveStreamStatus',
+			`/aws/lambda/${checkLiveStreamStatusFunction.functionName}`,
+		)
+		addErrorLogSubscriptionFilter(
+			'UpdateWorkNameTrendErrorLogSubscription',
+			'ImportedLogGroupUpdateWorkNameTrend',
+			`/aws/lambda/${updateWorkNameTrendFunction.functionName}`,
 		)
 
 		// API Gateway用ロググループ

--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -48,8 +48,14 @@ export class AwsCdkStack extends cdk.Stack {
 
 		const alarmEmail = new cdk.CfnParameter(this, 'AlarmEmail', {
 			type: 'String',
+			default: '',
 			description:
-				'Email address for SNS subscription on AlarmsTopic (CloudWatch alarms). Confirm the subscription in email after deploy.',
+				'Optional email address for SNS subscription on AlarmsTopic (CloudWatch alarms). Confirm the subscription in email after deploy when specified.',
+		})
+		const hasAlarmEmail = new cdk.CfnCondition(this, 'HasAlarmEmail', {
+			expression: cdk.Fn.conditionNot(
+				cdk.Fn.conditionEquals(alarmEmail.valueAsString, ''),
+			),
 		})
 
 		// =========================
@@ -193,9 +199,16 @@ export class AwsCdkStack extends cdk.Stack {
 		alarmsTopic.addSubscription(
 			new subs.LambdaSubscription(snsNotifyDiscordFunction),
 		)
-		alarmsTopic.addSubscription(
-			new subs.EmailSubscription(alarmEmail.valueAsString),
+		const alarmEmailSubscription = new sns.CfnSubscription(
+			this,
+			'AlarmsTopicEmailSubscription',
+			{
+				topicArn: alarmsTopic.topicArn,
+				protocol: 'email',
+				endpoint: alarmEmail.valueAsString,
+			},
 		)
+		alarmEmailSubscription.cfnOptions.condition = hasAlarmEmail
 
 		// Helper to create a common Lambda Errors>0 alarm wired to SNS
 		const createLambdaErrorAlarm = (

--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -689,7 +689,6 @@ export class AwsCdkStack extends cdk.Stack {
 				functionName: 'error_log_notify_discord',
 				code: createLambdaImageCode(systemDir, 'error_log_notify_discord'),
 				timeout: cdk.Duration.seconds(30),
-				reservedConcurrentExecutions: 1,
 			},
 		)
 		;(errorLogNotifyDiscordFunction.role as iam.Role).addToPolicy(

--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -696,16 +696,10 @@ export class AwsCdkStack extends cdk.Stack {
 
 		const addErrorLogSubscriptionFilter = (
 			constructId: string,
-			importedLogGroupId: string,
-			logGroupName: string,
+			targetFunction: lambda.Function,
 		) => {
-			const importedLogGroup = logs.LogGroup.fromLogGroupName(
-				this,
-				importedLogGroupId,
-				logGroupName,
-			)
 			new logs.SubscriptionFilter(this, constructId, {
-				logGroup: importedLogGroup,
+				logGroup: targetFunction.logGroup,
 				destination: new LambdaDestination(errorLogNotifyDiscordFunction),
 				filterPattern: errorLogFilterPattern,
 				filterName: 'error-level-to-discord',
@@ -714,18 +708,15 @@ export class AwsCdkStack extends cdk.Stack {
 
 		addErrorLogSubscriptionFilter(
 			'YoutubeOrganizeDatabaseErrorLogSubscription',
-			'ImportedLogGroupYoutubeOrganizeDatabase',
-			`/aws/lambda/${youtubeOrganizeDatabaseFunction.functionName}`,
+			youtubeOrganizeDatabaseFunction,
 		)
 		addErrorLogSubscriptionFilter(
 			'CheckLiveStreamStatusErrorLogSubscription',
-			'ImportedLogGroupCheckLiveStreamStatus',
-			`/aws/lambda/${checkLiveStreamStatusFunction.functionName}`,
+			checkLiveStreamStatusFunction,
 		)
 		addErrorLogSubscriptionFilter(
 			'UpdateWorkNameTrendErrorLogSubscription',
-			'ImportedLogGroupUpdateWorkNameTrend',
-			`/aws/lambda/${updateWorkNameTrendFunction.functionName}`,
+			updateWorkNameTrendFunction,
 		)
 
 		// API Gateway用ロググループ

--- a/aws-cdk/package.json
+++ b/aws-cdk/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
+    "pretest": "tsc",
     "test": "jest",
     "cdk:bootstrap": "cdk bootstrap",
     "cdk:deploy": "cdk deploy",

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -161,7 +161,10 @@ describe('AwsCdkStack', () => {
 				string,
 				{
 					Type?: string
-					Properties?: { FunctionName?: string; Principal?: string }
+					Properties?: {
+						FunctionName?: string
+						Principal?: string
+					}
 				}
 			>
 		}
@@ -175,6 +178,11 @@ describe('AwsCdkStack', () => {
 			(r) => r.Type === 'AWS::Logs::SubscriptionFilter',
 		)
 		expect(filters).toHaveLength(3)
+
+		const logRetentionCustomResources = Object.values(resources).filter(
+			(r) => r.Type === 'Custom::LogRetention',
+		)
+		expect(logRetentionCustomResources.length).toBeGreaterThanOrEqual(3)
 
 		const logsInvokePerms = Object.values(resources).filter(
 			(r) =>

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -126,6 +126,69 @@ describe('AwsCdkStack', () => {
 			expect(logGroup.Properties?.RetentionInDays).toBeUndefined()
 		}
 	})
+
+	test('defines AlarmEmail template parameter for SNS email backstop', () => {
+		const t = createTemplate()
+		t.hasParameter('AlarmEmail', { Type: 'String' })
+	})
+
+	test('subscribes AlarmsTopic to email and Lambda notifier', () => {
+		const t = createTemplate()
+		const subs = t.findResources('AWS::SNS::Subscription')
+		expect(Object.keys(subs).length).toBe(2)
+		t.hasResourceProperties('AWS::SNS::Subscription', {
+			Protocol: 'email',
+		})
+		t.hasResourceProperties('AWS::SNS::Subscription', {
+			Protocol: 'lambda',
+		})
+	})
+
+	test('creates Lambda errors alarms for sns_notify_discord and start_daily_batch', () => {
+		const t = createTemplate()
+		const alarms = t.findResources('AWS::CloudWatch::Alarm')
+		const descriptions = Object.values(alarms).map(
+			(a) => (a as { Properties?: { AlarmDescription?: string } }).Properties?.AlarmDescription,
+		)
+		expect(descriptions).toContain('Lambda sns_notify_discord errors > 0')
+		expect(descriptions).toContain('Lambda start_daily_batch errors > 0')
+	})
+
+	test('creates error_log_notify_discord Lambda, errors alarm, and three ERROR subscription filters', () => {
+		const t = createTemplate()
+		const json = t.toJSON() as {
+			Resources?: Record<
+				string,
+				{
+					Type?: string
+					Properties?: { FunctionName?: string; Principal?: string }
+				}
+			>
+		}
+		const resources = json.Resources ?? {}
+		const lambdaNames = Object.values(resources)
+			.filter((r) => r.Type === 'AWS::Lambda::Function')
+			.map((r) => r.Properties?.FunctionName)
+		expect(lambdaNames).toContain('error_log_notify_discord')
+
+		const filters = Object.values(resources).filter(
+			(r) => r.Type === 'AWS::Logs::SubscriptionFilter',
+		)
+		expect(filters).toHaveLength(3)
+
+		const logsInvokePerms = Object.values(resources).filter(
+			(r) =>
+				r.Type === 'AWS::Lambda::Permission' &&
+				r.Properties?.Principal === 'logs.amazonaws.com',
+		)
+		expect(logsInvokePerms.length).toBeGreaterThanOrEqual(3)
+
+		const alarms = t.findResources('AWS::CloudWatch::Alarm')
+		const descriptions = Object.values(alarms).map(
+			(a) => (a as { Properties?: { AlarmDescription?: string } }).Properties?.AlarmDescription,
+		)
+		expect(descriptions).toContain('Lambda error_log_notify_discord errors > 0')
+	})
 })
 
 // Issue #692: Docker アセット決定性テスト

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -172,7 +172,7 @@ describe('AwsCdkStack', () => {
 		expect(descriptions).toContain('Lambda start_daily_batch errors > 0')
 	})
 
-	test('creates error_log_notify_discord Lambda, errors alarm, and six ERROR subscription filters', () => {
+	test('creates error_log_notify_discord Lambda, errors alarm, and target ERROR subscription filters', () => {
 		const t = createTemplate()
 		const json = t.toJSON() as {
 			Resources?: Record<
@@ -195,12 +195,28 @@ describe('AwsCdkStack', () => {
 		const filters = Object.values(resources).filter(
 			(r) => r.Type === 'AWS::Logs::SubscriptionFilter',
 		)
-		expect(filters).toHaveLength(6)
-		expect(filters.map((filter) => JSON.stringify(filter))).not.toEqual(
-			expect.arrayContaining([
-				expect.stringContaining('error_log_notify_discord'),
-			]),
+		const filterIds = Object.entries(resources)
+			.filter(([, r]) => r.Type === 'AWS::Logs::SubscriptionFilter')
+			.map(([id]) => id)
+		const expectedFilterIdPrefixes = [
+			'StartDailyBatchErrorLogSubscription',
+			'SetDesiredMaxSeatsErrorLogSubscription',
+			'YoutubeOrganizeDatabaseErrorLogSubscription',
+			'CheckLiveStreamStatusErrorLogSubscription',
+			'UpdateWorkNameTrendErrorLogSubscription',
+			'SnsNotifyDiscordErrorLogSubscription',
+		]
+		expect(filters.length).toBeGreaterThanOrEqual(
+			expectedFilterIdPrefixes.length,
 		)
+		for (const expectedPrefix of expectedFilterIdPrefixes) {
+			expect(filterIds.some((id) => id.startsWith(expectedPrefix))).toBe(true)
+		}
+		expect(
+			filterIds.some((id) =>
+				id.startsWith('ErrorLogNotifyDiscordErrorLogSubscription'),
+			),
+		).toBe(false)
 
 		const logRetentionCustomResources = Object.values(resources).filter(
 			(r) => r.Type === 'Custom::LogRetention',

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -154,7 +154,7 @@ describe('AwsCdkStack', () => {
 		expect(descriptions).toContain('Lambda start_daily_batch errors > 0')
 	})
 
-	test('creates error_log_notify_discord Lambda, errors alarm, and three ERROR subscription filters', () => {
+	test('creates error_log_notify_discord Lambda, errors alarm, and six ERROR subscription filters', () => {
 		const t = createTemplate()
 		const json = t.toJSON() as {
 			Resources?: Record<
@@ -177,12 +177,17 @@ describe('AwsCdkStack', () => {
 		const filters = Object.values(resources).filter(
 			(r) => r.Type === 'AWS::Logs::SubscriptionFilter',
 		)
-		expect(filters).toHaveLength(3)
+		expect(filters).toHaveLength(6)
+		expect(filters.map((filter) => JSON.stringify(filter))).not.toEqual(
+			expect.arrayContaining([
+				expect.stringContaining('error_log_notify_discord'),
+			]),
+		)
 
 		const logRetentionCustomResources = Object.values(resources).filter(
 			(r) => r.Type === 'Custom::LogRetention',
 		)
-		expect(logRetentionCustomResources.length).toBeGreaterThanOrEqual(3)
+		expect(logRetentionCustomResources.length).toBeGreaterThanOrEqual(6)
 
 		const logsInvokePerms = Object.values(resources).filter(
 			(r) =>

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -129,19 +129,37 @@ describe('AwsCdkStack', () => {
 
 	test('defines AlarmEmail template parameter for SNS email backstop', () => {
 		const t = createTemplate()
-		t.hasParameter('AlarmEmail', { Type: 'String' })
+		t.hasParameter('AlarmEmail', { Type: 'String', Default: '' })
 	})
 
 	test('subscribes AlarmsTopic to email and Lambda notifier', () => {
 		const t = createTemplate()
+		const json = t.toJSON() as {
+			Conditions?: Record<string, unknown>
+			Resources?: Record<
+				string,
+				{
+					Type?: string
+					Condition?: string
+					Properties?: { Protocol?: string }
+				}
+			>
+		}
 		const subs = t.findResources('AWS::SNS::Subscription')
 		expect(Object.keys(subs).length).toBe(2)
+		expect(json.Conditions).toHaveProperty('HasAlarmEmail')
 		t.hasResourceProperties('AWS::SNS::Subscription', {
 			Protocol: 'email',
 		})
 		t.hasResourceProperties('AWS::SNS::Subscription', {
 			Protocol: 'lambda',
 		})
+		const emailSubscription = Object.values(json.Resources ?? {}).find(
+			(resource) =>
+				resource.Type === 'AWS::SNS::Subscription' &&
+				resource.Properties?.Protocol === 'email',
+		)
+		expect(emailSubscription?.Condition).toBe('HasAlarmEmail')
 	})
 
 	test('creates Lambda errors alarms for sns_notify_discord and start_daily_batch', () => {

--- a/system/Dockerfile.lambda
+++ b/system/Dockerfile.lambda
@@ -26,6 +26,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go build -tags lambda.norpc,timetzdata -trimpath -ldflags="-s -w" -o sns_notify_discord aws-lambda/sns_notify_discord/main.go
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
+    go build -tags lambda.norpc,timetzdata -trimpath -ldflags="-s -w" -o error_log_notify_discord aws-lambda/error_log_notify_discord/main.go
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
     go build -tags lambda.norpc,timetzdata -trimpath -ldflags="-s -w" -o start_daily_batch aws-lambda/start_daily_batch/main.go
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
@@ -42,5 +45,6 @@ COPY --from=build /var/task/set_desired_max_seats ./set_desired_max_seats
 COPY --from=build /var/task/youtube_organize_database ./youtube_organize_database
 COPY --from=build /var/task/check_live_stream_status ./check_live_stream_status
 COPY --from=build /var/task/sns_notify_discord ./sns_notify_discord
+COPY --from=build /var/task/error_log_notify_discord ./error_log_notify_discord
 COPY --from=build /var/task/start_daily_batch ./start_daily_batch
 COPY --from=build /var/task/update_work_name_trend ./update_work_name_trend

--- a/system/aws-lambda/check_live_stream_status/main.go
+++ b/system/aws-lambda/check_live_stream_status/main.go
@@ -70,6 +70,7 @@ func CheckLiveStream(ctx context.Context) (CheckLiveStreamResponse, error) {
 			slog.ErrorContext(ctx, "timeout warning in check_live_stream_status during CheckLiveStreamStatus", "err", err)
 			return okResponse(), nil
 		}
+		slog.ErrorContext(ctx, "failed to check live stream status", "err", err)
 		app.MessageToOwnerWithError(ctx, "failed to check live stream status", err)
 		return okResponse(), nil
 	}

--- a/system/aws-lambda/check_live_stream_status/main.go
+++ b/system/aws-lambda/check_live_stream_status/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 
 	"app.modules/aws-lambda/lambdautils"
@@ -25,7 +24,6 @@ type CheckLiveStreamResponse struct {
 
 type checkLiveStreamApp interface {
 	CheckLiveStreamStatus(ctx context.Context) error
-	NotifyTimeoutToOwner(ctx context.Context, err error) error
 	MessageToOwnerWithError(ctx context.Context, message string, err error)
 	CloseFirestoreClient()
 }
@@ -52,7 +50,7 @@ func CheckLiveStream(ctx context.Context) (CheckLiveStreamResponse, error) {
 
 	clientOption, err := firestoreClientOptionCheck()
 	if err != nil {
-		slog.ErrorContext(ctx, "in FirestoreClientOption",
+		slog.ErrorContext(ctx, "failed to get Firestore client option for check_live_stream_status",
 			"err", err,
 		)
 		return okResponse(), nil
@@ -60,7 +58,7 @@ func CheckLiveStream(ctx context.Context) (CheckLiveStreamResponse, error) {
 
 	app, err := newCheckWorkspaceApp(gracefulCtx, false, clientOption)
 	if err != nil {
-		slog.ErrorContext(ctx, "in NewWorkspaceApp",
+		slog.ErrorContext(ctx, "failed to init WorkspaceApp for check_live_stream_status",
 			"err", err,
 		)
 		return okResponse(), nil
@@ -69,11 +67,8 @@ func CheckLiveStream(ctx context.Context) (CheckLiveStreamResponse, error) {
 
 	if err := app.CheckLiveStreamStatus(gracefulCtx); err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			// NOTE: gracefulCtxは既にキャンセル済みのため、まだ残り時間のある元のctxを使用
-			if notifyErr := app.NotifyTimeoutToOwner(ctx, fmt.Errorf("CheckLiveStreamStatusでタイムアウト: %w", err)); notifyErr != nil {
-				return CheckLiveStreamResponse{}, fmt.Errorf("timeout notification failed: %w", notifyErr)
-			}
-			return CheckLiveStreamResponse{Result: "timeout_warning", Message: err.Error()}, nil
+			slog.ErrorContext(ctx, "timeout warning in check_live_stream_status during CheckLiveStreamStatus", "err", err)
+			return okResponse(), nil
 		}
 		app.MessageToOwnerWithError(ctx, "failed to check live stream status", err)
 		return okResponse(), nil

--- a/system/aws-lambda/check_live_stream_status/main.go
+++ b/system/aws-lambda/check_live_stream_status/main.go
@@ -11,6 +11,7 @@ import (
 	"app.modules/core/workspaceapp"
 	"app.modules/internal/logging"
 	"github.com/aws/aws-lambda-go/lambda"
+	"google.golang.org/api/option"
 )
 
 func init() {
@@ -22,6 +23,25 @@ type CheckLiveStreamResponse struct {
 	Message string `json:"message"`
 }
 
+type checkLiveStreamApp interface {
+	CheckLiveStreamStatus(ctx context.Context) error
+	NotifyTimeoutToOwner(ctx context.Context, err error) error
+	MessageToOwnerWithError(ctx context.Context, message string, err error)
+	CloseFirestoreClient()
+}
+
+var (
+	// Unit test で初期化失敗や timeout 分岐を差し替え検証できるようにしている。
+	firestoreClientOptionCheck = lambdautils.FirestoreClientOption
+	newCheckWorkspaceApp       = func(ctx context.Context, isTest bool, clientOption option.ClientOption) (checkLiveStreamApp, error) {
+		return workspaceapp.NewWorkspaceApp(ctx, isTest, clientOption)
+	}
+)
+
+func okResponse() CheckLiveStreamResponse {
+	return CheckLiveStreamResponse{Result: lambdautils.OK, Message: ""}
+}
+
 // CheckLiveStream checks the live stream status and, in case of an error, sends a message to the owner.
 func CheckLiveStream(ctx context.Context) (CheckLiveStreamResponse, error) {
 	slog.Info(utils.NameOf(CheckLiveStream))
@@ -30,18 +50,20 @@ func CheckLiveStream(ctx context.Context) (CheckLiveStreamResponse, error) {
 	gracefulCtx, cancel := lambdautils.CreateGracefulContext(ctx, lambdautils.DefaultGraceSeconds)
 	defer cancel()
 
-	clientOption, err := lambdautils.FirestoreClientOption()
+	clientOption, err := firestoreClientOptionCheck()
 	if err != nil {
-		return CheckLiveStreamResponse{}, fmt.Errorf("in FirestoreClientOption: %w", err)
+		slog.ErrorContext(ctx, "in FirestoreClientOption",
+			"err", err,
+		)
+		return okResponse(), nil
 	}
 
-	app, err := workspaceapp.NewWorkspaceApp(gracefulCtx, false, clientOption)
+	app, err := newCheckWorkspaceApp(gracefulCtx, false, clientOption)
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			// 初期化中のタイムアウト（appがないのでDiscord通知不可）
-			return CheckLiveStreamResponse{}, fmt.Errorf("timeout during NewWorkspaceApp: %w", err)
-		}
-		return CheckLiveStreamResponse{}, fmt.Errorf("in NewWorkspaceApp: %w", err)
+		slog.ErrorContext(ctx, "in NewWorkspaceApp",
+			"err", err,
+		)
+		return okResponse(), nil
 	}
 	defer app.CloseFirestoreClient()
 
@@ -54,13 +76,10 @@ func CheckLiveStream(ctx context.Context) (CheckLiveStreamResponse, error) {
 			return CheckLiveStreamResponse{Result: "timeout_warning", Message: err.Error()}, nil
 		}
 		app.MessageToOwnerWithError(ctx, "failed to check live stream status", err)
-		return CheckLiveStreamResponse{}, err
+		return okResponse(), nil
 	}
 
-	return CheckLiveStreamResponse{
-		Result:  lambdautils.OK,
-		Message: "",
-	}, nil
+	return okResponse(), nil
 }
 
 func main() {

--- a/system/aws-lambda/check_live_stream_status/main_test.go
+++ b/system/aws-lambda/check_live_stream_status/main_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"app.modules/aws-lambda/lambdautils"
+	"google.golang.org/api/option"
+)
+
+type mockCheckLiveStreamApp struct {
+	checkErr           error
+	notifyTimeoutErr   error
+	messageToOwnerMsgs []string
+	closed             bool
+}
+
+func (m *mockCheckLiveStreamApp) CheckLiveStreamStatus(ctx context.Context) error {
+	return m.checkErr
+}
+
+func (m *mockCheckLiveStreamApp) NotifyTimeoutToOwner(ctx context.Context, err error) error {
+	if m.notifyTimeoutErr != nil {
+		return m.notifyTimeoutErr
+	}
+	return nil
+}
+
+func (m *mockCheckLiveStreamApp) MessageToOwnerWithError(ctx context.Context, message string, err error) {
+	m.messageToOwnerMsgs = append(m.messageToOwnerMsgs, message+": "+err.Error())
+}
+
+func (m *mockCheckLiveStreamApp) CloseFirestoreClient() {
+	m.closed = true
+}
+
+func TestCheckLiveStreamFirestoreInitFailureReturnsOK(t *testing.T) {
+	restore := stubCheckLiveStreamDeps(t, errors.New("cred"), nil, nil)
+	defer restore()
+
+	resp, err := CheckLiveStream(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if resp.Result != lambdautils.OK {
+		t.Fatalf("expected ok result, got %#v", resp)
+	}
+}
+
+func TestCheckLiveStreamWorkspaceInitFailureReturnsOK(t *testing.T) {
+	restore := stubCheckLiveStreamDeps(t, nil, errors.New("init failed"), nil)
+	defer restore()
+
+	resp, err := CheckLiveStream(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if resp.Result != lambdautils.OK {
+		t.Fatalf("expected ok result, got %#v", resp)
+	}
+}
+
+func TestCheckLiveStreamHandlerFailureReturnsOKAfterOwnerMessage(t *testing.T) {
+	app := &mockCheckLiveStreamApp{
+		checkErr: errors.New("youtube api down"),
+	}
+	restore := stubCheckLiveStreamDeps(t, nil, nil, app)
+	defer restore()
+
+	resp, err := CheckLiveStream(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if resp.Result != lambdautils.OK {
+		t.Fatalf("expected ok result, got %#v", resp)
+	}
+	if len(app.messageToOwnerMsgs) != 1 {
+		t.Fatalf("expected one owner message, got %#v", app.messageToOwnerMsgs)
+	}
+	if !app.closed {
+		t.Fatal("expected CloseFirestoreClient to be called")
+	}
+}
+
+func TestCheckLiveStreamTimeoutNotifyFailureReturnsError(t *testing.T) {
+	app := &mockCheckLiveStreamApp{
+		checkErr:         context.DeadlineExceeded,
+		notifyTimeoutErr: errors.New("notify failed"),
+	}
+	restore := stubCheckLiveStreamDeps(t, nil, nil, app)
+	defer restore()
+
+	resp, err := CheckLiveStream(context.Background())
+	if err == nil {
+		t.Fatal("expected error when timeout notification fails")
+	}
+	if resp != (CheckLiveStreamResponse{}) {
+		t.Fatalf("expected empty response, got %#v", resp)
+	}
+	if !strings.Contains(err.Error(), "timeout notification failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func stubCheckLiveStreamDeps(
+	t *testing.T,
+	firestoreErr error,
+	newAppErr error,
+	app checkLiveStreamApp,
+) func() {
+	t.Helper()
+	origF := firestoreClientOptionCheck
+	origN := newCheckWorkspaceApp
+
+	firestoreClientOptionCheck = func() (option.ClientOption, error) {
+		return option.WithoutAuthentication(), firestoreErr
+	}
+	newCheckWorkspaceApp = func(ctx context.Context, isTest bool, clientOption option.ClientOption) (checkLiveStreamApp, error) {
+		if newAppErr != nil {
+			return nil, newAppErr
+		}
+		return app, nil
+	}
+
+	return func() {
+		firestoreClientOptionCheck = origF
+		newCheckWorkspaceApp = origN
+	}
+}

--- a/system/aws-lambda/check_live_stream_status/main_test.go
+++ b/system/aws-lambda/check_live_stream_status/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 
 	"app.modules/aws-lambda/lambdautils"
@@ -12,20 +11,12 @@ import (
 
 type mockCheckLiveStreamApp struct {
 	checkErr           error
-	notifyTimeoutErr   error
 	messageToOwnerMsgs []string
 	closed             bool
 }
 
 func (m *mockCheckLiveStreamApp) CheckLiveStreamStatus(ctx context.Context) error {
 	return m.checkErr
-}
-
-func (m *mockCheckLiveStreamApp) NotifyTimeoutToOwner(ctx context.Context, err error) error {
-	if m.notifyTimeoutErr != nil {
-		return m.notifyTimeoutErr
-	}
-	return nil
 }
 
 func (m *mockCheckLiveStreamApp) MessageToOwnerWithError(ctx context.Context, message string, err error) {
@@ -84,23 +75,22 @@ func TestCheckLiveStreamHandlerFailureReturnsOKAfterOwnerMessage(t *testing.T) {
 	}
 }
 
-func TestCheckLiveStreamTimeoutNotifyFailureReturnsError(t *testing.T) {
+func TestCheckLiveStreamTimeoutReturnsOK(t *testing.T) {
 	app := &mockCheckLiveStreamApp{
-		checkErr:         context.DeadlineExceeded,
-		notifyTimeoutErr: errors.New("notify failed"),
+		checkErr: context.DeadlineExceeded,
 	}
 	restore := stubCheckLiveStreamDeps(t, nil, nil, app)
 	defer restore()
 
 	resp, err := CheckLiveStream(context.Background())
-	if err == nil {
-		t.Fatal("expected error when timeout notification fails")
+	if err != nil {
+		t.Fatalf("expected nil error on handled timeout, got %v", err)
 	}
-	if resp != (CheckLiveStreamResponse{}) {
-		t.Fatalf("expected empty response, got %#v", resp)
+	if resp.Result != lambdautils.OK {
+		t.Fatalf("expected ok result, got %#v", resp)
 	}
-	if !strings.Contains(err.Error(), "timeout notification failed") {
-		t.Fatalf("unexpected error: %v", err)
+	if !app.closed {
+		t.Fatal("expected CloseFirestoreClient to be called")
 	}
 }
 

--- a/system/aws-lambda/error_log_notify_discord/main.go
+++ b/system/aws-lambda/error_log_notify_discord/main.go
@@ -47,6 +47,18 @@ func handler(ctx context.Context, ev events.CloudwatchLogsEvent) error {
 
 	// NOTE: 定期 3 Lambda と違い、この Lambda は通知経路そのものの故障を
 	// Errors Alarm + Email バックストップで拾いたいため、初期化や parse 失敗は return err を維持する。
+	data, err := ev.AWSLogs.Parse()
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to parse CloudWatch Logs payload", "err", err)
+		return fmt.Errorf("parse CloudWatch Logs: %w", err)
+	}
+
+	chunks := buildDiscordMessageChunks(&data, invokerRequestIDFromContext(ctx))
+	if len(chunks) == 0 {
+		slog.WarnContext(ctx, "CloudWatch Logs event had no log events")
+		return nil
+	}
+
 	clientOption, err := firestoreClientOptionErrorLog()
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to get Firestore client option for error_log_notify_discord", "err", err)
@@ -59,18 +71,6 @@ func handler(ctx context.Context, ev events.CloudwatchLogsEvent) error {
 		return err
 	}
 	defer app.CloseFirestoreClient()
-
-	data, err := ev.AWSLogs.Parse()
-	if err != nil {
-		slog.ErrorContext(ctx, "failed to parse CloudWatch Logs payload", "err", err)
-		return fmt.Errorf("parse CloudWatch Logs: %w", err)
-	}
-
-	chunks := buildDiscordMessageChunks(&data, invokerRequestIDFromContext(ctx))
-	if len(chunks) == 0 {
-		slog.WarnContext(ctx, "CloudWatch Logs event had no log events")
-		return nil
-	}
 
 	for _, chunk := range chunks {
 		if err := app.MessageToOwnerOrError(gracefulCtx, chunk); err != nil {

--- a/system/aws-lambda/error_log_notify_discord/main.go
+++ b/system/aws-lambda/error_log_notify_discord/main.go
@@ -94,13 +94,11 @@ func buildDiscordMessageChunks(data *events.CloudwatchLogsData, invokerRequestID
 
 	eventChunks := make([]string, 0, len(data.LogEvents))
 	for _, le := range data.LogEvents {
-		var b strings.Builder
-		_, _ = fmt.Fprintf(&b, "--- id=%s ts=%d ---\n%s\n", le.ID, le.Timestamp, le.Message)
-		eventChunks = append(eventChunks, b.String())
+		eventChunks = append(eventChunks, le.Message+"\n")
 	}
 
-	headerWithoutChunk := fmt.Sprintf("%slogGroup=%s\nlogStream=%s\ninvoker_request_id=%s\n",
-		notifyPrefix, data.LogGroup, data.LogStream, invokerRequestID)
+	headerWithoutChunk := fmt.Sprintf("%slogGroup=%s\ninvoker_request_id=%s\n",
+		notifyPrefix, data.LogGroup, invokerRequestID)
 	bodyLimit := discordBodyLimit(headerWithoutChunk, 1)
 
 	var bodyChunks []string

--- a/system/aws-lambda/error_log_notify_discord/main.go
+++ b/system/aws-lambda/error_log_notify_discord/main.go
@@ -46,8 +46,7 @@ func handler(ctx context.Context, ev events.CloudwatchLogsEvent) error {
 	gracefulCtx, cancel := lambdautils.CreateGracefulContext(ctx, lambdautils.DefaultGraceSeconds)
 	defer cancel()
 
-	// NOTE: 定期 3 Lambda と違い、この Lambda は通知経路そのものの故障を
-	// Errors Alarm + Email バックストップで拾いたいため、初期化や parse 失敗は return err を維持する。
+	// この Lambda は通知経路そのものの故障を Errors Alarm + Email バックストップで拾いたいため、初期化や parse 失敗は return err を維持する。
 	data, err := ev.AWSLogs.Parse()
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to parse CloudWatch Logs payload", "err", err)

--- a/system/aws-lambda/error_log_notify_discord/main.go
+++ b/system/aws-lambda/error_log_notify_discord/main.go
@@ -53,7 +53,7 @@ func handler(ctx context.Context, ev events.CloudwatchLogsEvent) error {
 		return fmt.Errorf("parse CloudWatch Logs: %w", err)
 	}
 
-	chunks := buildDiscordMessageChunks(&data, invokerRequestIDFromContext(ctx))
+	chunks := buildDiscordMessageChunks(&data, notifierRequestIDFromContext(ctx))
 	if len(chunks) == 0 {
 		slog.WarnContext(ctx, "CloudWatch Logs event had no log events")
 		return nil
@@ -82,14 +82,14 @@ func handler(ctx context.Context, ev events.CloudwatchLogsEvent) error {
 	return nil
 }
 
-func invokerRequestIDFromContext(ctx context.Context) string {
+func notifierRequestIDFromContext(ctx context.Context) string {
 	if lc, ok := lambdacontext.FromContext(ctx); ok {
 		return lc.AwsRequestID
 	}
 	return ""
 }
 
-func buildDiscordMessageChunks(data *events.CloudwatchLogsData, invokerRequestID string) []string {
+func buildDiscordMessageChunks(data *events.CloudwatchLogsData, notifierRequestID string) []string {
 	if len(data.LogEvents) == 0 {
 		return nil
 	}
@@ -108,8 +108,8 @@ func buildDiscordMessageChunks(data *events.CloudwatchLogsData, invokerRequestID
 		bodyLanguage = "text"
 	}
 
-	headerWithoutChunk := fmt.Sprintf("%slogGroup=%s\ninvoker_request_id=%s\n",
-		notifyPrefix, data.LogGroup, invokerRequestID)
+	headerWithoutChunk := fmt.Sprintf("%slogGroup=%s\nnotifier_request_id=%s\n",
+		notifyPrefix, data.LogGroup, notifierRequestID)
 	bodyLimit := discordBodyLimit(headerWithoutChunk, bodyLanguage, 1)
 
 	var bodyChunks []string

--- a/system/aws-lambda/error_log_notify_discord/main.go
+++ b/system/aws-lambda/error_log_notify_discord/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -93,18 +95,27 @@ func buildDiscordMessageChunks(data *events.CloudwatchLogsData, invokerRequestID
 	}
 
 	eventChunks := make([]string, 0, len(data.LogEvents))
+	allEventsAreJSON := true
 	for _, le := range data.LogEvents {
-		eventChunks = append(eventChunks, le.Message+"\n")
+		message, ok := formatLogEventMessage(le.Message)
+		if !ok {
+			allEventsAreJSON = false
+		}
+		eventChunks = append(eventChunks, message+"\n")
+	}
+	bodyLanguage := "json"
+	if !allEventsAreJSON {
+		bodyLanguage = "text"
 	}
 
 	headerWithoutChunk := fmt.Sprintf("%slogGroup=%s\ninvoker_request_id=%s\n",
 		notifyPrefix, data.LogGroup, invokerRequestID)
-	bodyLimit := discordBodyLimit(headerWithoutChunk, 1)
+	bodyLimit := discordBodyLimit(headerWithoutChunk, bodyLanguage, 1)
 
 	var bodyChunks []string
 	for {
 		bodyChunks = buildDiscordBodyChunks(eventChunks, bodyLimit)
-		nextBodyLimit := discordBodyLimit(headerWithoutChunk, len(bodyChunks))
+		nextBodyLimit := discordBodyLimit(headerWithoutChunk, bodyLanguage, len(bodyChunks))
 		if nextBodyLimit == bodyLimit {
 			break
 		}
@@ -114,18 +125,31 @@ func buildDiscordMessageChunks(data *events.CloudwatchLogsData, invokerRequestID
 	total := len(bodyChunks)
 	for i, body := range bodyChunks {
 		header := fmt.Sprintf("%schunk=%d/%d\n", headerWithoutChunk, i+1, total)
-		messageChunks = append(messageChunks, header+body)
+		messageChunks = append(messageChunks, header+wrapDiscordCodeBlock(bodyLanguage, body))
 	}
 
 	return messageChunks
 }
 
-func discordBodyLimit(headerWithoutChunk string, totalChunks int) int {
+func formatLogEventMessage(message string) (string, bool) {
+	var b bytes.Buffer
+	if err := json.Indent(&b, []byte(message), "", "  "); err != nil {
+		return message, false
+	}
+	return b.String(), true
+}
+
+func wrapDiscordCodeBlock(language string, body string) string {
+	return fmt.Sprintf("```%s\n%s```", language, body)
+}
+
+func discordBodyLimit(headerWithoutChunk string, bodyLanguage string, totalChunks int) int {
 	if totalChunks < 1 {
 		totalChunks = 1
 	}
 	chunkHeader := fmt.Sprintf("chunk=%d/%d\n", totalChunks, totalChunks)
-	bodyLimit := maxDiscordMessageLength - len([]rune(headerWithoutChunk)) - len([]rune(chunkHeader))
+	codeBlockOverhead := len([]rune(fmt.Sprintf("```%s\n", bodyLanguage))) + len([]rune("```"))
+	bodyLimit := maxDiscordMessageLength - len([]rune(headerWithoutChunk)) - len([]rune(chunkHeader)) - codeBlockOverhead
 	if bodyLimit <= 0 {
 		return 1
 	}

--- a/system/aws-lambda/error_log_notify_discord/main.go
+++ b/system/aws-lambda/error_log_notify_discord/main.go
@@ -62,13 +62,13 @@ func handler(ctx context.Context, ev events.CloudwatchLogsEvent) error {
 	clientOption, err := firestoreClientOptionErrorLog()
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to get Firestore client option for error_log_notify_discord", "err", err)
-		return err
+		return fmt.Errorf("get Firestore client option: %w", err)
 	}
 
 	app, err := newErrorLogWorkspaceApp(gracefulCtx, false, clientOption)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to init WorkspaceApp for error_log_notify_discord", "err", err)
-		return err
+		return fmt.Errorf("init WorkspaceApp: %w", err)
 	}
 	defer app.CloseFirestoreClient()
 

--- a/system/aws-lambda/error_log_notify_discord/main.go
+++ b/system/aws-lambda/error_log_notify_discord/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"unicode/utf8"
 
 	"app.modules/aws-lambda/lambdautils"
 	coreutils "app.modules/core/utils"
@@ -148,8 +149,13 @@ func discordBodyLimit(headerWithoutChunk string, bodyLanguage string, totalChunk
 		totalChunks = 1
 	}
 	chunkHeader := fmt.Sprintf("chunk=%d/%d\n", totalChunks, totalChunks)
-	codeBlockOverhead := len([]rune(fmt.Sprintf("```%s\n", bodyLanguage))) + len([]rune("```"))
-	bodyLimit := maxDiscordMessageLength - len([]rune(headerWithoutChunk)) - len([]rune(chunkHeader)) - codeBlockOverhead
+	codeBlockOpenRunes := utf8.RuneCountInString(fmt.Sprintf("```%s\n", bodyLanguage))
+	codeBlockCloseRunes := utf8.RuneCountInString("```")
+	bodyLimit := maxDiscordMessageLength -
+		utf8.RuneCountInString(headerWithoutChunk) -
+		utf8.RuneCountInString(chunkHeader) -
+		codeBlockOpenRunes -
+		codeBlockCloseRunes
 	if bodyLimit <= 0 {
 		return 1
 	}
@@ -176,7 +182,7 @@ func buildDiscordBodyChunks(parts []string, limit int) []string {
 
 	for _, part := range parts {
 		for _, piece := range splitToDiscordSizedChunks(part, limit) {
-			pieceRuneLength := len([]rune(piece))
+			pieceRuneLength := utf8.RuneCountInString(piece)
 			if current.Len() == 0 {
 				current.WriteString(piece)
 				currentRuneLength = pieceRuneLength

--- a/system/aws-lambda/error_log_notify_discord/main.go
+++ b/system/aws-lambda/error_log_notify_discord/main.go
@@ -92,15 +92,80 @@ func buildDiscordMessageChunks(data *events.CloudwatchLogsData, invokerRequestID
 		return nil
 	}
 
-	var b strings.Builder
-	_, _ = fmt.Fprintf(&b, "%slogGroup=%s\nlogStream=%s\ninvoker_request_id=%s\n",
-		notifyPrefix, data.LogGroup, data.LogStream, invokerRequestID)
-
+	eventChunks := make([]string, 0, len(data.LogEvents))
 	for _, le := range data.LogEvents {
+		var b strings.Builder
 		_, _ = fmt.Fprintf(&b, "--- id=%s ts=%d ---\n%s\n", le.ID, le.Timestamp, le.Message)
+		eventChunks = append(eventChunks, b.String())
 	}
 
-	return splitToDiscordSizedChunks(b.String(), maxDiscordMessageLength)
+	headerWithoutChunk := fmt.Sprintf("%slogGroup=%s\nlogStream=%s\ninvoker_request_id=%s\n",
+		notifyPrefix, data.LogGroup, data.LogStream, invokerRequestID)
+	bodyLimit := discordBodyLimit(headerWithoutChunk, 1)
+
+	var bodyChunks []string
+	for {
+		bodyChunks = buildDiscordBodyChunks(eventChunks, bodyLimit)
+		nextBodyLimit := discordBodyLimit(headerWithoutChunk, len(bodyChunks))
+		if nextBodyLimit == bodyLimit {
+			break
+		}
+		bodyLimit = nextBodyLimit
+	}
+	messageChunks := make([]string, 0, len(bodyChunks))
+	total := len(bodyChunks)
+	for i, body := range bodyChunks {
+		header := fmt.Sprintf("%schunk=%d/%d\n", headerWithoutChunk, i+1, total)
+		messageChunks = append(messageChunks, header+body)
+	}
+
+	return messageChunks
+}
+
+func discordBodyLimit(headerWithoutChunk string, totalChunks int) int {
+	if totalChunks < 1 {
+		totalChunks = 1
+	}
+	chunkHeader := fmt.Sprintf("chunk=%d/%d\n", totalChunks, totalChunks)
+	bodyLimit := maxDiscordMessageLength - len([]rune(headerWithoutChunk)) - len([]rune(chunkHeader))
+	if bodyLimit <= 0 {
+		return 1
+	}
+	return bodyLimit
+}
+
+func buildDiscordBodyChunks(parts []string, limit int) []string {
+	if len(parts) == 0 {
+		return nil
+	}
+
+	chunks := make([]string, 0, len(parts))
+	var current strings.Builder
+
+	flushCurrent := func() {
+		if current.Len() == 0 {
+			return
+		}
+		chunks = append(chunks, current.String())
+		current.Reset()
+	}
+
+	for _, part := range parts {
+		for _, piece := range splitToDiscordSizedChunks(part, limit) {
+			if current.Len() == 0 {
+				current.WriteString(piece)
+				continue
+			}
+
+			if len([]rune(current.String()))+len([]rune(piece)) > limit {
+				flushCurrent()
+			}
+			current.WriteString(piece)
+		}
+	}
+
+	flushCurrent()
+	return chunks
 }
 
 // splitToDiscordSizedChunks splits s into UTF-8 safe chunks no longer than limit runes.

--- a/system/aws-lambda/error_log_notify_discord/main.go
+++ b/system/aws-lambda/error_log_notify_discord/main.go
@@ -163,6 +163,7 @@ func buildDiscordBodyChunks(parts []string, limit int) []string {
 
 	chunks := make([]string, 0, len(parts))
 	var current strings.Builder
+	currentRuneLength := 0
 
 	flushCurrent := func() {
 		if current.Len() == 0 {
@@ -170,19 +171,23 @@ func buildDiscordBodyChunks(parts []string, limit int) []string {
 		}
 		chunks = append(chunks, current.String())
 		current.Reset()
+		currentRuneLength = 0
 	}
 
 	for _, part := range parts {
 		for _, piece := range splitToDiscordSizedChunks(part, limit) {
+			pieceRuneLength := len([]rune(piece))
 			if current.Len() == 0 {
 				current.WriteString(piece)
+				currentRuneLength = pieceRuneLength
 				continue
 			}
 
-			if len([]rune(current.String()))+len([]rune(piece)) > limit {
+			if currentRuneLength+pieceRuneLength > limit {
 				flushCurrent()
 			}
 			current.WriteString(piece)
+			currentRuneLength += pieceRuneLength
 		}
 	}
 

--- a/system/aws-lambda/error_log_notify_discord/main.go
+++ b/system/aws-lambda/error_log_notify_discord/main.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"app.modules/aws-lambda/lambdautils"
+	coreutils "app.modules/core/utils"
+	"app.modules/core/workspaceapp"
+	"app.modules/internal/logging"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-lambda-go/lambdacontext"
+	"google.golang.org/api/option"
+)
+
+func init() {
+	logging.InitLogger()
+}
+
+const (
+	maxDiscordMessageLength = 1800
+	notifyPrefix            = "[ERROR_LOG] "
+)
+
+type errorLogNotifyApp interface {
+	MessageToOwnerOrError(ctx context.Context, message string) error
+	CloseFirestoreClient()
+}
+
+var (
+	// Unit test で初期化失敗や通知失敗を差し替え検証できるようにしている。
+	firestoreClientOptionErrorLog = lambdautils.FirestoreClientOption
+	newErrorLogWorkspaceApp       = func(ctx context.Context, isTest bool, clientOption option.ClientOption) (errorLogNotifyApp, error) {
+		return workspaceapp.NewWorkspaceApp(ctx, isTest, clientOption)
+	}
+)
+
+func handler(ctx context.Context, ev events.CloudwatchLogsEvent) error {
+	gracefulCtx, cancel := lambdautils.CreateGracefulContext(ctx, lambdautils.DefaultGraceSeconds)
+	defer cancel()
+
+	// NOTE: 定期 3 Lambda と違い、この Lambda は通知経路そのものの故障を
+	// Errors Alarm + Email バックストップで拾いたいため、初期化や parse 失敗は return err を維持する。
+	clientOption, err := firestoreClientOptionErrorLog()
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to get Firestore client option for error_log_notify_discord", "err", err)
+		return err
+	}
+
+	app, err := newErrorLogWorkspaceApp(gracefulCtx, false, clientOption)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to init WorkspaceApp for error_log_notify_discord", "err", err)
+		return err
+	}
+	defer app.CloseFirestoreClient()
+
+	data, err := ev.AWSLogs.Parse()
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to parse CloudWatch Logs payload", "err", err)
+		return fmt.Errorf("parse CloudWatch Logs: %w", err)
+	}
+
+	chunks := buildDiscordMessageChunks(&data, invokerRequestIDFromContext(ctx))
+	if len(chunks) == 0 {
+		slog.WarnContext(ctx, "CloudWatch Logs event had no log events")
+		return nil
+	}
+
+	for _, chunk := range chunks {
+		if err := app.MessageToOwnerOrError(gracefulCtx, chunk); err != nil {
+			slog.ErrorContext(ctx, "failed to send log notification to owner", "err", err)
+			return fmt.Errorf("send log notification to owner: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func invokerRequestIDFromContext(ctx context.Context) string {
+	if lc, ok := lambdacontext.FromContext(ctx); ok {
+		return lc.AwsRequestID
+	}
+	return ""
+}
+
+func buildDiscordMessageChunks(data *events.CloudwatchLogsData, invokerRequestID string) []string {
+	if len(data.LogEvents) == 0 {
+		return nil
+	}
+
+	var b strings.Builder
+	_, _ = fmt.Fprintf(&b, "%slogGroup=%s\nlogStream=%s\ninvoker_request_id=%s\n",
+		notifyPrefix, data.LogGroup, data.LogStream, invokerRequestID)
+
+	for _, le := range data.LogEvents {
+		_, _ = fmt.Fprintf(&b, "--- id=%s ts=%d ---\n%s\n", le.ID, le.Timestamp, le.Message)
+	}
+
+	return splitToDiscordSizedChunks(b.String(), maxDiscordMessageLength)
+}
+
+// splitToDiscordSizedChunks splits s into UTF-8 safe chunks no longer than limit runes.
+func splitToDiscordSizedChunks(s string, limit int) []string {
+	return coreutils.SplitStringRunes(s, limit)
+}
+
+func main() {
+	lambda.Start(handler)
+}

--- a/system/aws-lambda/error_log_notify_discord/main_test.go
+++ b/system/aws-lambda/error_log_notify_discord/main_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -48,8 +49,41 @@ func TestBuildDiscordMessageChunksIncludesLogLines(t *testing.T) {
 	if !strings.Contains(chunks[0], "invoker_request_id=req-1") {
 		t.Fatalf("expected invoker request id: %q", chunks[0])
 	}
+	if !strings.Contains(chunks[0], "chunk=1/1") {
+		t.Fatalf("expected chunk number: %q", chunks[0])
+	}
 	if !strings.Contains(chunks[0], `"msg":"boom"`) {
 		t.Fatalf("expected raw message: %q", chunks[0])
+	}
+}
+
+func TestBuildDiscordMessageChunksIncludesHeaderInEveryChunk(t *testing.T) {
+	data := &events.CloudwatchLogsData{
+		LogGroup:  "/aws/lambda/check_live_stream_status",
+		LogStream: "2025/01/01/[$LATEST]abc",
+		LogEvents: []events.CloudwatchLogsLogEvent{
+			{ID: "1", Timestamp: 123, Message: strings.Repeat("勉強🚀", 2000)},
+		},
+	}
+
+	chunks := buildDiscordMessageChunks(data, "req-1")
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+	for i, chunk := range chunks {
+		if len([]rune(chunk)) > maxDiscordMessageLength {
+			t.Fatalf("chunk %d over limit: %d", i, len([]rune(chunk)))
+		}
+		if !strings.Contains(chunk, "/aws/lambda/check_live_stream_status") {
+			t.Fatalf("expected log group in chunk %d: %q", i, chunk)
+		}
+		if !strings.Contains(chunk, "logStream=2025/01/01/[$LATEST]abc") {
+			t.Fatalf("expected log stream in chunk %d: %q", i, chunk)
+		}
+		expectedChunkNumber := "chunk=" + strconv.Itoa(i+1) + "/" + strconv.Itoa(len(chunks))
+		if !strings.Contains(chunk, expectedChunkNumber) {
+			t.Fatalf("expected %s in chunk %d: %q", expectedChunkNumber, i, chunk)
+		}
 	}
 }
 

--- a/system/aws-lambda/error_log_notify_discord/main_test.go
+++ b/system/aws-lambda/error_log_notify_discord/main_test.go
@@ -46,8 +46,8 @@ func TestBuildDiscordMessageChunksIncludesLogLines(t *testing.T) {
 	if !strings.Contains(chunks[0], "/aws/lambda/youtube_organize_database") {
 		t.Fatalf("expected log group in chunk: %q", chunks[0])
 	}
-	if !strings.Contains(chunks[0], "invoker_request_id=req-1") {
-		t.Fatalf("expected invoker request id: %q", chunks[0])
+	if !strings.Contains(chunks[0], "notifier_request_id=req-1") {
+		t.Fatalf("expected notifier request id: %q", chunks[0])
 	}
 	if !strings.Contains(chunks[0], "chunk=1/1") {
 		t.Fatalf("expected chunk number: %q", chunks[0])

--- a/system/aws-lambda/error_log_notify_discord/main_test.go
+++ b/system/aws-lambda/error_log_notify_discord/main_test.go
@@ -139,7 +139,14 @@ func TestHandlerReturnsErrorWhenWorkspaceInitFails(t *testing.T) {
 	restore := stubErrorLogNotifyDeps(t, nil, errors.New("workspace init failed"), nil)
 	defer restore()
 
-	err := handler(context.Background(), events.CloudwatchLogsEvent{})
+	ev := mustCloudwatchLogsEvent(t, events.CloudwatchLogsData{
+		LogGroup: "/aws/lambda/check_live_stream_status",
+		LogEvents: []events.CloudwatchLogsLogEvent{
+			{ID: "1", Timestamp: 123, Message: `{"level":"ERROR","msg":"boom"}`},
+		},
+	})
+
+	err := handler(context.Background(), ev)
 	if err == nil || !strings.Contains(err.Error(), "workspace init failed") {
 		t.Fatalf("expected workspace init error, got %v", err)
 	}
@@ -195,7 +202,14 @@ func TestHandlerReturnsErrorWhenFirestoreInitFails(t *testing.T) {
 	restore := stubErrorLogNotifyDeps(t, errors.New("firestore init failed"), nil, nil)
 	defer restore()
 
-	err := handler(context.Background(), events.CloudwatchLogsEvent{})
+	ev := mustCloudwatchLogsEvent(t, events.CloudwatchLogsData{
+		LogGroup: "/aws/lambda/check_live_stream_status",
+		LogEvents: []events.CloudwatchLogsLogEvent{
+			{ID: "1", Timestamp: 123, Message: `{"level":"ERROR","msg":"boom"}`},
+		},
+	})
+
+	err := handler(context.Background(), ev)
 	if err == nil || !strings.Contains(err.Error(), "firestore init failed") {
 		t.Fatalf("expected firestore init error, got %v", err)
 	}
@@ -214,8 +228,8 @@ func TestHandlerReturnsErrorWhenPayloadParseFails(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "parse CloudWatch Logs") {
 		t.Fatalf("expected parse error, got %v", err)
 	}
-	if !app.closed {
-		t.Fatal("expected CloseFirestoreClient")
+	if app.closed {
+		t.Fatal("expected no WorkspaceApp initialization before payload parse succeeds")
 	}
 }
 
@@ -235,8 +249,8 @@ func TestHandlerReturnsNilWhenNoLogEvents(t *testing.T) {
 	if len(app.messages) != 0 {
 		t.Fatalf("expected no owner messages, got %#v", app.messages)
 	}
-	if !app.closed {
-		t.Fatal("expected CloseFirestoreClient")
+	if app.closed {
+		t.Fatal("expected no WorkspaceApp initialization for empty log events")
 	}
 }
 

--- a/system/aws-lambda/error_log_notify_discord/main_test.go
+++ b/system/aws-lambda/error_log_notify_discord/main_test.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/aws/aws-lambda-go/events"
+	"google.golang.org/api/option"
+)
+
+type mockErrorLogNotifyApp struct {
+	sendErr  error
+	messages []string
+	closed   bool
+}
+
+func (m *mockErrorLogNotifyApp) MessageToOwnerOrError(ctx context.Context, message string) error {
+	m.messages = append(m.messages, message)
+	return m.sendErr
+}
+
+func (m *mockErrorLogNotifyApp) CloseFirestoreClient() {
+	m.closed = true
+}
+
+func TestBuildDiscordMessageChunksIncludesLogLines(t *testing.T) {
+	data := &events.CloudwatchLogsData{
+		LogGroup:  "/aws/lambda/youtube_organize_database",
+		LogStream: "2025/01/01/[$LATEST]abc",
+		LogEvents: []events.CloudwatchLogsLogEvent{
+			{ID: "1", Timestamp: 123, Message: `{"level":"ERROR","msg":"boom"}`},
+		},
+	}
+	chunks := buildDiscordMessageChunks(data, "req-1")
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if !strings.Contains(chunks[0], "/aws/lambda/youtube_organize_database") {
+		t.Fatalf("expected log group in chunk: %q", chunks[0])
+	}
+	if !strings.Contains(chunks[0], "invoker_request_id=req-1") {
+		t.Fatalf("expected invoker request id: %q", chunks[0])
+	}
+	if !strings.Contains(chunks[0], `"msg":"boom"`) {
+		t.Fatalf("expected raw message: %q", chunks[0])
+	}
+}
+
+func TestSplitToDiscordSizedChunksUTF8Safe(t *testing.T) {
+	long := strings.Repeat("勉強🚀", 400)
+	chunks := splitToDiscordSizedChunks(long, 200)
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+	for _, c := range chunks {
+		if len([]rune(c)) > 200 {
+			t.Fatalf("chunk over limit: %d", len([]rune(c)))
+		}
+		if !utf8.ValidString(c) {
+			t.Fatalf("invalid utf-8: %q", c)
+		}
+	}
+}
+
+func TestHandlerReturnsErrorWhenWorkspaceInitFails(t *testing.T) {
+	restore := stubErrorLogNotifyDeps(t, nil, errors.New("workspace init failed"), nil)
+	defer restore()
+
+	err := handler(context.Background(), events.CloudwatchLogsEvent{})
+	if err == nil || !strings.Contains(err.Error(), "workspace init failed") {
+		t.Fatalf("expected workspace init error, got %v", err)
+	}
+}
+
+func TestHandlerReturnsErrorWhenOwnerMessageFails(t *testing.T) {
+	app := &mockErrorLogNotifyApp{sendErr: errors.New("discord unavailable")}
+	restore := stubErrorLogNotifyDeps(t, nil, nil, app)
+	defer restore()
+
+	ev := mustCloudwatchLogsEvent(t, events.CloudwatchLogsData{
+		LogGroup:  "/aws/lambda/check_live_stream_status",
+		LogStream: "2025/01/01/[$LATEST]abc",
+		LogEvents: []events.CloudwatchLogsLogEvent{
+			{ID: "1", Timestamp: 123, Message: `{"level":"ERROR","msg":"boom"}`},
+		},
+	})
+
+	err := handler(context.Background(), ev)
+	if err == nil || !strings.Contains(err.Error(), "send log notification to owner") {
+		t.Fatalf("expected owner send error, got %v", err)
+	}
+	if !app.closed {
+		t.Fatal("expected CloseFirestoreClient")
+	}
+}
+
+func TestHandlerSuccessSendsAllChunksAndClosesClient(t *testing.T) {
+	app := &mockErrorLogNotifyApp{}
+	restore := stubErrorLogNotifyDeps(t, nil, nil, app)
+	defer restore()
+
+	ev := mustCloudwatchLogsEvent(t, events.CloudwatchLogsData{
+		LogGroup:  "/aws/lambda/check_live_stream_status",
+		LogStream: "2025/01/01/[$LATEST]abc",
+		LogEvents: []events.CloudwatchLogsLogEvent{
+			{ID: "1", Timestamp: 123, Message: strings.Repeat("勉強🚀", 2000)},
+		},
+	})
+
+	if err := handler(context.Background(), ev); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(app.messages) < 2 {
+		t.Fatalf("expected multiple chunks to be sent, got %d", len(app.messages))
+	}
+	if !app.closed {
+		t.Fatal("expected CloseFirestoreClient")
+	}
+}
+
+func TestHandlerReturnsErrorWhenFirestoreInitFails(t *testing.T) {
+	restore := stubErrorLogNotifyDeps(t, errors.New("firestore init failed"), nil, nil)
+	defer restore()
+
+	err := handler(context.Background(), events.CloudwatchLogsEvent{})
+	if err == nil || !strings.Contains(err.Error(), "firestore init failed") {
+		t.Fatalf("expected firestore init error, got %v", err)
+	}
+}
+
+func TestHandlerReturnsErrorWhenPayloadParseFails(t *testing.T) {
+	app := &mockErrorLogNotifyApp{}
+	restore := stubErrorLogNotifyDeps(t, nil, nil, app)
+	defer restore()
+
+	ev := events.CloudwatchLogsEvent{
+		AWSLogs: events.CloudwatchLogsRawData{Data: "not-base64"},
+	}
+
+	err := handler(context.Background(), ev)
+	if err == nil || !strings.Contains(err.Error(), "parse CloudWatch Logs") {
+		t.Fatalf("expected parse error, got %v", err)
+	}
+	if !app.closed {
+		t.Fatal("expected CloseFirestoreClient")
+	}
+}
+
+func TestHandlerReturnsNilWhenNoLogEvents(t *testing.T) {
+	app := &mockErrorLogNotifyApp{}
+	restore := stubErrorLogNotifyDeps(t, nil, nil, app)
+	defer restore()
+
+	ev := mustCloudwatchLogsEvent(t, events.CloudwatchLogsData{
+		LogGroup:  "/aws/lambda/check_live_stream_status",
+		LogStream: "2025/01/01/[$LATEST]abc",
+	})
+
+	if err := handler(context.Background(), ev); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(app.messages) != 0 {
+		t.Fatalf("expected no owner messages, got %#v", app.messages)
+	}
+	if !app.closed {
+		t.Fatal("expected CloseFirestoreClient")
+	}
+}
+
+func stubErrorLogNotifyDeps(
+	t *testing.T,
+	firestoreErr error,
+	newAppErr error,
+	app errorLogNotifyApp,
+) func() {
+	t.Helper()
+
+	origF := firestoreClientOptionErrorLog
+	origN := newErrorLogWorkspaceApp
+
+	firestoreClientOptionErrorLog = func() (option.ClientOption, error) {
+		return option.WithoutAuthentication(), firestoreErr
+	}
+	newErrorLogWorkspaceApp = func(ctx context.Context, isTest bool, clientOption option.ClientOption) (errorLogNotifyApp, error) {
+		if newAppErr != nil {
+			return nil, newAppErr
+		}
+		return app, nil
+	}
+
+	return func() {
+		firestoreClientOptionErrorLog = origF
+		newErrorLogWorkspaceApp = origN
+	}
+}
+
+func mustCloudwatchLogsEvent(t *testing.T, data events.CloudwatchLogsData) events.CloudwatchLogsEvent {
+	t.Helper()
+
+	payload, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	if _, err := zw.Write(payload); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+
+	return events.CloudwatchLogsEvent{
+		AWSLogs: events.CloudwatchLogsRawData{
+			Data: base64.StdEncoding.EncodeToString(compressed.Bytes()),
+		},
+	}
+}

--- a/system/aws-lambda/error_log_notify_discord/main_test.go
+++ b/system/aws-lambda/error_log_notify_discord/main_test.go
@@ -55,6 +55,12 @@ func TestBuildDiscordMessageChunksIncludesLogLines(t *testing.T) {
 	if !strings.Contains(chunks[0], `"msg":"boom"`) {
 		t.Fatalf("expected raw message: %q", chunks[0])
 	}
+	if strings.Contains(chunks[0], "logStream=") {
+		t.Fatalf("expected no log stream in chunk: %q", chunks[0])
+	}
+	if strings.Contains(chunks[0], "--- id=") || strings.Contains(chunks[0], " ts=") {
+		t.Fatalf("expected no CloudWatch event id/timestamp wrapper: %q", chunks[0])
+	}
 }
 
 func TestBuildDiscordMessageChunksIncludesHeaderInEveryChunk(t *testing.T) {
@@ -77,8 +83,11 @@ func TestBuildDiscordMessageChunksIncludesHeaderInEveryChunk(t *testing.T) {
 		if !strings.Contains(chunk, "/aws/lambda/check_live_stream_status") {
 			t.Fatalf("expected log group in chunk %d: %q", i, chunk)
 		}
-		if !strings.Contains(chunk, "logStream=2025/01/01/[$LATEST]abc") {
-			t.Fatalf("expected log stream in chunk %d: %q", i, chunk)
+		if strings.Contains(chunk, "logStream=") {
+			t.Fatalf("expected no log stream in chunk %d: %q", i, chunk)
+		}
+		if strings.Contains(chunk, "--- id=") || strings.Contains(chunk, " ts=") {
+			t.Fatalf("expected no CloudWatch event id/timestamp wrapper in chunk %d: %q", i, chunk)
 		}
 		expectedChunkNumber := "chunk=" + strconv.Itoa(i+1) + "/" + strconv.Itoa(len(chunks))
 		if !strings.Contains(chunk, expectedChunkNumber) {

--- a/system/aws-lambda/error_log_notify_discord/main_test.go
+++ b/system/aws-lambda/error_log_notify_discord/main_test.go
@@ -147,7 +147,7 @@ func TestHandlerReturnsErrorWhenWorkspaceInitFails(t *testing.T) {
 	})
 
 	err := handler(context.Background(), ev)
-	if err == nil || !strings.Contains(err.Error(), "workspace init failed") {
+	if err == nil || !strings.Contains(err.Error(), "init WorkspaceApp: workspace init failed") {
 		t.Fatalf("expected workspace init error, got %v", err)
 	}
 }
@@ -210,7 +210,7 @@ func TestHandlerReturnsErrorWhenFirestoreInitFails(t *testing.T) {
 	})
 
 	err := handler(context.Background(), ev)
-	if err == nil || !strings.Contains(err.Error(), "firestore init failed") {
+	if err == nil || !strings.Contains(err.Error(), "get Firestore client option: firestore init failed") {
 		t.Fatalf("expected firestore init error, got %v", err)
 	}
 }

--- a/system/aws-lambda/error_log_notify_discord/main_test.go
+++ b/system/aws-lambda/error_log_notify_discord/main_test.go
@@ -52,14 +52,34 @@ func TestBuildDiscordMessageChunksIncludesLogLines(t *testing.T) {
 	if !strings.Contains(chunks[0], "chunk=1/1") {
 		t.Fatalf("expected chunk number: %q", chunks[0])
 	}
-	if !strings.Contains(chunks[0], `"msg":"boom"`) {
-		t.Fatalf("expected raw message: %q", chunks[0])
+	if !strings.Contains(chunks[0], "```json\n") {
+		t.Fatalf("expected json code block: %q", chunks[0])
+	}
+	if !strings.Contains(chunks[0], "\"msg\": \"boom\"") {
+		t.Fatalf("expected pretty JSON message: %q", chunks[0])
 	}
 	if strings.Contains(chunks[0], "logStream=") {
 		t.Fatalf("expected no log stream in chunk: %q", chunks[0])
 	}
 	if strings.Contains(chunks[0], "--- id=") || strings.Contains(chunks[0], " ts=") {
 		t.Fatalf("expected no CloudWatch event id/timestamp wrapper: %q", chunks[0])
+	}
+}
+
+func TestBuildDiscordMessageChunksFallsBackToTextForNonJSON(t *testing.T) {
+	data := &events.CloudwatchLogsData{
+		LogGroup: "/aws/lambda/youtube_organize_database",
+		LogEvents: []events.CloudwatchLogsLogEvent{
+			{ID: "1", Timestamp: 123, Message: "plain error line"},
+		},
+	}
+
+	chunks := buildDiscordMessageChunks(data, "req-1")
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if !strings.Contains(chunks[0], "```text\nplain error line\n```") {
+		t.Fatalf("expected text code block fallback: %q", chunks[0])
 	}
 }
 
@@ -79,6 +99,9 @@ func TestBuildDiscordMessageChunksIncludesHeaderInEveryChunk(t *testing.T) {
 	for i, chunk := range chunks {
 		if len([]rune(chunk)) > maxDiscordMessageLength {
 			t.Fatalf("chunk %d over limit: %d", i, len([]rune(chunk)))
+		}
+		if !strings.Contains(chunk, "```text\n") {
+			t.Fatalf("expected text code block in chunk %d: %q", i, chunk)
 		}
 		if !strings.Contains(chunk, "/aws/lambda/check_live_stream_status") {
 			t.Fatalf("expected log group in chunk %d: %q", i, chunk)

--- a/system/aws-lambda/set_desired_max_seats/main.go
+++ b/system/aws-lambda/set_desired_max_seats/main.go
@@ -82,6 +82,7 @@ func SetDesiredMaxSeats(ctx context.Context, request events.APIGatewayProxyReque
 			slog.ErrorContext(ctx, "timeout warning in set_desired_max_seats during UpdateDesiredMaxSeats", "err", err)
 			return events.APIGatewayProxyResponse{}, fmt.Errorf("timeout during UpdateDesiredMaxSeats: %w", err)
 		}
+		slog.ErrorContext(ctx, "failed to update desired max seats", "err", err)
 		app.MessageToOwnerWithError(ctx, "failed UpdateDesiredMaxSeats", err)
 		return events.APIGatewayProxyResponse{}, err
 	}
@@ -91,6 +92,7 @@ func SetDesiredMaxSeats(ctx context.Context, request events.APIGatewayProxyReque
 			slog.ErrorContext(ctx, "timeout warning in set_desired_max_seats during UpdateDesiredMemberMaxSeats", "err", err)
 			return events.APIGatewayProxyResponse{}, fmt.Errorf("timeout during UpdateDesiredMemberMaxSeats: %w", err)
 		}
+		slog.ErrorContext(ctx, "failed to update desired member max seats", "err", err)
 		app.MessageToOwnerWithError(ctx, "failed UpdateDesiredMemberMaxSeats", err)
 		return events.APIGatewayProxyResponse{}, err
 	}

--- a/system/aws-lambda/set_desired_max_seats/main.go
+++ b/system/aws-lambda/set_desired_max_seats/main.go
@@ -80,7 +80,7 @@ func SetDesiredMaxSeats(ctx context.Context, request events.APIGatewayProxyReque
 	if err := app.Repository.UpdateDesiredMaxSeats(gracefulCtx, nil, params.DesiredMaxSeats); err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			slog.ErrorContext(ctx, "timeout warning in set_desired_max_seats during UpdateDesiredMaxSeats", "err", err)
-			return events.APIGatewayProxyResponse{}, fmt.Errorf("timeout during UpdateDesiredMaxSeats: %w", err)
+			return errorResponse(http.StatusGatewayTimeout, "timeout during UpdateDesiredMaxSeats"), nil
 		}
 		slog.ErrorContext(ctx, "failed to update desired max seats", "err", err)
 		app.MessageToOwnerWithError(ctx, "failed UpdateDesiredMaxSeats", err)
@@ -90,7 +90,7 @@ func SetDesiredMaxSeats(ctx context.Context, request events.APIGatewayProxyReque
 	if err := app.Repository.UpdateDesiredMemberMaxSeats(gracefulCtx, nil, params.DesiredMemberMaxSeats); err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			slog.ErrorContext(ctx, "timeout warning in set_desired_max_seats during UpdateDesiredMemberMaxSeats", "err", err)
-			return events.APIGatewayProxyResponse{}, fmt.Errorf("timeout during UpdateDesiredMemberMaxSeats: %w", err)
+			return errorResponse(http.StatusGatewayTimeout, "timeout during UpdateDesiredMemberMaxSeats"), nil
 		}
 		slog.ErrorContext(ctx, "failed to update desired member max seats", "err", err)
 		app.MessageToOwnerWithError(ctx, "failed UpdateDesiredMemberMaxSeats", err)
@@ -110,6 +110,15 @@ func SetDesiredMaxSeats(ctx context.Context, request events.APIGatewayProxyReque
 		Body:            string(body),
 		IsBase64Encoded: false,
 	}, nil
+}
+
+func errorResponse(statusCode int, message string) events.APIGatewayProxyResponse {
+	body, _ := json.Marshal(SetMaxSeatsResponse{Result: "error", Message: message}) //nolint:errcheck
+	return events.APIGatewayProxyResponse{
+		StatusCode: statusCode,
+		Headers:    map[string]string{"Access-Control-Allow-Origin": "*"},
+		Body:       string(body),
+	}
 }
 
 func main() {

--- a/system/aws-lambda/set_desired_max_seats/main.go
+++ b/system/aws-lambda/set_desired_max_seats/main.go
@@ -79,16 +79,8 @@ func SetDesiredMaxSeats(ctx context.Context, request events.APIGatewayProxyReque
 	// transaction not necessary
 	if err := app.Repository.UpdateDesiredMaxSeats(gracefulCtx, nil, params.DesiredMaxSeats); err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			// NOTE: gracefulCtxは既にキャンセル済みのため、まだ残り時間のある元のctxを使用
-			if notifyErr := app.NotifyTimeoutToOwner(ctx, fmt.Errorf("UpdateDesiredMaxSeatsでタイムアウト: %w", err)); notifyErr != nil {
-				return events.APIGatewayProxyResponse{}, fmt.Errorf("timeout notification failed: %w", notifyErr)
-			}
-			body, _ := json.Marshal(SetMaxSeatsResponse{Result: "timeout_warning", Message: err.Error()}) //nolint:errcheck
-			return events.APIGatewayProxyResponse{
-				StatusCode: http.StatusOK,
-				Headers:    map[string]string{"Access-Control-Allow-Origin": "*"},
-				Body:       string(body),
-			}, nil
+			slog.ErrorContext(ctx, "timeout warning in set_desired_max_seats during UpdateDesiredMaxSeats", "err", err)
+			return events.APIGatewayProxyResponse{}, fmt.Errorf("timeout during UpdateDesiredMaxSeats: %w", err)
 		}
 		app.MessageToOwnerWithError(ctx, "failed UpdateDesiredMaxSeats", err)
 		return events.APIGatewayProxyResponse{}, err
@@ -96,16 +88,8 @@ func SetDesiredMaxSeats(ctx context.Context, request events.APIGatewayProxyReque
 
 	if err := app.Repository.UpdateDesiredMemberMaxSeats(gracefulCtx, nil, params.DesiredMemberMaxSeats); err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			// NOTE: gracefulCtxは既にキャンセル済みのため、まだ残り時間のある元のctxを使用
-			if notifyErr := app.NotifyTimeoutToOwner(ctx, fmt.Errorf("UpdateDesiredMemberMaxSeatsでタイムアウト: %w", err)); notifyErr != nil {
-				return events.APIGatewayProxyResponse{}, fmt.Errorf("timeout notification failed: %w", notifyErr)
-			}
-			body, _ := json.Marshal(SetMaxSeatsResponse{Result: "timeout_warning", Message: err.Error()}) //nolint:errcheck
-			return events.APIGatewayProxyResponse{
-				StatusCode: http.StatusOK,
-				Headers:    map[string]string{"Access-Control-Allow-Origin": "*"},
-				Body:       string(body),
-			}, nil
+			slog.ErrorContext(ctx, "timeout warning in set_desired_max_seats during UpdateDesiredMemberMaxSeats", "err", err)
+			return events.APIGatewayProxyResponse{}, fmt.Errorf("timeout during UpdateDesiredMemberMaxSeats: %w", err)
 		}
 		app.MessageToOwnerWithError(ctx, "failed UpdateDesiredMemberMaxSeats", err)
 		return events.APIGatewayProxyResponse{}, err

--- a/system/aws-lambda/set_desired_max_seats/main.go
+++ b/system/aws-lambda/set_desired_max_seats/main.go
@@ -84,7 +84,7 @@ func SetDesiredMaxSeats(ctx context.Context, request events.APIGatewayProxyReque
 		}
 		slog.ErrorContext(ctx, "failed to update desired max seats", "err", err)
 		app.MessageToOwnerWithError(ctx, "failed UpdateDesiredMaxSeats", err)
-		return events.APIGatewayProxyResponse{}, err
+		return errorResponse(http.StatusInternalServerError, "failed UpdateDesiredMaxSeats"), nil
 	}
 
 	if err := app.Repository.UpdateDesiredMemberMaxSeats(gracefulCtx, nil, params.DesiredMemberMaxSeats); err != nil {
@@ -94,7 +94,7 @@ func SetDesiredMaxSeats(ctx context.Context, request events.APIGatewayProxyReque
 		}
 		slog.ErrorContext(ctx, "failed to update desired member max seats", "err", err)
 		app.MessageToOwnerWithError(ctx, "failed UpdateDesiredMemberMaxSeats", err)
-		return events.APIGatewayProxyResponse{}, err
+		return errorResponse(http.StatusInternalServerError, "failed UpdateDesiredMemberMaxSeats"), nil
 	}
 
 	body, _ := json.Marshal(SetMaxSeatsResponse{ //nolint:errcheck

--- a/system/aws-lambda/sns_notify_discord/main.go
+++ b/system/aws-lambda/sns_notify_discord/main.go
@@ -71,7 +71,10 @@ func handler(ctx context.Context, evt events.SNSEvent) error {
 		slog.InfoContext(gracefulCtx, "sns notify full message", "record_index", i, "subject", subject, "message_full", message)
 
 		notify := buildDiscordNotification(subject, message)
-		app.MessageToOwner(gracefulCtx, notify)
+		if err := app.MessageToOwnerOrError(gracefulCtx, notify); err != nil {
+			slog.ErrorContext(gracefulCtx, "failed to send SNS notification to owner", "record_index", i, "err", err)
+			return fmt.Errorf("send SNS notification to owner: %w", err)
+		}
 	}
 
 	// 処理完了後にコンテキストがキャンセルされていたらログ出力

--- a/system/aws-lambda/sns_notify_discord/main.go
+++ b/system/aws-lambda/sns_notify_discord/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"unicode/utf8"
 
 	"app.modules/aws-lambda/lambdautils"
 	coreutils "app.modules/core/utils"
@@ -91,15 +92,18 @@ func main() {
 
 func buildDiscordNotification(subject string, message string) string {
 	notify := fmt.Sprintf("%s%s\n%s", notifyPrefix, subject, message)
-	if len([]rune(notify)) <= maxDiscordMessageLength {
+	if utf8.RuneCountInString(notify) <= maxDiscordMessageLength {
 		return notify
 	}
 
-	availableMessageLength := maxDiscordMessageLength - len([]rune(notifyPrefix)) - len([]rune(subject)) - 1
-	if availableMessageLength <= len([]rune(truncatedSuffix)) {
+	prefixRunes := utf8.RuneCountInString(notifyPrefix)
+	subjectRunes := utf8.RuneCountInString(subject)
+	suffixRunes := utf8.RuneCountInString(truncatedSuffix)
+	availableMessageLength := maxDiscordMessageLength - prefixRunes - subjectRunes - 1
+	if availableMessageLength <= suffixRunes {
 		return coreutils.TruncateStringRunes(notify, maxDiscordMessageLength)
 	}
 
-	truncatedMessage := coreutils.TruncateStringRunes(message, availableMessageLength-len([]rune(truncatedSuffix))) + truncatedSuffix
+	truncatedMessage := coreutils.TruncateStringRunes(message, availableMessageLength-suffixRunes) + truncatedSuffix
 	return fmt.Sprintf("%s%s\n%s", notifyPrefix, subject, truncatedMessage)
 }

--- a/system/aws-lambda/sns_notify_discord/main.go
+++ b/system/aws-lambda/sns_notify_discord/main.go
@@ -21,9 +21,9 @@ func init() {
 }
 
 const (
-	maxDiscordMessageBytes = 1800
-	truncatedSuffix        = "... (truncated)"
-	notifyPrefix           = "[SNS] "
+	maxDiscordMessageLength = 1800
+	truncatedSuffix         = "... (truncated)"
+	notifyPrefix            = "[SNS] "
 )
 
 func handler(ctx context.Context, evt events.SNSEvent) error {
@@ -88,15 +88,15 @@ func main() {
 
 func buildDiscordNotification(subject string, message string) string {
 	notify := fmt.Sprintf("%s%s\n%s", notifyPrefix, subject, message)
-	if len(notify) <= maxDiscordMessageBytes {
+	if len([]rune(notify)) <= maxDiscordMessageLength {
 		return notify
 	}
 
-	availableMessageBytes := maxDiscordMessageBytes - len(notifyPrefix) - len(subject) - 1
-	if availableMessageBytes <= len(truncatedSuffix) {
-		return coreutils.TruncateStringUTF8(notify, maxDiscordMessageBytes)
+	availableMessageLength := maxDiscordMessageLength - len([]rune(notifyPrefix)) - len([]rune(subject)) - 1
+	if availableMessageLength <= len([]rune(truncatedSuffix)) {
+		return coreutils.TruncateStringRunes(notify, maxDiscordMessageLength)
 	}
 
-	truncatedMessage := coreutils.TruncateStringUTF8(message, availableMessageBytes-len(truncatedSuffix)) + truncatedSuffix
+	truncatedMessage := coreutils.TruncateStringRunes(message, availableMessageLength-len([]rune(truncatedSuffix))) + truncatedSuffix
 	return fmt.Sprintf("%s%s\n%s", notifyPrefix, subject, truncatedMessage)
 }

--- a/system/aws-lambda/sns_notify_discord/main_test.go
+++ b/system/aws-lambda/sns_notify_discord/main_test.go
@@ -8,12 +8,12 @@ import (
 
 func TestBuildDiscordNotificationTruncatesMessageUTF8Safely(t *testing.T) {
 	subject := "subject"
-	message := strings.Repeat("勉強🚀", 500)
+	message := strings.Repeat("勉強🚀", 700)
 
 	notify := buildDiscordNotification(subject, message)
 
-	if len(notify) > maxDiscordMessageBytes {
-		t.Fatalf("expected notification to fit byte limit, got %d", len(notify))
+	if len([]rune(notify)) > maxDiscordMessageLength {
+		t.Fatalf("expected notification to fit length limit, got %d", len([]rune(notify)))
 	}
 	if !utf8.ValidString(notify) {
 		t.Fatalf("expected valid UTF-8 notification, got %q", notify)
@@ -24,13 +24,13 @@ func TestBuildDiscordNotificationTruncatesMessageUTF8Safely(t *testing.T) {
 }
 
 func TestBuildDiscordNotificationAccountsForSubjectLength(t *testing.T) {
-	subject := strings.Repeat("件名", 300)
-	message := strings.Repeat("本文", 500)
+	subject := strings.Repeat("件名", 600)
+	message := strings.Repeat("本文", 700)
 
 	notify := buildDiscordNotification(subject, message)
 
-	if len(notify) > maxDiscordMessageBytes {
-		t.Fatalf("expected notification to fit byte limit, got %d", len(notify))
+	if len([]rune(notify)) > maxDiscordMessageLength {
+		t.Fatalf("expected notification to fit length limit, got %d", len([]rune(notify)))
 	}
 	if !utf8.ValidString(notify) {
 		t.Fatalf("expected valid UTF-8 notification, got %q", notify)

--- a/system/aws-lambda/update_work_name_trend/main.go
+++ b/system/aws-lambda/update_work_name_trend/main.go
@@ -12,11 +12,27 @@ import (
 	"app.modules/core/workspaceapp"
 	"app.modules/internal/logging"
 	"github.com/aws/aws-lambda-go/lambda"
+	"google.golang.org/api/option"
 )
 
 func init() {
 	logging.InitLogger()
 }
+
+type updateWorkNameTrendApp interface {
+	UpdateWorkNameTrend(ctx context.Context, apiKey string) error
+	NotifyTimeoutToOwner(ctx context.Context, err error) error
+	CloseFirestoreClient()
+}
+
+var (
+	// Unit test で初期化失敗や timeout 分岐を差し替え検証できるようにしている。
+	secretFieldFromSecretsManager = lambdautils.SecretFieldFromSecretsManager
+	firestoreClientOptionTrend    = lambdautils.FirestoreClientOption
+	newTrendWorkspaceApp          = func(ctx context.Context, isTest bool, clientOption option.ClientOption) (updateWorkNameTrendApp, error) {
+		return workspaceapp.NewWorkspaceApp(ctx, isTest, clientOption)
+	}
+)
 
 func UpdateWorkNameTrend(ctx context.Context) error {
 	slog.Info(utils.NameOf(UpdateWorkNameTrend))
@@ -27,29 +43,33 @@ func UpdateWorkNameTrend(ctx context.Context) error {
 
 	secretName := os.Getenv("SECRET_NAME")
 	if secretName == "" {
-		return fmt.Errorf("環境変数 SECRET_NAME を設定してください")
+		slog.ErrorContext(ctx, "環境変数 SECRET_NAME を設定してください",
+		)
+		return nil
 	}
 
-	apiKey, err := lambdautils.SecretFieldFromSecretsManager(gracefulCtx, secretName, "OPENAI_API_KEY")
+	apiKey, err := secretFieldFromSecretsManager(gracefulCtx, secretName, "OPENAI_API_KEY")
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			// 初期化中のタイムアウト（appがないのでDiscord通知不可）
-			return fmt.Errorf("timeout during SecretFieldFromSecretsManager: %w", err)
-		}
-		return fmt.Errorf("failed to get OPENAI API key from Secrets Manager: %w", err)
+		slog.ErrorContext(ctx, "failed to get OPENAI API key from Secrets Manager",
+			"err", err,
+		)
+		return nil
 	}
 
-	clientOption, err := lambdautils.FirestoreClientOption()
+	clientOption, err := firestoreClientOptionTrend()
 	if err != nil {
-		return fmt.Errorf("failed to get Firestore client option: %w", err)
+		slog.ErrorContext(ctx, "failed to get Firestore client option",
+			"err", err,
+		)
+		return nil
 	}
 
-	app, err := workspaceapp.NewWorkspaceApp(gracefulCtx, false, clientOption)
+	app, err := newTrendWorkspaceApp(gracefulCtx, false, clientOption)
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return fmt.Errorf("timeout during NewWorkspaceApp: %w", err)
-		}
-		return fmt.Errorf("failed to get WorkspaceApp: %w", err)
+		slog.ErrorContext(ctx, "failed to get WorkspaceApp",
+			"err", err,
+		)
+		return nil
 	}
 	defer app.CloseFirestoreClient()
 
@@ -61,7 +81,10 @@ func UpdateWorkNameTrend(ctx context.Context) error {
 			}
 			return nil // タイムアウト警告はDiscord通知成功で、成功として返す
 		}
-		return fmt.Errorf("failed to update work name trends: %w", err)
+		slog.ErrorContext(ctx, "failed to update work name trends",
+			"err", err,
+		)
+		return nil
 	}
 
 	slog.Info(utils.NameOf(UpdateWorkNameTrend) + " finished")

--- a/system/aws-lambda/update_work_name_trend/main.go
+++ b/system/aws-lambda/update_work_name_trend/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"os"
 
@@ -21,7 +20,6 @@ func init() {
 
 type updateWorkNameTrendApp interface {
 	UpdateWorkNameTrend(ctx context.Context, apiKey string) error
-	NotifyTimeoutToOwner(ctx context.Context, err error) error
 	CloseFirestoreClient()
 }
 
@@ -43,8 +41,7 @@ func UpdateWorkNameTrend(ctx context.Context) error {
 
 	secretName := os.Getenv("SECRET_NAME")
 	if secretName == "" {
-		slog.ErrorContext(ctx, "環境変数 SECRET_NAME を設定してください",
-		)
+		slog.ErrorContext(ctx, "環境変数 SECRET_NAME を設定してください")
 		return nil
 	}
 
@@ -75,11 +72,8 @@ func UpdateWorkNameTrend(ctx context.Context) error {
 
 	if err := app.UpdateWorkNameTrend(gracefulCtx, apiKey); err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			// NOTE: gracefulCtxは既にキャンセル済みのため、まだ残り時間のある元のctxを使用
-			if notifyErr := app.NotifyTimeoutToOwner(ctx, fmt.Errorf("UpdateWorkNameTrendでタイムアウト: %w", err)); notifyErr != nil {
-				return fmt.Errorf("timeout notification failed: %w", notifyErr)
-			}
-			return nil // タイムアウト警告はDiscord通知成功で、成功として返す
+			slog.ErrorContext(ctx, "timeout warning in update_work_name_trend during UpdateWorkNameTrend", "err", err)
+			return nil
 		}
 		slog.ErrorContext(ctx, "failed to update work name trends",
 			"err", err,

--- a/system/aws-lambda/update_work_name_trend/main_test.go
+++ b/system/aws-lambda/update_work_name_trend/main_test.go
@@ -43,7 +43,7 @@ func TestUpdateWorkNameTrendSecretFetchFailureReturnsNil(t *testing.T) {
 
 func TestUpdateWorkNameTrendFirestoreFailureReturnsNil(t *testing.T) {
 	t.Setenv("SECRET_NAME", "my-secret")
-	restore := stubUpdateTrendDeps(t, nil, errors.New("dynamo failed"), nil, nil)
+	restore := stubUpdateTrendDeps(t, nil, errors.New("firestore failed"), nil, nil)
 	defer restore()
 
 	if err := UpdateWorkNameTrend(context.Background()); err != nil {

--- a/system/aws-lambda/update_work_name_trend/main_test.go
+++ b/system/aws-lambda/update_work_name_trend/main_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+)
+
+type mockUpdateTrendApp struct {
+	updateErr        error
+	notifyTimeoutErr error
+	closed           bool
+}
+
+func (m *mockUpdateTrendApp) UpdateWorkNameTrend(ctx context.Context, apiKey string) error {
+	return m.updateErr
+}
+
+func (m *mockUpdateTrendApp) NotifyTimeoutToOwner(ctx context.Context, err error) error {
+	if m.notifyTimeoutErr != nil {
+		return m.notifyTimeoutErr
+	}
+	return nil
+}
+
+func (m *mockUpdateTrendApp) CloseFirestoreClient() {
+	m.closed = true
+}
+
+func TestUpdateWorkNameTrendSecretNameMissingReturnsNil(t *testing.T) {
+	t.Setenv("SECRET_NAME", "")
+	restore := stubUpdateTrendDeps(t, nil, nil, nil, nil)
+	defer restore()
+
+	if err := UpdateWorkNameTrend(context.Background()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestUpdateWorkNameTrendSecretFetchFailureReturnsNil(t *testing.T) {
+	t.Setenv("SECRET_NAME", "my-secret")
+	restore := stubUpdateTrendDeps(t, errors.New("secret fetch failed"), nil, nil, nil)
+	defer restore()
+
+	if err := UpdateWorkNameTrend(context.Background()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestUpdateWorkNameTrendFirestoreFailureReturnsNil(t *testing.T) {
+	t.Setenv("SECRET_NAME", "my-secret")
+	restore := stubUpdateTrendDeps(t, nil, errors.New("dynamo failed"), nil, nil)
+	defer restore()
+
+	if err := UpdateWorkNameTrend(context.Background()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestUpdateWorkNameTrendWorkspaceInitFailureReturnsNil(t *testing.T) {
+	t.Setenv("SECRET_NAME", "my-secret")
+	restore := stubUpdateTrendDeps(t, nil, nil, errors.New("workspace init"), nil)
+	defer restore()
+
+	if err := UpdateWorkNameTrend(context.Background()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestUpdateWorkNameTrendUpdateFailureReturnsNil(t *testing.T) {
+	t.Setenv("SECRET_NAME", "my-secret")
+	app := &mockUpdateTrendApp{updateErr: errors.New("trend failed")}
+	restore := stubUpdateTrendDeps(t, nil, nil, nil, app)
+	defer restore()
+
+	if err := UpdateWorkNameTrend(context.Background()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if !app.closed {
+		t.Fatal("expected CloseFirestoreClient")
+	}
+}
+
+func TestUpdateWorkNameTrendTimeoutNotifyFailureReturnsError(t *testing.T) {
+	t.Setenv("SECRET_NAME", "my-secret")
+	app := &mockUpdateTrendApp{
+		updateErr:        context.DeadlineExceeded,
+		notifyTimeoutErr: errors.New("notify failed"),
+	}
+	restore := stubUpdateTrendDeps(t, nil, nil, nil, app)
+	defer restore()
+
+	err := UpdateWorkNameTrend(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "timeout notification failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func stubUpdateTrendDeps(
+	t *testing.T,
+	secretErr error,
+	firestoreErr error,
+	newAppErr error,
+	app updateWorkNameTrendApp,
+) func() {
+	t.Helper()
+	origS := secretFieldFromSecretsManager
+	origF := firestoreClientOptionTrend
+	origN := newTrendWorkspaceApp
+
+	secretFieldFromSecretsManager = func(ctx context.Context, secretName string, field string) (string, error) {
+		if secretErr != nil {
+			return "", secretErr
+		}
+		return "dummy-api-key", nil
+	}
+	firestoreClientOptionTrend = func() (option.ClientOption, error) {
+		return option.WithoutAuthentication(), firestoreErr
+	}
+	newTrendWorkspaceApp = func(ctx context.Context, isTest bool, clientOption option.ClientOption) (updateWorkNameTrendApp, error) {
+		if newAppErr != nil {
+			return nil, newAppErr
+		}
+		return app, nil
+	}
+
+	return func() {
+		secretFieldFromSecretsManager = origS
+		firestoreClientOptionTrend = origF
+		newTrendWorkspaceApp = origN
+	}
+}

--- a/system/aws-lambda/update_work_name_trend/main_test.go
+++ b/system/aws-lambda/update_work_name_trend/main_test.go
@@ -3,27 +3,18 @@ package main
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 
 	"google.golang.org/api/option"
 )
 
 type mockUpdateTrendApp struct {
-	updateErr        error
-	notifyTimeoutErr error
-	closed           bool
+	updateErr error
+	closed    bool
 }
 
 func (m *mockUpdateTrendApp) UpdateWorkNameTrend(ctx context.Context, apiKey string) error {
 	return m.updateErr
-}
-
-func (m *mockUpdateTrendApp) NotifyTimeoutToOwner(ctx context.Context, err error) error {
-	if m.notifyTimeoutErr != nil {
-		return m.notifyTimeoutErr
-	}
-	return nil
 }
 
 func (m *mockUpdateTrendApp) CloseFirestoreClient() {
@@ -84,21 +75,19 @@ func TestUpdateWorkNameTrendUpdateFailureReturnsNil(t *testing.T) {
 	}
 }
 
-func TestUpdateWorkNameTrendTimeoutNotifyFailureReturnsError(t *testing.T) {
+func TestUpdateWorkNameTrendTimeoutReturnsNil(t *testing.T) {
 	t.Setenv("SECRET_NAME", "my-secret")
 	app := &mockUpdateTrendApp{
-		updateErr:        context.DeadlineExceeded,
-		notifyTimeoutErr: errors.New("notify failed"),
+		updateErr: context.DeadlineExceeded,
 	}
 	restore := stubUpdateTrendDeps(t, nil, nil, nil, app)
 	defer restore()
 
-	err := UpdateWorkNameTrend(context.Background())
-	if err == nil {
-		t.Fatal("expected error")
+	if err := UpdateWorkNameTrend(context.Background()); err != nil {
+		t.Fatalf("expected nil error on handled timeout, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "timeout notification failed") {
-		t.Fatalf("unexpected error: %v", err)
+	if !app.closed {
+		t.Fatal("expected CloseFirestoreClient")
 	}
 }
 

--- a/system/aws-lambda/youtube_organize_database/main.go
+++ b/system/aws-lambda/youtube_organize_database/main.go
@@ -31,11 +31,16 @@ type OrganizeDatabaseResponse struct {
 }
 
 var (
+	// Unit test で初期化失敗や timeout 分岐を差し替え検証できるようにしている。
 	firestoreClientOption = lambdautils.FirestoreClientOption
 	newWorkspaceApp       = func(ctx context.Context, isTest bool, clientOption option.ClientOption) (organizeDatabaseApp, error) {
 		return workspaceapp.NewWorkspaceApp(ctx, isTest, clientOption)
 	}
 )
+
+func okResponse() OrganizeDatabaseResponse {
+	return OrganizeDatabaseResponse{Result: lambdautils.OK, Message: ""}
+}
 
 type organizeRoomResult struct {
 	err                   error
@@ -52,20 +57,20 @@ func OrganizeDatabase(ctx context.Context) (OrganizeDatabaseResponse, error) {
 
 	clientOption, err := firestoreClientOption()
 	if err != nil {
-		return OrganizeDatabaseResponse{}, fmt.Errorf("in FirestoreClientOption: %w", err)
+		slog.ErrorContext(ctx, "failed to get Firestore client option",
+			"err", err,
+		)
+		return okResponse(), nil
 	}
 
 	app, err := newWorkspaceApp(gracefulCtx, false, clientOption)
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			// 初期化中のタイムアウト（appがないのでDiscord通知不可）
-			return OrganizeDatabaseResponse{}, fmt.Errorf("timeout during NewWorkspaceApp: %w", err)
-		}
-		return OrganizeDatabaseResponse{}, fmt.Errorf("in NewWorkspaceApp: %w", err)
+		slog.ErrorContext(ctx, "failed to get WorkspaceApp",
+			"err", err,
+		)
+		return okResponse(), nil
 	}
 	defer app.CloseFirestoreClient()
-
-	var roomErrors []error
 
 	memberResult := runOrganizeDBRoom(ctx, gracefulCtx, app, true, "member room")
 	if memberResult.timeoutWarningMessage != "" {
@@ -74,10 +79,6 @@ func OrganizeDatabase(ctx context.Context) (OrganizeDatabaseResponse, error) {
 	if memberResult.abort {
 		return OrganizeDatabaseResponse{}, memberResult.err
 	}
-	if memberResult.err != nil {
-		roomErrors = append(roomErrors, memberResult.err)
-	}
-
 	generalResult := runOrganizeDBRoom(ctx, gracefulCtx, app, false, "general room")
 	if generalResult.timeoutWarningMessage != "" {
 		return OrganizeDatabaseResponse{Result: "timeout_warning", Message: generalResult.timeoutWarningMessage}, nil
@@ -85,18 +86,7 @@ func OrganizeDatabase(ctx context.Context) (OrganizeDatabaseResponse, error) {
 	if generalResult.abort {
 		return OrganizeDatabaseResponse{}, generalResult.err
 	}
-	if generalResult.err != nil {
-		roomErrors = append(roomErrors, generalResult.err)
-	}
-
-	if len(roomErrors) > 0 {
-		return OrganizeDatabaseResponse{}, errors.Join(roomErrors...)
-	}
-
-	return OrganizeDatabaseResponse{
-		Result:  lambdautils.OK,
-		Message: "",
-	}, nil
+	return okResponse(), nil
 }
 
 func runOrganizeDBRoom(ctx context.Context, gracefulCtx context.Context, app organizeDatabaseApp, isMemberRoom bool, roomLabel string) organizeRoomResult {
@@ -117,9 +107,8 @@ func runOrganizeDBRoom(ctx context.Context, gracefulCtx context.Context, app org
 		return organizeRoomResult{timeoutWarningMessage: timeoutErr.Error()}
 	}
 
-	wrappedErr := fmt.Errorf("in OrganizeDB (%s): %w", roomLabel, err)
 	app.MessageToOwnerWithError(ctx, fmt.Sprintf("failed to OrganizeDB (%s)", roomLabel), err)
-	return organizeRoomResult{err: wrappedErr}
+	return organizeRoomResult{}
 }
 
 func main() {

--- a/system/aws-lambda/youtube_organize_database/main.go
+++ b/system/aws-lambda/youtube_organize_database/main.go
@@ -20,7 +20,6 @@ func init() {
 
 type organizeDatabaseApp interface {
 	OrganizeDB(ctx context.Context, isMemberRoom bool) error
-	NotifyTimeoutToOwner(ctx context.Context, err error) error
 	MessageToOwnerWithError(ctx context.Context, message string, err error)
 	CloseFirestoreClient()
 }
@@ -40,12 +39,6 @@ var (
 
 func okResponse() OrganizeDatabaseResponse {
 	return OrganizeDatabaseResponse{Result: lambdautils.OK, Message: ""}
-}
-
-type organizeRoomResult struct {
-	err                   error
-	timeoutWarningMessage string
-	abort                 bool
 }
 
 func OrganizeDatabase(ctx context.Context) (OrganizeDatabaseResponse, error) {
@@ -72,43 +65,28 @@ func OrganizeDatabase(ctx context.Context) (OrganizeDatabaseResponse, error) {
 	}
 	defer app.CloseFirestoreClient()
 
-	memberResult := runOrganizeDBRoom(ctx, gracefulCtx, app, true, "member room")
-	if memberResult.timeoutWarningMessage != "" {
-		return OrganizeDatabaseResponse{Result: "timeout_warning", Message: memberResult.timeoutWarningMessage}, nil
+	if timedOut := runOrganizeDBRoom(ctx, gracefulCtx, app, true, "member room"); timedOut {
+		return okResponse(), nil
 	}
-	if memberResult.abort {
-		return OrganizeDatabaseResponse{}, memberResult.err
-	}
-	generalResult := runOrganizeDBRoom(ctx, gracefulCtx, app, false, "general room")
-	if generalResult.timeoutWarningMessage != "" {
-		return OrganizeDatabaseResponse{Result: "timeout_warning", Message: generalResult.timeoutWarningMessage}, nil
-	}
-	if generalResult.abort {
-		return OrganizeDatabaseResponse{}, generalResult.err
+	if timedOut := runOrganizeDBRoom(ctx, gracefulCtx, app, false, "general room"); timedOut {
+		return okResponse(), nil
 	}
 	return okResponse(), nil
 }
 
-func runOrganizeDBRoom(ctx context.Context, gracefulCtx context.Context, app organizeDatabaseApp, isMemberRoom bool, roomLabel string) organizeRoomResult {
+func runOrganizeDBRoom(ctx context.Context, gracefulCtx context.Context, app organizeDatabaseApp, isMemberRoom bool, roomLabel string) bool {
 	err := app.OrganizeDB(gracefulCtx, isMemberRoom)
 	if err == nil {
-		return organizeRoomResult{}
+		return false
 	}
 
 	if errors.Is(err, context.DeadlineExceeded) {
-		timeoutErr := fmt.Errorf("OrganizeDB (%s)でタイムアウト: %w", roomLabel, err)
-		// NOTE: gracefulCtxは既にキャンセル済みのため、まだ残り時間のある元のctxを使用
-		if notifyErr := app.NotifyTimeoutToOwner(ctx, timeoutErr); notifyErr != nil {
-			return organizeRoomResult{
-				err:   fmt.Errorf("timeout notification failed: %w", notifyErr),
-				abort: true,
-			}
-		}
-		return organizeRoomResult{timeoutWarningMessage: timeoutErr.Error()}
+		slog.ErrorContext(ctx, "timeout warning in youtube_organize_database during OrganizeDB", "room", roomLabel, "err", err)
+		return true
 	}
 
 	app.MessageToOwnerWithError(ctx, fmt.Sprintf("failed to OrganizeDB (%s)", roomLabel), err)
-	return organizeRoomResult{}
+	return false
 }
 
 func main() {

--- a/system/aws-lambda/youtube_organize_database/main.go
+++ b/system/aws-lambda/youtube_organize_database/main.go
@@ -85,6 +85,7 @@ func runOrganizeDBRoom(ctx context.Context, gracefulCtx context.Context, app org
 		return true
 	}
 
+	slog.ErrorContext(ctx, "failed to OrganizeDB", "room", roomLabel, "err", err)
 	app.MessageToOwnerWithError(ctx, fmt.Sprintf("failed to OrganizeDB (%s)", roomLabel), err)
 	return false
 }

--- a/system/aws-lambda/youtube_organize_database/main_test.go
+++ b/system/aws-lambda/youtube_organize_database/main_test.go
@@ -47,7 +47,7 @@ func TestOrganizeDatabaseSuccess(t *testing.T) {
 	}
 }
 
-func TestOrganizeDatabaseReturnsJoinedErrorAfterBothRoomsRun(t *testing.T) {
+func TestOrganizeDatabaseLogsRoomFailuresAndReturnsOKAfterBothRoomsRun(t *testing.T) {
 	memberErr := errors.New("member failed")
 	generalErr := errors.New("general failed")
 	var callOrder []bool
@@ -161,7 +161,7 @@ func TestOrganizeDatabaseReturnsOKOnGeneralTimeout(t *testing.T) {
 	}
 }
 
-func TestOrganizeDatabaseReturnsInitializationError(t *testing.T) {
+func TestOrganizeDatabaseLogsInitializationFailureAndReturnsOK(t *testing.T) {
 	initErr := errors.New("credential failed")
 	restore := stubOrganizeDatabaseDeps(t, nil, initErr, nil)
 	defer restore()
@@ -175,7 +175,7 @@ func TestOrganizeDatabaseReturnsInitializationError(t *testing.T) {
 	}
 }
 
-func TestOrganizeDatabaseReturnsWorkspaceAppInitializationError(t *testing.T) {
+func TestOrganizeDatabaseLogsWorkspaceAppInitializationFailureAndReturnsOK(t *testing.T) {
 	initErr := errors.New("workspace init failed")
 	restore := stubOrganizeDatabaseDeps(t, nil, nil, initErr)
 	defer restore()

--- a/system/aws-lambda/youtube_organize_database/main_test.go
+++ b/system/aws-lambda/youtube_organize_database/main_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"app.modules/aws-lambda/lambdautils"
 	"google.golang.org/api/option"
 )
 
@@ -47,7 +48,7 @@ func TestOrganizeDatabaseSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
-	if resp.Result != "ok" {
+	if resp.Result != lambdautils.OK {
 		t.Fatalf("expected ok result, got %#v", resp)
 	}
 	if !app.closed {
@@ -73,23 +74,17 @@ func TestOrganizeDatabaseReturnsJoinedErrorAfterBothRoomsRun(t *testing.T) {
 	defer restore()
 
 	resp, err := OrganizeDatabase(context.Background())
-	if err == nil {
-		t.Fatal("expected non-nil error")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
 	}
-	if resp != (OrganizeDatabaseResponse{}) {
-		t.Fatalf("expected empty response on error, got %#v", resp)
+	if resp.Result != lambdautils.OK {
+		t.Fatalf("expected ok result after handled failures, got %#v", resp)
 	}
 	if len(callOrder) != 2 || callOrder[0] != true || callOrder[1] != false {
 		t.Fatalf("expected member then general execution, got %#v", callOrder)
 	}
 	if len(app.messageToOwnerCalls) != 2 {
 		t.Fatalf("expected 2 owner notifications, got %#v", app.messageToOwnerCalls)
-	}
-	if !strings.Contains(err.Error(), "in OrganizeDB (member room): member failed") {
-		t.Fatalf("expected joined error to contain member failure, got %v", err)
-	}
-	if !strings.Contains(err.Error(), "in OrganizeDB (general room): general failed") {
-		t.Fatalf("expected joined error to contain general failure, got %v", err)
 	}
 }
 
@@ -109,9 +104,12 @@ func TestOrganizeDatabaseContinuesToGeneralRoomAfterMemberFailure(t *testing.T) 
 	restore := stubOrganizeDatabaseDeps(t, app, nil, nil)
 	defer restore()
 
-	_, err := OrganizeDatabase(context.Background())
-	if err == nil {
-		t.Fatal("expected non-nil error")
+	resp, err := OrganizeDatabase(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if resp.Result != lambdautils.OK {
+		t.Fatalf("expected ok result, got %#v", resp)
 	}
 	if len(callOrder) != 2 || callOrder[1] != false {
 		t.Fatalf("expected general room to run after member failure, got %#v", callOrder)
@@ -229,9 +227,12 @@ func TestOrganizeDatabaseReturnsInitializationError(t *testing.T) {
 	restore := stubOrganizeDatabaseDeps(t, nil, initErr, nil)
 	defer restore()
 
-	_, err := OrganizeDatabase(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "in FirestoreClientOption") {
-		t.Fatalf("expected initialization error, got %v", err)
+	resp, err := OrganizeDatabase(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error after logging init failure, got %v", err)
+	}
+	if resp.Result != lambdautils.OK {
+		t.Fatalf("expected ok result, got %#v", resp)
 	}
 }
 
@@ -240,9 +241,12 @@ func TestOrganizeDatabaseReturnsWorkspaceAppInitializationError(t *testing.T) {
 	restore := stubOrganizeDatabaseDeps(t, nil, nil, initErr)
 	defer restore()
 
-	_, err := OrganizeDatabase(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "in NewWorkspaceApp") {
-		t.Fatalf("expected workspace init error, got %v", err)
+	resp, err := OrganizeDatabase(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error after logging workspace init failure, got %v", err)
+	}
+	if resp.Result != lambdautils.OK {
+		t.Fatalf("expected ok result, got %#v", resp)
 	}
 }
 

--- a/system/aws-lambda/youtube_organize_database/main_test.go
+++ b/system/aws-lambda/youtube_organize_database/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 
 	"app.modules/aws-lambda/lambdautils"
@@ -11,21 +10,13 @@ import (
 )
 
 type mockOrganizeDatabaseApp struct {
-	organizeDBFunc           func(ctx context.Context, isMemberRoom bool) error
-	notifyTimeoutToOwnerFunc func(ctx context.Context, err error) error
-	messageToOwnerCalls      []string
-	closed                   bool
+	organizeDBFunc      func(ctx context.Context, isMemberRoom bool) error
+	messageToOwnerCalls []string
+	closed              bool
 }
 
 func (m *mockOrganizeDatabaseApp) OrganizeDB(ctx context.Context, isMemberRoom bool) error {
 	return m.organizeDBFunc(ctx, isMemberRoom)
-}
-
-func (m *mockOrganizeDatabaseApp) NotifyTimeoutToOwner(ctx context.Context, err error) error {
-	if m.notifyTimeoutToOwnerFunc != nil {
-		return m.notifyTimeoutToOwnerFunc(ctx, err)
-	}
-	return nil
 }
 
 func (m *mockOrganizeDatabaseApp) MessageToOwnerWithError(ctx context.Context, message string, err error) {
@@ -119,17 +110,12 @@ func TestOrganizeDatabaseContinuesToGeneralRoomAfterMemberFailure(t *testing.T) 
 	}
 }
 
-func TestOrganizeDatabaseReturnsTimeoutWarningOnMemberTimeout(t *testing.T) {
+func TestOrganizeDatabaseReturnsOKOnMemberTimeout(t *testing.T) {
 	var callOrder []bool
-	var notifiedErr error
 	app := &mockOrganizeDatabaseApp{
 		organizeDBFunc: func(ctx context.Context, isMemberRoom bool) error {
 			callOrder = append(callOrder, isMemberRoom)
 			return context.DeadlineExceeded
-		},
-		notifyTimeoutToOwnerFunc: func(ctx context.Context, err error) error {
-			notifiedErr = err
-			return nil
 		},
 	}
 
@@ -138,25 +124,18 @@ func TestOrganizeDatabaseReturnsTimeoutWarningOnMemberTimeout(t *testing.T) {
 
 	resp, err := OrganizeDatabase(context.Background())
 	if err != nil {
-		t.Fatalf("expected nil error on timeout warning, got %v", err)
+		t.Fatalf("expected nil error on handled timeout, got %v", err)
 	}
-	if resp.Result != "timeout_warning" {
-		t.Fatalf("expected timeout_warning result, got %#v", resp)
-	}
-	if !strings.Contains(resp.Message, "member room") {
-		t.Fatalf("expected timeout warning message to include room label, got %#v", resp)
+	if resp.Result != lambdautils.OK {
+		t.Fatalf("expected ok result, got %#v", resp)
 	}
 	if len(callOrder) != 1 || callOrder[0] != true {
 		t.Fatalf("expected processing to stop after member timeout, got %#v", callOrder)
 	}
-	if notifiedErr == nil || !strings.Contains(notifiedErr.Error(), "member room") {
-		t.Fatalf("expected timeout notification for member room, got %v", notifiedErr)
-	}
 }
 
-func TestOrganizeDatabaseReturnsTimeoutWarningOnGeneralTimeout(t *testing.T) {
+func TestOrganizeDatabaseReturnsOKOnGeneralTimeout(t *testing.T) {
 	var callOrder []bool
-	var notifiedErr error
 	app := &mockOrganizeDatabaseApp{
 		organizeDBFunc: func(ctx context.Context, isMemberRoom bool) error {
 			callOrder = append(callOrder, isMemberRoom)
@@ -165,10 +144,6 @@ func TestOrganizeDatabaseReturnsTimeoutWarningOnGeneralTimeout(t *testing.T) {
 			}
 			return context.DeadlineExceeded
 		},
-		notifyTimeoutToOwnerFunc: func(ctx context.Context, err error) error {
-			notifiedErr = err
-			return nil
-		},
 	}
 
 	restore := stubOrganizeDatabaseDeps(t, app, nil, nil)
@@ -176,49 +151,13 @@ func TestOrganizeDatabaseReturnsTimeoutWarningOnGeneralTimeout(t *testing.T) {
 
 	resp, err := OrganizeDatabase(context.Background())
 	if err != nil {
-		t.Fatalf("expected nil error on timeout warning, got %v", err)
+		t.Fatalf("expected nil error on handled timeout, got %v", err)
 	}
-	if resp.Result != "timeout_warning" {
-		t.Fatalf("expected timeout_warning result, got %#v", resp)
-	}
-	if !strings.Contains(resp.Message, "general room") {
-		t.Fatalf("expected timeout warning message to include room label, got %#v", resp)
+	if resp.Result != lambdautils.OK {
+		t.Fatalf("expected ok result, got %#v", resp)
 	}
 	if len(callOrder) != 2 || callOrder[1] != false {
 		t.Fatalf("expected member then general execution, got %#v", callOrder)
-	}
-	if notifiedErr == nil || !strings.Contains(notifiedErr.Error(), "general room") {
-		t.Fatalf("expected timeout notification for general room, got %v", notifiedErr)
-	}
-}
-
-func TestOrganizeDatabaseReturnsErrorWhenTimeoutNotificationFails(t *testing.T) {
-	var callOrder []bool
-	app := &mockOrganizeDatabaseApp{
-		organizeDBFunc: func(ctx context.Context, isMemberRoom bool) error {
-			callOrder = append(callOrder, isMemberRoom)
-			return context.DeadlineExceeded
-		},
-		notifyTimeoutToOwnerFunc: func(ctx context.Context, err error) error {
-			return errors.New("notify failed")
-		},
-	}
-
-	restore := stubOrganizeDatabaseDeps(t, app, nil, nil)
-	defer restore()
-
-	resp, err := OrganizeDatabase(context.Background())
-	if err == nil {
-		t.Fatal("expected timeout notification failure to be returned")
-	}
-	if resp != (OrganizeDatabaseResponse{}) {
-		t.Fatalf("expected empty response on notification failure, got %#v", resp)
-	}
-	if len(callOrder) != 1 || callOrder[0] != true {
-		t.Fatalf("expected processing to stop after member timeout notification failure, got %#v", callOrder)
-	}
-	if !strings.Contains(err.Error(), "timeout notification failed") {
-		t.Fatalf("expected timeout notification failure context, got %v", err)
 	}
 }
 

--- a/system/core/utils/utils.go
+++ b/system/core/utils/utils.go
@@ -191,6 +191,7 @@ func TruncateStringRunes(s string, maxRunes int) string {
 }
 
 // SplitStringRunes は文字列をmaxRunes文字ごとに分割する。
+// 空文字のときは nil を返す。
 // maxRunes が 0 以下のときは分割せず、そのまま返す。
 func SplitStringRunes(s string, maxRunes int) []string {
 	if s == "" {

--- a/system/core/utils/utils.go
+++ b/system/core/utils/utils.go
@@ -177,6 +177,42 @@ func TruncateStringUTF8(s string, maxBytes int) string {
 	return s[:maxBytes]
 }
 
+// TruncateStringRunes は文字列をmaxRunes文字以内にトランケートする。
+// rune 単位で切ることで、日本語や絵文字を含んでも UTF-8 を壊さない。
+func TruncateStringRunes(s string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+	return string(runes[:maxRunes])
+}
+
+// SplitStringRunes は文字列をmaxRunes文字ごとに分割する。
+func SplitStringRunes(s string, maxRunes int) []string {
+	if s == "" {
+		return nil
+	}
+	if maxRunes <= 0 {
+		return []string{s}
+	}
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return []string{s}
+	}
+	out := make([]string, 0, (len(runes)+maxRunes-1)/maxRunes)
+	for start := 0; start < len(runes); start += maxRunes {
+		end := start + maxRunes
+		if end > len(runes) {
+			end = len(runes)
+		}
+		out = append(out, string(runes[start:end]))
+	}
+	return out
+}
+
 // GenerateSessionID generates a UUID v4 string with hyphens removed (32 chars).
 func GenerateSessionID() string {
 	return strings.ReplaceAll(uuid.New().String(), "-", "")

--- a/system/core/utils/utils.go
+++ b/system/core/utils/utils.go
@@ -191,6 +191,7 @@ func TruncateStringRunes(s string, maxRunes int) string {
 }
 
 // SplitStringRunes は文字列をmaxRunes文字ごとに分割する。
+// maxRunes が 0 以下のときは分割せず、そのまま返す。
 func SplitStringRunes(s string, maxRunes int) []string {
 	if s == "" {
 		return nil

--- a/system/core/utils/utils_test.go
+++ b/system/core/utils/utils_test.go
@@ -287,3 +287,28 @@ func TestTruncateStringUTF8(t *testing.T) {
 		assert.Equal(t, "あ", TruncateStringUTF8(s, 3))
 	})
 }
+
+func TestTruncateStringRunes(t *testing.T) {
+	t.Run("negative maxRunes should not panic", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			got := TruncateStringRunes("hello", -1)
+			assert.Equal(t, "", got)
+		})
+	})
+
+	t.Run("rune boundary should not split", func(t *testing.T) {
+		assert.Equal(t, "あい", TruncateStringRunes("あいう", 2))
+		assert.Equal(t, "勉強", TruncateStringRunes("勉強🚀", 2))
+	})
+}
+
+func TestSplitStringRunes(t *testing.T) {
+	t.Run("empty string returns nil", func(t *testing.T) {
+		assert.Nil(t, SplitStringRunes("", 10))
+	})
+
+	t.Run("split preserves utf8 boundaries", func(t *testing.T) {
+		got := SplitStringRunes("勉強🚀最高", 2)
+		assert.Equal(t, []string{"勉強", "🚀最", "高"}, got)
+	})
+}

--- a/system/core/workspaceapp/utils.go
+++ b/system/core/workspaceapp/utils.go
@@ -259,6 +259,12 @@ func (app *WorkspaceApp) MessageToOwner(ctx context.Context, message string) {
 	// これが最終連絡手段のため、エラーは返さずログのみ。
 }
 
+// MessageToOwnerOrError はOwner通知を行い、通知失敗を呼び出し元へ返す。
+// 通知Lambdaのように、配送失敗自体をCloudWatch Alarmで検知したい用途で使う。
+func (app *WorkspaceApp) MessageToOwnerOrError(ctx context.Context, message string) error {
+	return app.alertOwnerBot.SendMessage(ctx, message)
+}
+
 func (app *WorkspaceApp) MessageToOwnerWithError(ctx context.Context, message string, argErr error) {
 	if err := app.alertOwnerBot.SendMessageWithError(ctx, message, argErr); err != nil {
 		slog.ErrorContext(ctx, "failed to send message to owner", "error", err)
@@ -277,10 +283,9 @@ func (app *WorkspaceApp) NotifyTimeoutToOwner(ctx context.Context, timeoutErr er
 	message := prefix + errStr
 
 	// Discordの2000文字制限を超える場合はトランケートする
-	if len(message) > maxDiscordMessageLength {
-		maxErrLength := maxDiscordMessageLength - len(prefix) - len(truncatedSuffix)
-		// UTF-8のマルチバイト文字境界を考慮してトランケート
-		truncatedErr := utils.TruncateStringUTF8(errStr, maxErrLength)
+	if len([]rune(message)) > maxDiscordMessageLength {
+		maxErrLength := maxDiscordMessageLength - len([]rune(prefix)) - len([]rune(truncatedSuffix))
+		truncatedErr := utils.TruncateStringRunes(errStr, maxErrLength)
 		message = prefix + truncatedErr + truncatedSuffix
 	}
 

--- a/system/core/workspaceapp/utils.go
+++ b/system/core/workspaceapp/utils.go
@@ -272,26 +272,6 @@ func (app *WorkspaceApp) MessageToOwnerWithError(ctx context.Context, message st
 	// これが最終連絡手段のため、エラーは返さずログのみ。
 }
 
-// NotifyTimeoutToOwner はタイムアウトをDiscordのOwnerチャンネルに通知し、通知失敗時はエラーを返す。
-// NOTE: 通常のMessageToOwnerWithErrorと異なり、通知失敗時にエラーを返す（CloudWatchアラーム発火のため）
-func (app *WorkspaceApp) NotifyTimeoutToOwner(ctx context.Context, timeoutErr error) error {
-	const maxDiscordMessageLength = 2000
-	const prefix = "timeout warning:\n"
-	const truncatedSuffix = "\n...(truncated)"
-
-	errStr := fmt.Sprintf("%+v", timeoutErr)
-	message := prefix + errStr
-
-	// Discordの2000文字制限を超える場合はトランケートする
-	if len([]rune(message)) > maxDiscordMessageLength {
-		maxErrLength := maxDiscordMessageLength - len([]rune(prefix)) - len([]rune(truncatedSuffix))
-		truncatedErr := utils.TruncateStringRunes(errStr, maxErrLength)
-		message = prefix + truncatedErr + truncatedSuffix
-	}
-
-	return app.alertOwnerBot.SendMessage(ctx, message)
-}
-
 func (app *WorkspaceApp) MessageToModerators(ctx context.Context, message string) error {
 	return app.alertModeratorsBot.SendMessage(ctx, message)
 }


### PR DESCRIPTION
## Summary
- separate CloudWatch ERROR-log Discord delivery into a dedicated `error_log_notify_discord` Lambda while keeping `sns_notify_discord` SNS-only
- subscribe all CDK-managed Lambda ERROR logs to Discord except `error_log_notify_discord` itself, which is excluded to avoid recursive notifications
- remove the old direct timeout notification path (`NotifyTimeoutToOwner`, `timeout_warning`, and `timeout notification failed`) and rely on ERROR logs for timeout visibility
- keep Email and CloudWatch alarm backstops for notification-path failures, including `error_log_notify_discord` itself
- format forwarded ERROR log payloads for Discord with compact headers and pretty JSON code blocks when possible

## Test plan
- [x] `cd /Users/kani3camp/GitHub/youtube-study-space/system && GOCACHE=/tmp/youtube-study-space-go-build go test ./aws-lambda/youtube_organize_database ./aws-lambda/check_live_stream_status ./aws-lambda/update_work_name_trend ./aws-lambda/set_desired_max_seats ./aws-lambda/sns_notify_discord ./aws-lambda/error_log_notify_discord`
- [x] `cd /Users/kani3camp/GitHub/youtube-study-space/aws-cdk && pnpm test -- --runInBand aws-cdk.test.ts`
- [x] `rg "NotifyTimeoutToOwner|timeout_warning|timeout notification failed" system`

Made with [Cursor](https://cursor.com)
