### PR TITLE
Update simulator Dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,8 +84,7 @@ updates:
   - package-ecosystem: npm
     directory: /tools/video-maker/1000-minutes-simulator
     schedule:
-      interval: weekly
-      day: monday
+      interval: semiannually
       time: "09:00"
       timezone: Asia/Tokyo
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -94,8 +94,7 @@ updates:
   - package-ecosystem: npm
     directory: /tools/figma-plugin/room-layout-analyzer
     schedule:
-      interval: weekly
-      day: monday
+      interval: semiannually
       time: "09:00"
       timezone: Asia/Tokyo
     commit-message:


### PR DESCRIPTION
## Summary
- Change Dependabot updates for `tools/video-maker/1000-minutes-simulator` from weekly to semiannual
- Remove the weekly-only `day` setting while keeping the existing time and timezone

## Testing
- Not run (not requested)