### PR TITLE
Handle empty work name trends

### DIFF
--- a/system/core/workspaceapp/work_name_trend.go
+++ b/system/core/workspaceapp/work_name_trend.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"time"
 
 	"app.modules/core/repository"
 	"app.modules/core/utils"
@@ -23,11 +22,11 @@ func (app *WorkspaceApp) UpdateWorkNameTrend(ctx context.Context, apiKey string)
 	var workNames []string
 	memberSeats, err := app.Repository.ReadActiveWorkNameSeats(ctx, true)
 	if err != nil {
-		return fmt.Errorf("in ReadActiveWorkNameSeats(): %w", err)
+		return fmt.Errorf("in ReadActiveWorkNameSeats(member seats): %w", err)
 	}
 	generalSeats, err := app.Repository.ReadActiveWorkNameSeats(ctx, false)
 	if err != nil {
-		return fmt.Errorf("in ReadActiveWorkNameSeats(): %w", err)
+		return fmt.Errorf("in ReadActiveWorkNameSeats(general seats): %w", err)
 	}
 
 	for _, seat := range memberSeats {
@@ -37,126 +36,113 @@ func (app *WorkspaceApp) UpdateWorkNameTrend(ctx context.Context, apiKey string)
 		workNames = append(workNames, seat.WorkName)
 	}
 
-	if len(workNames) == 0 {
-		workNameTrend := repository.WorkNameTrendDoc{
-			Ranking:  []repository.WorkNameTrendRanking{},
-			RankedAt: time.Now(),
-		}
-		txErr := app.Repository.FirestoreClient().RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
-			return app.Repository.UpdateWorkNameTrend(ctx, tx, workNameTrend)
-		})
-		if txErr != nil {
-			return fmt.Errorf("in FirestoreClient().RunTransaction(): %w", txErr)
-		}
+	rankings := []repository.WorkNameTrendRanking{}
+	if len(workNames) > 0 {
+		// AIで作業内容のトレンドを導く
+		client := openai.NewClient(option.WithAPIKey(apiKey))
 
-		slog.Info(utils.NameOf(app.UpdateWorkNameTrend) + " finished")
+		userInput := strings.Join(workNames, "\n")
+		slog.Info("userInput", "value", userInput)
 
-		return nil
-	}
-
-	// AIで作業内容のトレンドを導く
-	client := openai.NewClient(option.WithAPIKey(apiKey))
-
-	userInput := strings.Join(workNames, "\n")
-	slog.Info("userInput", "value", userInput)
-
-	resp, err := client.Responses.New(ctx, responses.ResponseNewParams{
-		Model: shared.ResponsesModel("gpt-5-nano"),
-		Reasoning: shared.ReasoningParam{
-			Effort:  shared.ReasoningEffortMedium,
-			Summary: shared.ReasoningSummaryAuto,
-		},
-		Store: openai.Bool(true),
-		Instructions: openai.String(`作業内容の一覧を改行区切りで入力します。
+		resp, err := client.Responses.New(ctx, responses.ResponseNewParams{
+			Model: shared.ResponsesModel("gpt-5-nano"),
+			Reasoning: shared.ReasoningParam{
+				Effort:  shared.ReasoningEffortMedium,
+				Summary: shared.ReasoningSummaryAuto,
+			},
+			Store: openai.Bool(true),
+			Instructions: openai.String(`作業内容の一覧を改行区切りで入力します。
 作業内容のトレンドのジャンルをランキング形式で上位5個を列挙してください。
 ランキングでは、そのジャンル名、代表的な作業項目（例）を含めるようにしてください。
 ただし、トレンドになっているとは言い難いものは、無理にランキングする必要はありません。
 絵文字だけの作業内容もありますが、絵文字から意味を推測してください。
 その他、作業内容の意味がわかりづらいものは集計では無視してください。
 `),
-		Input: responses.ResponseNewParamsInputUnion{
-			OfString: openai.String(userInput),
-		},
-		Text: responses.ResponseTextConfigParam{
-			Format: responses.ResponseFormatTextConfigUnionParam{
-				OfJSONSchema: &responses.ResponseFormatTextJSONSchemaConfigParam{
-					Name: "ranking_top5",
-					Schema: map[string]interface{}{
-						"type": "object",
-						"properties": map[string]interface{}{
-							"rankings": map[string]interface{}{
-								"type":        "array",
-								"description": "ランキングのリスト（最大５件）",
-								"items": map[string]interface{}{
-									"type": "object",
-									"properties": map[string]interface{}{
-										"rank": map[string]interface{}{
-											"type":        "integer",
-											"description": "順位（1〜5）",
-											"minimum":     1,
-											"maximum":     5,
-										},
-										"genre": map[string]interface{}{
-											"type":        "string",
-											"description": "ジャンル名",
-										},
-										"count": map[string]interface{}{
-											"type":        "integer",
-											"description": "対象作業項目のカウント数",
-											"minimum":     1,
-										},
-										"examples": map[string]interface{}{
-											"type":        "array",
-											"description": "代表的な作業項目抽出例",
-											"minItems":    1,
-											"maxItems":    5,
-											"items": map[string]interface{}{
+			Input: responses.ResponseNewParamsInputUnion{
+				OfString: openai.String(userInput),
+			},
+			Text: responses.ResponseTextConfigParam{
+				Format: responses.ResponseFormatTextConfigUnionParam{
+					OfJSONSchema: &responses.ResponseFormatTextJSONSchemaConfigParam{
+						Name: "ranking_top5",
+						Schema: map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"rankings": map[string]interface{}{
+									"type":        "array",
+									"description": "ランキングのリスト（最大５件）",
+									"items": map[string]interface{}{
+										"type": "object",
+										"properties": map[string]interface{}{
+											"rank": map[string]interface{}{
+												"type":        "integer",
+												"description": "順位（1〜5）",
+												"minimum":     1,
+												"maximum":     5,
+											},
+											"genre": map[string]interface{}{
 												"type":        "string",
-												"description": "作業項目名",
+												"description": "ジャンル名",
+											},
+											"count": map[string]interface{}{
+												"type":        "integer",
+												"description": "対象作業項目のカウント数",
+												"minimum":     1,
+											},
+											"examples": map[string]interface{}{
+												"type":        "array",
+												"description": "代表的な作業項目抽出例",
+												"minItems":    1,
+												"maxItems":    5,
+												"items": map[string]interface{}{
+													"type":        "string",
+													"description": "作業項目名",
+												},
 											},
 										},
+										"required":             []string{"rank", "genre", "count", "examples"},
+										"additionalProperties": false,
 									},
-									"required":             []string{"rank", "genre", "count", "examples"},
-									"additionalProperties": false,
+									"minItems": 0,
+									"maxItems": 5,
 								},
-								"minItems": 0,
-								"maxItems": 5,
 							},
+							"required":             []string{"rankings"},
+							"additionalProperties": false,
 						},
-						"required":             []string{"rankings"},
-						"additionalProperties": false,
+						Strict: openai.Bool(true),
 					},
-					Strict: openai.Bool(true),
 				},
+				Verbosity: responses.ResponseTextConfigVerbosityMedium,
 			},
-			Verbosity: responses.ResponseTextConfigVerbosityMedium,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("in client.Responses.New(): %w", err)
-	}
+		})
+		if err != nil {
+			return fmt.Errorf("in client.Responses.New(): %w", err)
+		}
 
-	slog.Info("resp.OutputText()", "value", resp.OutputText())
+		slog.Info("resp.OutputText()", "value", resp.OutputText())
 
-	type workNameTrendResponse struct {
-		Rankings []repository.WorkNameTrendRanking `json:"rankings"`
-	}
-	var result workNameTrendResponse
-	err = json.Unmarshal([]byte(resp.OutputText()), &result)
-	if err != nil {
-		return fmt.Errorf("in json.Unmarshal(): %w", err)
+		type workNameTrendResponse struct {
+			Rankings []repository.WorkNameTrendRanking `json:"rankings"`
+		}
+		var result workNameTrendResponse
+		err = json.Unmarshal([]byte(resp.OutputText()), &result)
+		if err != nil {
+			return fmt.Errorf("in json.Unmarshal(): %w", err)
+		}
+		rankings = result.Rankings
 	}
 
 	// DBに保存
 	workNameTrend := repository.WorkNameTrendDoc{
-		Ranking:  result.Rankings,
-		RankedAt: time.Now(),
+		Ranking:  rankings,
+		RankedAt: app.currentTime(),
 	}
-	txErr := app.Repository.FirestoreClient().RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+	txErr := app.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
 		return app.Repository.UpdateWorkNameTrend(ctx, tx, workNameTrend)
 	})
 	if txErr != nil {
-		return fmt.Errorf("in FirestoreClient().RunTransaction(): %w", txErr)
+		return fmt.Errorf("in app.RunTransaction(): %w", txErr)
 	}
 
 	slog.Info(utils.NameOf(app.UpdateWorkNameTrend) + " finished")

--- a/system/core/workspaceapp/work_name_trend.go
+++ b/system/core/workspaceapp/work_name_trend.go
@@ -132,6 +132,7 @@ func (app *WorkspaceApp) UpdateWorkNameTrend(ctx context.Context, apiKey string)
 		}
 		rankings = result.Rankings
 	}
+	rankings = nonNilWorkNameTrendRankings(rankings)
 
 	// DBに保存
 	workNameTrend := repository.WorkNameTrendDoc{
@@ -148,4 +149,11 @@ func (app *WorkspaceApp) UpdateWorkNameTrend(ctx context.Context, apiKey string)
 	slog.Info(utils.NameOf(app.UpdateWorkNameTrend) + " finished")
 
 	return nil
+}
+
+func nonNilWorkNameTrendRankings(rankings []repository.WorkNameTrendRanking) []repository.WorkNameTrendRanking {
+	if rankings == nil {
+		return []repository.WorkNameTrendRanking{}
+	}
+	return rankings
 }

--- a/system/core/workspaceapp/work_name_trend.go
+++ b/system/core/workspaceapp/work_name_trend.go
@@ -21,20 +21,37 @@ func (app *WorkspaceApp) UpdateWorkNameTrend(ctx context.Context, apiKey string)
 	slog.Info(utils.NameOf(app.UpdateWorkNameTrend))
 
 	var workNames []string
-	generalSeats, err := app.Repository.ReadActiveWorkNameSeats(ctx, true)
+	memberSeats, err := app.Repository.ReadActiveWorkNameSeats(ctx, true)
 	if err != nil {
 		return fmt.Errorf("in ReadActiveWorkNameSeats(): %w", err)
 	}
-	memberSeats, err := app.Repository.ReadActiveWorkNameSeats(ctx, false)
+	generalSeats, err := app.Repository.ReadActiveWorkNameSeats(ctx, false)
 	if err != nil {
 		return fmt.Errorf("in ReadActiveWorkNameSeats(): %w", err)
 	}
 
+	for _, seat := range memberSeats {
+		workNames = append(workNames, seat.WorkName)
+	}
 	for _, seat := range generalSeats {
 		workNames = append(workNames, seat.WorkName)
 	}
-	for _, seat := range memberSeats {
-		workNames = append(workNames, seat.WorkName)
+
+	if len(workNames) == 0 {
+		workNameTrend := repository.WorkNameTrendDoc{
+			Ranking:  []repository.WorkNameTrendRanking{},
+			RankedAt: time.Now(),
+		}
+		txErr := app.Repository.FirestoreClient().RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+			return app.Repository.UpdateWorkNameTrend(ctx, tx, workNameTrend)
+		})
+		if txErr != nil {
+			return fmt.Errorf("in FirestoreClient().RunTransaction(): %w", txErr)
+		}
+
+		slog.Info(utils.NameOf(app.UpdateWorkNameTrend) + " finished")
+
+		return nil
 	}
 
 	// AIで作業内容のトレンドを導く

--- a/system/core/workspaceapp/work_name_trend.go
+++ b/system/core/workspaceapp/work_name_trend.go
@@ -19,14 +19,34 @@ import (
 func (app *WorkspaceApp) UpdateWorkNameTrend(ctx context.Context, apiKey string) error {
 	slog.Info(utils.NameOf(app.UpdateWorkNameTrend))
 
+	workNames, err := app.readActiveWorkNames(ctx)
+	if err != nil {
+		return err
+	}
+
+	rankings, err := app.generateWorkNameTrendRankings(ctx, apiKey, workNames)
+	if err != nil {
+		return err
+	}
+
+	if err := app.saveWorkNameTrend(ctx, rankings); err != nil {
+		return err
+	}
+
+	slog.Info(utils.NameOf(app.UpdateWorkNameTrend) + " finished")
+
+	return nil
+}
+
+func (app *WorkspaceApp) readActiveWorkNames(ctx context.Context) ([]string, error) {
 	var workNames []string
 	memberSeats, err := app.Repository.ReadActiveWorkNameSeats(ctx, true)
 	if err != nil {
-		return fmt.Errorf("in ReadActiveWorkNameSeats(member seats): %w", err)
+		return nil, fmt.Errorf("in ReadActiveWorkNameSeats(member seats): %w", err)
 	}
 	generalSeats, err := app.Repository.ReadActiveWorkNameSeats(ctx, false)
 	if err != nil {
-		return fmt.Errorf("in ReadActiveWorkNameSeats(general seats): %w", err)
+		return nil, fmt.Errorf("in ReadActiveWorkNameSeats(general seats): %w", err)
 	}
 
 	for _, seat := range memberSeats {
@@ -36,107 +56,124 @@ func (app *WorkspaceApp) UpdateWorkNameTrend(ctx context.Context, apiKey string)
 		workNames = append(workNames, seat.WorkName)
 	}
 
-	rankings := []repository.WorkNameTrendRanking{}
-	if len(workNames) > 0 {
-		// AIで作業内容のトレンドを導く
-		client := openai.NewClient(option.WithAPIKey(apiKey))
+	return workNames, nil
+}
 
-		userInput := strings.Join(workNames, "\n")
-		slog.Info("userInput", "value", userInput)
+func (app *WorkspaceApp) generateWorkNameTrendRankings(ctx context.Context, apiKey string, workNames []string) ([]repository.WorkNameTrendRanking, error) {
+	if len(workNames) == 0 {
+		return []repository.WorkNameTrendRanking{}, nil
+	}
 
-		resp, err := client.Responses.New(ctx, responses.ResponseNewParams{
-			Model: shared.ResponsesModel("gpt-5-nano"),
-			Reasoning: shared.ReasoningParam{
-				Effort:  shared.ReasoningEffortMedium,
-				Summary: shared.ReasoningSummaryAuto,
-			},
-			Store: openai.Bool(true),
-			Instructions: openai.String(`作業内容の一覧を改行区切りで入力します。
+	client := openai.NewClient(option.WithAPIKey(apiKey))
+	userInput := strings.Join(workNames, "\n")
+	slog.Info("userInput", "value", userInput)
+
+	resp, err := client.Responses.New(ctx, newWorkNameTrendResponseParams(userInput))
+	if err != nil {
+		return nil, fmt.Errorf("in client.Responses.New(): %w", err)
+	}
+
+	slog.Info("resp.OutputText()", "value", resp.OutputText())
+
+	rankings, err := parseWorkNameTrendRankings(resp.OutputText())
+	if err != nil {
+		return nil, err
+	}
+
+	return rankings, nil
+}
+
+func newWorkNameTrendResponseParams(userInput string) responses.ResponseNewParams {
+	return responses.ResponseNewParams{
+		Model: shared.ResponsesModel("gpt-5-nano"),
+		Reasoning: shared.ReasoningParam{
+			Effort:  shared.ReasoningEffortMedium,
+			Summary: shared.ReasoningSummaryAuto,
+		},
+		Store: openai.Bool(true),
+		Instructions: openai.String(`作業内容の一覧を改行区切りで入力します。
 作業内容のトレンドのジャンルをランキング形式で上位5個を列挙してください。
 ランキングでは、そのジャンル名、代表的な作業項目（例）を含めるようにしてください。
 ただし、トレンドになっているとは言い難いものは、無理にランキングする必要はありません。
 絵文字だけの作業内容もありますが、絵文字から意味を推測してください。
 その他、作業内容の意味がわかりづらいものは集計では無視してください。
 `),
-			Input: responses.ResponseNewParamsInputUnion{
-				OfString: openai.String(userInput),
-			},
-			Text: responses.ResponseTextConfigParam{
-				Format: responses.ResponseFormatTextConfigUnionParam{
-					OfJSONSchema: &responses.ResponseFormatTextJSONSchemaConfigParam{
-						Name: "ranking_top5",
-						Schema: map[string]interface{}{
-							"type": "object",
-							"properties": map[string]interface{}{
-								"rankings": map[string]interface{}{
-									"type":        "array",
-									"description": "ランキングのリスト（最大５件）",
-									"items": map[string]interface{}{
-										"type": "object",
-										"properties": map[string]interface{}{
-											"rank": map[string]interface{}{
-												"type":        "integer",
-												"description": "順位（1〜5）",
-												"minimum":     1,
-												"maximum":     5,
-											},
-											"genre": map[string]interface{}{
+		Input: responses.ResponseNewParamsInputUnion{
+			OfString: openai.String(userInput),
+		},
+		Text: responses.ResponseTextConfigParam{
+			Format: responses.ResponseFormatTextConfigUnionParam{
+				OfJSONSchema: &responses.ResponseFormatTextJSONSchemaConfigParam{
+					Name: "ranking_top5",
+					Schema: map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"rankings": map[string]interface{}{
+								"type":        "array",
+								"description": "ランキングのリスト（最大５件）",
+								"items": map[string]interface{}{
+									"type": "object",
+									"properties": map[string]interface{}{
+										"rank": map[string]interface{}{
+											"type":        "integer",
+											"description": "順位（1〜5）",
+											"minimum":     1,
+											"maximum":     5,
+										},
+										"genre": map[string]interface{}{
+											"type":        "string",
+											"description": "ジャンル名",
+										},
+										"count": map[string]interface{}{
+											"type":        "integer",
+											"description": "対象作業項目のカウント数",
+											"minimum":     1,
+										},
+										"examples": map[string]interface{}{
+											"type":        "array",
+											"description": "代表的な作業項目抽出例",
+											"minItems":    1,
+											"maxItems":    5,
+											"items": map[string]interface{}{
 												"type":        "string",
-												"description": "ジャンル名",
-											},
-											"count": map[string]interface{}{
-												"type":        "integer",
-												"description": "対象作業項目のカウント数",
-												"minimum":     1,
-											},
-											"examples": map[string]interface{}{
-												"type":        "array",
-												"description": "代表的な作業項目抽出例",
-												"minItems":    1,
-												"maxItems":    5,
-												"items": map[string]interface{}{
-													"type":        "string",
-													"description": "作業項目名",
-												},
+												"description": "作業項目名",
 											},
 										},
-										"required":             []string{"rank", "genre", "count", "examples"},
-										"additionalProperties": false,
 									},
-									"minItems": 0,
-									"maxItems": 5,
+									"required":             []string{"rank", "genre", "count", "examples"},
+									"additionalProperties": false,
 								},
+								"minItems": 0,
+								"maxItems": 5,
 							},
-							"required":             []string{"rankings"},
-							"additionalProperties": false,
 						},
-						Strict: openai.Bool(true),
+						"required":             []string{"rankings"},
+						"additionalProperties": false,
 					},
+					Strict: openai.Bool(true),
 				},
-				Verbosity: responses.ResponseTextConfigVerbosityMedium,
 			},
-		})
-		if err != nil {
-			return fmt.Errorf("in client.Responses.New(): %w", err)
-		}
-
-		slog.Info("resp.OutputText()", "value", resp.OutputText())
-
-		type workNameTrendResponse struct {
-			Rankings []repository.WorkNameTrendRanking `json:"rankings"`
-		}
-		var result workNameTrendResponse
-		err = json.Unmarshal([]byte(resp.OutputText()), &result)
-		if err != nil {
-			return fmt.Errorf("in json.Unmarshal(): %w", err)
-		}
-		rankings = result.Rankings
+			Verbosity: responses.ResponseTextConfigVerbosityMedium,
+		},
 	}
-	rankings = nonNilWorkNameTrendRankings(rankings)
+}
 
+func parseWorkNameTrendRankings(outputText string) ([]repository.WorkNameTrendRanking, error) {
+	type workNameTrendResponse struct {
+		Rankings []repository.WorkNameTrendRanking `json:"rankings"`
+	}
+	var result workNameTrendResponse
+	err := json.Unmarshal([]byte(outputText), &result)
+	if err != nil {
+		return nil, fmt.Errorf("in json.Unmarshal(): %w", err)
+	}
+	return normalizeWorkNameTrendRankings(result.Rankings), nil
+}
+
+func (app *WorkspaceApp) saveWorkNameTrend(ctx context.Context, rankings []repository.WorkNameTrendRanking) error {
 	// DBに保存
 	workNameTrend := repository.WorkNameTrendDoc{
-		Ranking:  rankings,
+		Ranking:  normalizeWorkNameTrendRankings(rankings),
 		RankedAt: app.currentTime(),
 	}
 	txErr := app.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
@@ -146,12 +183,10 @@ func (app *WorkspaceApp) UpdateWorkNameTrend(ctx context.Context, apiKey string)
 		return fmt.Errorf("in app.RunTransaction(): %w", txErr)
 	}
 
-	slog.Info(utils.NameOf(app.UpdateWorkNameTrend) + " finished")
-
 	return nil
 }
 
-func nonNilWorkNameTrendRankings(rankings []repository.WorkNameTrendRanking) []repository.WorkNameTrendRanking {
+func normalizeWorkNameTrendRankings(rankings []repository.WorkNameTrendRanking) []repository.WorkNameTrendRanking {
 	if rankings == nil {
 		return []repository.WorkNameTrendRanking{}
 	}

--- a/system/core/workspaceapp/work_name_trend_test.go
+++ b/system/core/workspaceapp/work_name_trend_test.go
@@ -53,3 +53,27 @@ func TestUpdateWorkNameTrend_EmptyWorkNames(t *testing.T) {
 	assert.Empty(t, savedWorkNameTrend.Ranking)
 	assert.Equal(t, fixedNow, savedWorkNameTrend.RankedAt)
 }
+
+func TestNonNilWorkNameTrendRankings(t *testing.T) {
+	t.Run("nilは空スライスに正規化する", func(t *testing.T) {
+		rankings := nonNilWorkNameTrendRankings(nil)
+
+		assert.NotNil(t, rankings)
+		assert.Empty(t, rankings)
+	})
+
+	t.Run("non-nilはそのまま返す", func(t *testing.T) {
+		input := []repository.WorkNameTrendRanking{
+			{
+				Rank:     1,
+				Genre:    "study",
+				Count:    2,
+				Examples: []string{"math", "english"},
+			},
+		}
+
+		rankings := nonNilWorkNameTrendRankings(input)
+
+		assert.Equal(t, input, rankings)
+	})
+}

--- a/system/core/workspaceapp/work_name_trend_test.go
+++ b/system/core/workspaceapp/work_name_trend_test.go
@@ -1,0 +1,57 @@
+package workspaceapp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"app.modules/core/repository"
+	mock_myfirestore "app.modules/core/repository/mocks"
+	"cloud.google.com/go/firestore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestUpdateWorkNameTrend_EmptyWorkNames(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	mockDB := mock_myfirestore.NewMockRepository(ctrl)
+	mockFirestoreClient := mock_myfirestore.NewMockDBClient(ctrl)
+
+	mockDB.EXPECT().ReadActiveWorkNameSeats(gomock.Any(), true).Return([]repository.SeatDoc{}, nil).Times(1)
+	mockDB.EXPECT().ReadActiveWorkNameSeats(gomock.Any(), false).Return([]repository.SeatDoc{}, nil).Times(1)
+	mockDB.EXPECT().FirestoreClient().Return(mockFirestoreClient).Times(1)
+
+	var savedWorkNameTrend *repository.WorkNameTrendDoc
+	mockDB.EXPECT().UpdateWorkNameTrend(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, tx *firestore.Transaction, workNameTrend repository.WorkNameTrendDoc) error {
+			savedWorkNameTrend = &workNameTrend
+			return nil
+		}).
+		Times(1)
+	mockFirestoreClient.EXPECT().RunTransaction(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, f func(context.Context, *firestore.Transaction) error, opts ...firestore.TransactionOption) error {
+			tx := &firestore.Transaction{}
+			return f(ctx, tx)
+		}).
+		Times(1)
+
+	app := WorkspaceApp{
+		Repository: mockDB,
+	}
+
+	before := time.Now()
+	err := app.UpdateWorkNameTrend(ctx, "dummy-api-key")
+	after := time.Now()
+
+	require.NoError(t, err)
+	require.NotNil(t, savedWorkNameTrend)
+	assert.NotNil(t, savedWorkNameTrend.Ranking)
+	assert.Empty(t, savedWorkNameTrend.Ranking)
+	assert.False(t, savedWorkNameTrend.RankedAt.IsZero())
+	assert.False(t, savedWorkNameTrend.RankedAt.Before(before))
+	assert.False(t, savedWorkNameTrend.RankedAt.After(after))
+}

--- a/system/core/workspaceapp/work_name_trend_test.go
+++ b/system/core/workspaceapp/work_name_trend_test.go
@@ -18,6 +18,7 @@ func TestUpdateWorkNameTrend_EmptyWorkNames(t *testing.T) {
 	defer ctrl.Finish()
 
 	ctx := context.Background()
+	fixedNow := time.Date(2026, time.January, 1, 10, 0, 0, 0, time.UTC)
 	mockDB := mock_myfirestore.NewMockRepository(ctrl)
 	mockFirestoreClient := mock_myfirestore.NewMockDBClient(ctrl)
 
@@ -41,17 +42,14 @@ func TestUpdateWorkNameTrend_EmptyWorkNames(t *testing.T) {
 
 	app := WorkspaceApp{
 		Repository: mockDB,
+		nowFunc:    func() time.Time { return fixedNow },
 	}
 
-	before := time.Now()
 	err := app.UpdateWorkNameTrend(ctx, "dummy-api-key")
-	after := time.Now()
 
 	require.NoError(t, err)
 	require.NotNil(t, savedWorkNameTrend)
 	assert.NotNil(t, savedWorkNameTrend.Ranking)
 	assert.Empty(t, savedWorkNameTrend.Ranking)
-	assert.False(t, savedWorkNameTrend.RankedAt.IsZero())
-	assert.False(t, savedWorkNameTrend.RankedAt.Before(before))
-	assert.False(t, savedWorkNameTrend.RankedAt.After(after))
+	assert.Equal(t, fixedNow, savedWorkNameTrend.RankedAt)
 }

--- a/system/core/workspaceapp/work_name_trend_test.go
+++ b/system/core/workspaceapp/work_name_trend_test.go
@@ -54,9 +54,56 @@ func TestUpdateWorkNameTrend_EmptyWorkNames(t *testing.T) {
 	assert.Equal(t, fixedNow, savedWorkNameTrend.RankedAt)
 }
 
-func TestNonNilWorkNameTrendRankings(t *testing.T) {
+func TestParseWorkNameTrendRankings(t *testing.T) {
+	t.Run("rankings欠落は空スライスに正規化する", func(t *testing.T) {
+		rankings, err := parseWorkNameTrendRankings(`{}`)
+
+		require.NoError(t, err)
+		assert.NotNil(t, rankings)
+		assert.Empty(t, rankings)
+	})
+
+	t.Run("rankings nullは空スライスに正規化する", func(t *testing.T) {
+		rankings, err := parseWorkNameTrendRankings(`{"rankings":null}`)
+
+		require.NoError(t, err)
+		assert.NotNil(t, rankings)
+		assert.Empty(t, rankings)
+	})
+
+	t.Run("rankings空配列は空スライスに正規化する", func(t *testing.T) {
+		rankings, err := parseWorkNameTrendRankings(`{"rankings":[]}`)
+
+		require.NoError(t, err)
+		assert.NotNil(t, rankings)
+		assert.Empty(t, rankings)
+	})
+
+	t.Run("valid ranking JSONは値を保持する", func(t *testing.T) {
+		rankings, err := parseWorkNameTrendRankings(`{"rankings":[{"rank":1,"genre":"study","count":2,"examples":["math","english"]}]}`)
+
+		require.NoError(t, err)
+		assert.Equal(t, []repository.WorkNameTrendRanking{
+			{
+				Rank:     1,
+				Genre:    "study",
+				Count:    2,
+				Examples: []string{"math", "english"},
+			},
+		}, rankings)
+	})
+
+	t.Run("invalid JSONはエラーを返す", func(t *testing.T) {
+		rankings, err := parseWorkNameTrendRankings(`{`)
+
+		require.Error(t, err)
+		assert.Nil(t, rankings)
+	})
+}
+
+func TestNormalizeWorkNameTrendRankings(t *testing.T) {
 	t.Run("nilは空スライスに正規化する", func(t *testing.T) {
-		rankings := nonNilWorkNameTrendRankings(nil)
+		rankings := normalizeWorkNameTrendRankings(nil)
 
 		assert.NotNil(t, rankings)
 		assert.Empty(t, rankings)
@@ -72,7 +119,7 @@ func TestNonNilWorkNameTrendRankings(t *testing.T) {
 			},
 		}
 
-		rankings := nonNilWorkNameTrendRankings(input)
+		rankings := normalizeWorkNameTrendRankings(input)
 
 		assert.Equal(t, input, rankings)
 	})


### PR DESCRIPTION
## Summary
- Add an early-return path for empty work-name input in `UpdateWorkNameTrend`
- Save an empty non-nil ranking and current `RankedAt` without calling OpenAI
- Add a unit test for the empty-input path with a dummy API key

## Tests
- `go test ./core/workspaceapp/...`