### PR TITLE
fix: set_desired_max_seats失敗を修正し新規ルーム構成を追加

### DIFF
--- a/youtube-monitor/src/components/MainContent.tsx
+++ b/youtube-monitor/src/components/MainContent.tsx
@@ -9,7 +9,7 @@ import {
 import { useRouter } from 'next/router'
 import { type FC, useEffect, useMemo, useState } from 'react'
 import api from '../lib/api-config'
-import { numSeatsOfRoomLayouts, useInterval } from '../lib/common'
+import { useInterval } from '../lib/common'
 import { Constants } from '../lib/constants'
 import fetcher from '../lib/fetcher'
 import {
@@ -19,6 +19,11 @@ import {
 	getFirebaseApp,
 	type SystemConstants,
 } from '../lib/firestore'
+import {
+	buildRoomLayouts,
+	desiredMaxSeatsByVacancyRate,
+	desiredMemberMaxSeats,
+} from '../rooms/max-seats'
 import {
 	allRooms,
 	numSeatsInGeneralAllBasicRooms,
@@ -56,7 +61,7 @@ const Seats: FC<SeatsProps> = ({ menuItems }) => {
 	const [latestMemberLayouts, setMemberLayouts] = useState<RoomLayout[]>([])
 	const [pageProps, setPageProps] = useState<LayoutPageProps[]>([])
 	const [latestYoutubeMembershipEnabled, setLatestYoutubeMembershipEnabled] =
-		useState<boolean>(false)
+		useState<boolean>()
 	const [latestFixedMaxSeatsEnabled, setLatestFixedMaxSeatsEnabled] =
 		useState<boolean>()
 	const [latestWorkNameTrend, setLatestWorkNameTrend] = useState<WorkNameTrend>(
@@ -285,142 +290,70 @@ const Seats: FC<SeatsProps> = ({ menuItems }) => {
 			snapshotGeneralMaxSeats === undefined ||
 			snapshotMemberMaxSeats === undefined ||
 			snapshotMinVacancyRate === undefined ||
+			snapshotMembershipEnabled === undefined ||
 			snapshotFixedMaxSeatsEnabled === undefined
 		) {
 			return
 		}
 
-		if (snapshotFixedMaxSeatsEnabled) {
-			const numSeatsGeneralBasicRooms = numSeatsInGeneralAllBasicRooms()
-			const numSeatsMemberBasicRooms = snapshotMembershipEnabled
-				? numSeatsInMemberAllBasicRooms()
-				: 0
-			if (
-				snapshotGeneralMaxSeats !== numSeatsGeneralBasicRooms ||
-				snapshotMemberMaxSeats !== numSeatsMemberBasicRooms
-			) {
-				console.log('sending request to change max_seats')
-				console.log(
-					`general: ${snapshotGeneralMaxSeats} => ${numSeatsGeneralBasicRooms}`,
+		const generalBasicRoomSeats = numSeatsInGeneralAllBasicRooms()
+		const memberBasicRoomSeats = numSeatsInMemberAllBasicRooms()
+		const finalDesiredGeneralMaxSeats = snapshotFixedMaxSeatsEnabled
+			? generalBasicRoomSeats
+			: desiredMaxSeatsByVacancyRate(
+					snapshotGeneralSeats.length,
+					snapshotMinVacancyRate,
+					generalBasicRoomSeats,
+					allRooms.generalTemporaryRooms,
 				)
-				console.log(
-					`members-only: ${snapshotMemberMaxSeats} => ${numSeatsMemberBasicRooms}`,
-				)
-				await requestMaxSeatsUpdate(
-					numSeatsGeneralBasicRooms,
-					numSeatsMemberBasicRooms,
-				)
-			}
-		} else {
-			// GENERAL
-			// まず、現状の入室状況（seatsとmax_seats）と設定された空席率（min_vacancy_rate）を基に、適切なmax_seatsを求める。
-			let finalDesiredGeneralMaxSeats: number
-			const generalMinSeatsByVacancyRate = Math.ceil(
-				snapshotGeneralSeats.length / (1 - snapshotMinVacancyRate),
-			)
-			// もしmax_seatsが基本ルームの席数より多ければ、臨時ルームを増やす
-			if (generalMinSeatsByVacancyRate > numSeatsInGeneralAllBasicRooms()) {
-				let current_num_seats: number = numSeatsInGeneralAllBasicRooms()
-				let current_adding_temporary_room_index = 0
-				while (current_num_seats < generalMinSeatsByVacancyRate) {
-					current_num_seats +=
-						allRooms.generalTemporaryRooms[current_adding_temporary_room_index]
-							.seats.length
-					current_adding_temporary_room_index =
-						(current_adding_temporary_room_index + 1) %
-						allRooms.generalTemporaryRooms.length
-				}
-				finalDesiredGeneralMaxSeats = current_num_seats
-			} else {
-				// そうでなければ、基本ルームの席数とするべき
-				finalDesiredGeneralMaxSeats = numSeatsInGeneralAllBasicRooms()
-			}
+		const finalDesiredMemberMaxSeats = desiredMemberMaxSeats(
+			snapshotMembershipEnabled,
+			snapshotFixedMaxSeatsEnabled,
+			snapshotMemberSeats.length,
+			snapshotMinVacancyRate,
+			memberBasicRoomSeats,
+			allRooms.memberTemporaryRooms,
+		)
 
-			// MEMBER
-			let finalDesiredMemberMaxSeats: number
-			if (snapshotMembershipEnabled) {
-				const memberMinSeatsByVacancyRate = Math.ceil(
-					snapshotMemberSeats.length / (1 - snapshotMinVacancyRate),
-				)
-				// もしmax_seatsが基本ルームの席数より多ければ、臨時ルームを増やす
-				if (memberMinSeatsByVacancyRate > numSeatsInMemberAllBasicRooms()) {
-					let current_num_seats: number = numSeatsInMemberAllBasicRooms()
-					let current_adding_temporary_room_index = 0
-					while (current_num_seats < memberMinSeatsByVacancyRate) {
-						current_num_seats +=
-							allRooms.memberTemporaryRooms[current_adding_temporary_room_index]
-								.seats.length
-						current_adding_temporary_room_index =
-							(current_adding_temporary_room_index + 1) %
-							allRooms.memberTemporaryRooms.length
-					}
-					finalDesiredMemberMaxSeats = current_num_seats
-				} else {
-					// そうでなければ、基本ルームの席数とするべき
-					finalDesiredMemberMaxSeats = numSeatsInMemberAllBasicRooms()
-				}
-			} else {
-				finalDesiredMemberMaxSeats = 0
-			}
-			if (
-				finalDesiredGeneralMaxSeats !== snapshotGeneralMaxSeats ||
-				finalDesiredMemberMaxSeats !== snapshotMemberMaxSeats
-			) {
-				console.log('sending request to change max_seats')
-				console.log(
-					`general: ${snapshotGeneralMaxSeats} => ${finalDesiredGeneralMaxSeats}`,
-				)
-				console.log(
-					`members-only: ${snapshotMemberMaxSeats} => ${finalDesiredMemberMaxSeats}`,
-				)
-				await requestMaxSeatsUpdate(
-					finalDesiredGeneralMaxSeats,
-					finalDesiredMemberMaxSeats,
-				)
-			}
+		if (
+			finalDesiredGeneralMaxSeats !== snapshotGeneralMaxSeats ||
+			finalDesiredMemberMaxSeats !== snapshotMemberMaxSeats
+		) {
+			console.log('sending request to change max_seats')
+			console.log(
+				`general: ${snapshotGeneralMaxSeats} => ${finalDesiredGeneralMaxSeats}`,
+			)
+			console.log(
+				`members-only: ${snapshotMemberMaxSeats} => ${finalDesiredMemberMaxSeats}`,
+			)
+			await requestMaxSeatsUpdate(
+				finalDesiredGeneralMaxSeats,
+				finalDesiredMemberMaxSeats,
+			)
 		}
 
 		// TODO: レイアウト的にmaxSeatsより大きい番号の席が含まれそうであれば、それらの席は表示しない
 
 		// リクエストが送信されたら、すぐに反映されるわけではないのでとりあえずレイアウトを用意して表示する
 		// 必要分（＝r.seatsにある席は全てカバーする）だけ臨時レイアウトを追加
-		const nextGeneralLayouts: RoomLayout[] = [...allRooms.generalBasicRooms] // まずは基本ルームを設定
-		if (
-			!snapshotFixedMaxSeatsEnabled &&
-			snapshotGeneralMaxSeats > numSeatsInGeneralAllBasicRooms()
-		) {
-			let currentAddingLayoutIndex = 0
-			while (
-				numSeatsOfRoomLayouts(nextGeneralLayouts) < snapshotGeneralMaxSeats
-			) {
-				nextGeneralLayouts.push(
-					allRooms.generalTemporaryRooms[currentAddingLayoutIndex],
-				)
-				currentAddingLayoutIndex =
-					(currentAddingLayoutIndex + 1) % allRooms.generalTemporaryRooms.length
-			}
-		}
-		setGeneralLayouts(nextGeneralLayouts)
+		setGeneralLayouts(
+			buildRoomLayouts(
+				allRooms.generalBasicRooms,
+				allRooms.generalTemporaryRooms,
+				snapshotGeneralMaxSeats,
+				snapshotFixedMaxSeatsEnabled,
+			),
+		)
 
 		if (snapshotMembershipEnabled) {
-			const nextMemberLayouts: RoomLayout[] = [...allRooms.memberBasicRooms] // まずは基本ルームを設定
-			if (
-				!snapshotFixedMaxSeatsEnabled &&
-				snapshotMemberMaxSeats > numSeatsInMemberAllBasicRooms()
-			) {
-				let currentAddingLayoutIndex = 0
-				while (
-					numSeatsOfRoomLayouts(nextMemberLayouts) < snapshotMemberMaxSeats
-				) {
-					nextMemberLayouts.push(
-						allRooms.memberTemporaryRooms[currentAddingLayoutIndex],
-					)
-					currentAddingLayoutIndex =
-						(currentAddingLayoutIndex + 1) %
-						allRooms.memberTemporaryRooms.length
-				}
-			}
-			setMemberLayouts(nextMemberLayouts)
+			setMemberLayouts(
+				buildRoomLayouts(
+					allRooms.memberBasicRooms,
+					allRooms.memberTemporaryRooms,
+					snapshotMemberMaxSeats,
+					snapshotFixedMaxSeatsEnabled,
+				),
+			)
 		}
 	}
 

--- a/youtube-monitor/src/components/MainContent.tsx
+++ b/youtube-monitor/src/components/MainContent.tsx
@@ -292,7 +292,9 @@ const Seats: FC<SeatsProps> = ({ menuItems }) => {
 
 		if (snapshotFixedMaxSeatsEnabled) {
 			const numSeatsGeneralBasicRooms = numSeatsInGeneralAllBasicRooms()
-			const numSeatsMemberBasicRooms = numSeatsInMemberAllBasicRooms()
+			const numSeatsMemberBasicRooms = snapshotMembershipEnabled
+				? numSeatsInMemberAllBasicRooms()
+				: 0
 			if (
 				snapshotGeneralMaxSeats !== numSeatsGeneralBasicRooms ||
 				snapshotMemberMaxSeats !== numSeatsMemberBasicRooms

--- a/youtube-monitor/src/components/MainContent.tsx
+++ b/youtube-monitor/src/components/MainContent.tsx
@@ -358,7 +358,7 @@ const Seats: FC<SeatsProps> = ({ menuItems }) => {
 					finalDesiredMemberMaxSeats = numSeatsInMemberAllBasicRooms()
 				}
 			} else {
-				finalDesiredMemberMaxSeats = snapshotMemberMaxSeats
+				finalDesiredMemberMaxSeats = 0
 			}
 			if (
 				finalDesiredGeneralMaxSeats !== snapshotGeneralMaxSeats ||

--- a/youtube-monitor/src/rooms/layouts/cafe-winter-night-room.ts
+++ b/youtube-monitor/src/rooms/layouts/cafe-winter-night-room.ts
@@ -1,0 +1,33 @@
+import type { RoomLayout } from '../../types/room-layout'
+
+export const CafeWinterNightRoom: RoomLayout = {
+	floor_image: '/images/rooms/cafe-winter-night-room.png',
+	font_size_ratio: 0.015,
+	room_shape: {
+		width: 1520,
+		height: 1000,
+	},
+	seat_shape: {
+		width: 140,
+		height: 100,
+	},
+	partition_shapes: [],
+	seats: [
+		{ id: 1, x: 60, y: 413, rotate: 0 },
+		{ id: 2, x: 238, y: 391, rotate: 0 },
+		{ id: 3, x: 405, y: 365, rotate: 0 },
+		{ id: 4, x: 571, y: 343, rotate: 0 },
+		{ id: 5, x: 723, y: 321, rotate: 0 },
+		{ id: 6, x: 744, y: 428, rotate: 0 },
+		{ id: 7, x: 889, y: 491, rotate: 0 },
+		{ id: 8, x: 928, y: 598, rotate: 0 },
+		{ id: 9, x: 1074, y: 673, rotate: 0 },
+		{ id: 10, x: 1172, y: 782, rotate: 0 },
+		{ id: 11, x: 1312, y: 889, rotate: 0 },
+		{ id: 12, x: 113, y: 832, rotate: 0 },
+		{ id: 13, x: 345, y: 817, rotate: 0 },
+		{ id: 14, x: 604, y: 732, rotate: 0 },
+		{ id: 15, x: 819, y: 710, rotate: 0 },
+	],
+	partitions: [],
+}

--- a/youtube-monitor/src/rooms/layouts/city-night-view-room.ts
+++ b/youtube-monitor/src/rooms/layouts/city-night-view-room.ts
@@ -1,0 +1,33 @@
+import type { RoomLayout } from '../../types/room-layout'
+
+export const CityNightViewRoom: RoomLayout = {
+	floor_image: '/images/rooms/city-night-view-room.png',
+	font_size_ratio: 0.015,
+	room_shape: {
+		width: 1520,
+		height: 1000,
+	},
+	seat_shape: {
+		width: 140,
+		height: 100,
+	},
+	partition_shapes: [],
+	seats: [
+		{ id: 1, x: 255, y: 376, rotate: 0 },
+		{ id: 2, x: 476, y: 376, rotate: 0 },
+		{ id: 3, x: 694, y: 376, rotate: 0 },
+		{ id: 4, x: 912, y: 376, rotate: 0 },
+		{ id: 5, x: 1133, y: 376, rotate: 0 },
+		{ id: 6, x: 194, y: 576, rotate: 0 },
+		{ id: 7, x: 444, y: 576, rotate: 0 },
+		{ id: 8, x: 694, y: 576, rotate: 0 },
+		{ id: 9, x: 939, y: 576, rotate: 0 },
+		{ id: 10, x: 1193, y: 576, rotate: 0 },
+		{ id: 11, x: 124, y: 876, rotate: 0 },
+		{ id: 12, x: 414, y: 876, rotate: 0 },
+		{ id: 13, x: 698, y: 876, rotate: 0 },
+		{ id: 14, x: 993, y: 876, rotate: 0 },
+		{ id: 15, x: 1262, y: 876, rotate: 0 },
+	],
+	partitions: [],
+}

--- a/youtube-monitor/src/rooms/layouts/moon-night-room-1.ts
+++ b/youtube-monitor/src/rooms/layouts/moon-night-room-1.ts
@@ -1,0 +1,30 @@
+import type { RoomLayout } from '../../types/room-layout'
+
+export const MoonNightRoom1: RoomLayout = {
+	floor_image: '/images/rooms/moon-night-room-1.png',
+	font_size_ratio: 0.015,
+	room_shape: {
+		width: 1520,
+		height: 1000,
+	},
+	seat_shape: {
+		width: 140,
+		height: 100,
+	},
+	partition_shapes: [],
+	seats: [
+		{ id: 1, x: 325, y: 276, rotate: 0 },
+		{ id: 2, x: 608, y: 276, rotate: 0 },
+		{ id: 3, x: 869, y: 276, rotate: 0 },
+		{ id: 4, x: 1272, y: 226, rotate: 0 },
+		{ id: 5, x: 235, y: 567, rotate: 0 },
+		{ id: 6, x: 565, y: 567, rotate: 0 },
+		{ id: 7, x: 895, y: 567, rotate: 0 },
+		{ id: 8, x: 1201, y: 567, rotate: 0 },
+		{ id: 9, x: 118, y: 876, rotate: 0 },
+		{ id: 10, x: 515, y: 876, rotate: 0 },
+		{ id: 11, x: 912, y: 876, rotate: 0 },
+		{ id: 12, x: 1270, y: 876, rotate: 0 },
+	],
+	partitions: [],
+}

--- a/youtube-monitor/src/rooms/layouts/moon-night-room-2.ts
+++ b/youtube-monitor/src/rooms/layouts/moon-night-room-2.ts
@@ -1,0 +1,30 @@
+import type { RoomLayout } from '../../types/room-layout'
+
+export const MoonNightRoom2: RoomLayout = {
+	floor_image: '/images/rooms/moon-night-room-2.png',
+	font_size_ratio: 0.015,
+	room_shape: {
+		width: 1520,
+		height: 1000,
+	},
+	seat_shape: {
+		width: 140,
+		height: 100,
+	},
+	partition_shapes: [],
+	seats: [
+		{ id: 1, x: 325, y: 276, rotate: 0 },
+		{ id: 2, x: 608, y: 276, rotate: 0 },
+		{ id: 3, x: 869, y: 276, rotate: 0 },
+		{ id: 4, x: 1272, y: 226, rotate: 0 },
+		{ id: 5, x: 235, y: 567, rotate: 0 },
+		{ id: 6, x: 565, y: 567, rotate: 0 },
+		{ id: 7, x: 895, y: 567, rotate: 0 },
+		{ id: 8, x: 1201, y: 567, rotate: 0 },
+		{ id: 9, x: 118, y: 876, rotate: 0 },
+		{ id: 10, x: 515, y: 876, rotate: 0 },
+		{ id: 11, x: 912, y: 876, rotate: 0 },
+		{ id: 12, x: 1270, y: 876, rotate: 0 },
+	],
+	partitions: [],
+}

--- a/youtube-monitor/src/rooms/max-seats.test.ts
+++ b/youtube-monitor/src/rooms/max-seats.test.ts
@@ -29,6 +29,18 @@ test('desiredMaxSeatsByVacancyRate adds temporary seats to satisfy vacancy targe
 	).toBe(15)
 })
 
+test('desiredMaxSeatsByVacancyRate returns basic seats when vacancy rate is 1', () => {
+	expect(
+		desiredMaxSeatsByVacancyRate(20, 1, 10, [roomLayoutWithSeatCount(5)]),
+	).toBe(10)
+})
+
+test('desiredMaxSeatsByVacancyRate treats negative vacancy rate as 0', () => {
+	expect(
+		desiredMaxSeatsByVacancyRate(12, -0.5, 10, [roomLayoutWithSeatCount(5)]),
+	).toBe(15)
+})
+
 test('desiredMemberMaxSeats returns 0 when membership is disabled', () => {
 	expect(
 		desiredMemberMaxSeats(false, false, 10, 0.5, 8, [

--- a/youtube-monitor/src/rooms/max-seats.test.ts
+++ b/youtube-monitor/src/rooms/max-seats.test.ts
@@ -1,0 +1,88 @@
+import {
+	buildRoomLayouts,
+	desiredMaxSeatsByVacancyRate,
+	desiredMemberMaxSeats,
+	expandSeatsWithTemporaryRooms,
+} from './max-seats'
+
+test('expandSeatsWithTemporaryRooms cycles temporary rooms until minSeats is covered', () => {
+	expect(
+		expandSeatsWithTemporaryRooms(12, 5, [
+			roomLayoutWithSeatCount(2),
+			roomLayoutWithSeatCount(3),
+		]),
+	).toBe(12)
+})
+
+test('desiredMaxSeatsByVacancyRate keeps basic seats when vacancy target is already covered', () => {
+	expect(
+		desiredMaxSeatsByVacancyRate(4, 0.5, 10, [roomLayoutWithSeatCount(5)]),
+	).toBe(10)
+})
+
+test('desiredMaxSeatsByVacancyRate adds temporary seats to satisfy vacancy target', () => {
+	expect(
+		desiredMaxSeatsByVacancyRate(9, 0.25, 10, [
+			roomLayoutWithSeatCount(1),
+			roomLayoutWithSeatCount(4),
+		]),
+	).toBe(15)
+})
+
+test('desiredMemberMaxSeats returns 0 when membership is disabled', () => {
+	expect(
+		desiredMemberMaxSeats(false, false, 10, 0.5, 8, [
+			roomLayoutWithSeatCount(4),
+		]),
+	).toBe(0)
+})
+
+test('desiredMemberMaxSeats returns basic room seats when fixed max seats is enabled', () => {
+	expect(
+		desiredMemberMaxSeats(true, true, 10, 0.5, 8, [roomLayoutWithSeatCount(4)]),
+	).toBe(8)
+})
+
+test('buildRoomLayouts returns only basic rooms when fixed max seats is enabled', () => {
+	const basicRoom = roomLayoutWithSeatCount(4)
+	const temporaryRoom = roomLayoutWithSeatCount(4)
+
+	expect(buildRoomLayouts([basicRoom], [temporaryRoom], 8, true)).toEqual([
+		basicRoom,
+	])
+})
+
+test('buildRoomLayouts appends temporary rooms until maxSeats is covered', () => {
+	const basicRoom = roomLayoutWithSeatCount(4)
+	const temporaryRooms = [
+		roomLayoutWithSeatCount(2),
+		roomLayoutWithSeatCount(3),
+	]
+
+	expect(buildRoomLayouts([basicRoom], temporaryRooms, 9, false)).toEqual([
+		basicRoom,
+		temporaryRooms[0],
+		temporaryRooms[1],
+	])
+})
+
+const roomLayoutWithSeatCount = (seatCount: number) => ({
+	floor_image: '',
+	font_size_ratio: 1,
+	room_shape: {
+		height: 0,
+		width: 0,
+	},
+	seat_shape: {
+		height: 0,
+		width: 0,
+	},
+	partition_shapes: [],
+	seats: Array.from({ length: seatCount }, (_, index) => ({
+		id: index + 1,
+		x: 0,
+		y: 0,
+		rotate: 0,
+	})),
+	partitions: [],
+})

--- a/youtube-monitor/src/rooms/max-seats.ts
+++ b/youtube-monitor/src/rooms/max-seats.ts
@@ -1,0 +1,78 @@
+import type { RoomLayout } from '../types/room-layout'
+
+const numSeatsOfRoomLayouts = (layouts: RoomLayout[]): number =>
+	layouts.reduce((count, layout) => count + layout.seats.length, 0)
+
+export const expandSeatsWithTemporaryRooms = (
+	minSeats: number,
+	basicRoomSeats: number,
+	temporaryRooms: RoomLayout[],
+): number => {
+	let currentSeats = basicRoomSeats
+	let currentTemporaryRoomIndex = 0
+	while (currentSeats < minSeats) {
+		currentSeats += temporaryRooms[currentTemporaryRoomIndex].seats.length
+		currentTemporaryRoomIndex =
+			(currentTemporaryRoomIndex + 1) % temporaryRooms.length
+	}
+	return currentSeats
+}
+
+export const desiredMaxSeatsByVacancyRate = (
+	numUsedSeats: number,
+	minVacancyRate: number,
+	basicRoomSeats: number,
+	temporaryRooms: RoomLayout[],
+): number => {
+	const minSeatsByVacancyRate = Math.ceil(numUsedSeats / (1 - minVacancyRate))
+	return expandSeatsWithTemporaryRooms(
+		minSeatsByVacancyRate,
+		basicRoomSeats,
+		temporaryRooms,
+	)
+}
+
+export const buildRoomLayouts = (
+	basicRooms: RoomLayout[],
+	temporaryRooms: RoomLayout[],
+	maxSeats: number,
+	fixedMaxSeatsEnabled: boolean,
+): RoomLayout[] => {
+	const nextLayouts = [...basicRooms]
+	let currentSeats = numSeatsOfRoomLayouts(nextLayouts)
+	if (fixedMaxSeatsEnabled || maxSeats <= currentSeats) {
+		return nextLayouts
+	}
+
+	let currentTemporaryRoomIndex = 0
+	while (currentSeats < maxSeats) {
+		const temporaryRoom = temporaryRooms[currentTemporaryRoomIndex]
+		nextLayouts.push(temporaryRoom)
+		currentSeats += temporaryRoom.seats.length
+		currentTemporaryRoomIndex =
+			(currentTemporaryRoomIndex + 1) % temporaryRooms.length
+	}
+	return nextLayouts
+}
+
+export const desiredMemberMaxSeats = (
+	membershipEnabled: boolean,
+	fixedMaxSeatsEnabled: boolean,
+	numUsedSeats: number,
+	minVacancyRate: number,
+	basicRoomSeats: number,
+	temporaryRooms: RoomLayout[],
+): number => {
+	if (!membershipEnabled) {
+		return 0
+	}
+	if (fixedMaxSeatsEnabled) {
+		return basicRoomSeats
+	}
+	return desiredMaxSeatsByVacancyRate(
+		numUsedSeats,
+		minVacancyRate,
+		basicRoomSeats,
+		temporaryRooms,
+	)
+}

--- a/youtube-monitor/src/rooms/max-seats.ts
+++ b/youtube-monitor/src/rooms/max-seats.ts
@@ -24,7 +24,14 @@ export const desiredMaxSeatsByVacancyRate = (
 	basicRoomSeats: number,
 	temporaryRooms: RoomLayout[],
 ): number => {
-	const minSeatsByVacancyRate = Math.ceil(numUsedSeats / (1 - minVacancyRate))
+	if (!Number.isFinite(minVacancyRate) || minVacancyRate >= 1) {
+		return basicRoomSeats
+	}
+
+	const normalizedMinVacancyRate = Math.max(minVacancyRate, 0)
+	const minSeatsByVacancyRate = Math.ceil(
+		numUsedSeats / (1 - normalizedMinVacancyRate),
+	)
 	return expandSeatsWithTemporaryRooms(
 		minSeatsByVacancyRate,
 		basicRoomSeats,

--- a/youtube-monitor/src/rooms/rooms-config.ts
+++ b/youtube-monitor/src/rooms/rooms-config.ts
@@ -2,11 +2,11 @@ import { ROOM_CONFIG } from '../lib/constants'
 import type { RoomLayout } from '../types/room-layout'
 import { Anonymous1Room } from './layouts/anonymous1'
 import { CafeRainyRoom } from './layouts/cafe-rainy-room'
+import { CafeWinterNightRoom } from './layouts/cafe-winter-night-room'
 import { CampRoom } from './layouts/camp-room'
 import { Chabio1Room } from './layouts/chabio1-room'
 import { Chabio2Room } from './layouts/chabio2-room'
-import { circleRoom } from './layouts/circle-room'
-import { Freepik1Room } from './layouts/freepik1-room'
+import { CityNightViewRoom } from './layouts/city-night-view-room'
 import { Freepik3Room } from './layouts/freepik3-room'
 import { Freepik5Room } from './layouts/freepik5-room'
 import { Freepik7Room } from './layouts/freepik7-room'
@@ -15,6 +15,8 @@ import { MemberBoxRooms2 } from './layouts/member-box-rooms-2'
 import { MemberBoxRooms3 } from './layouts/member-box-rooms-3'
 import { MemberIllustratedRoomSpring } from './layouts/member-illustrated-room-spring'
 import { MemberIllustratedRoom1 } from './layouts/member-illustrated-room1'
+import { MoonNightRoom1 } from './layouts/moon-night-room-1'
+import { MoonNightRoom2 } from './layouts/moon-night-room-2'
 import { ResortSeaRoom } from './layouts/resort-sea-room'
 
 type AllRoomsConfig = {
@@ -31,6 +33,8 @@ const prodAllRooms: AllRoomsConfig = {
 		CafeRainyRoom,
 		Anonymous1Room,
 		Freepik8Room,
+		MoonNightRoom1,
+		MoonNightRoom2,
 	],
 	generalTemporaryRooms: [
 		CampRoom,
@@ -40,6 +44,8 @@ const prodAllRooms: AllRoomsConfig = {
 		Freepik5Room,
 		Freepik8Room,
 		Freepik7Room,
+		MoonNightRoom1,
+		MoonNightRoom2,
 	],
 	memberBasicRooms: [
 		MemberBoxRooms2,
@@ -58,12 +64,17 @@ const prodAllRooms: AllRoomsConfig = {
 }
 
 const testAllRooms: AllRoomsConfig = {
-	generalBasicRooms: [Freepik1Room],
+	generalBasicRooms: [
+		CafeWinterNightRoom,
+		CityNightViewRoom,
+		MoonNightRoom1,
+		MoonNightRoom2,
+	],
 	generalTemporaryRooms: [
-		Freepik5Room,
-		circleRoom,
-		Anonymous1Room,
-		Freepik1Room,
+		CafeWinterNightRoom,
+		CityNightViewRoom,
+		MoonNightRoom1,
+		MoonNightRoom2,
 	],
 	memberBasicRooms: [ResortSeaRoom],
 	memberTemporaryRooms: [ResortSeaRoom],

--- a/youtube-monitor/src/rooms/rooms-config.ts
+++ b/youtube-monitor/src/rooms/rooms-config.ts
@@ -2,11 +2,9 @@ import { ROOM_CONFIG } from '../lib/constants'
 import type { RoomLayout } from '../types/room-layout'
 import { Anonymous1Room } from './layouts/anonymous1'
 import { CafeRainyRoom } from './layouts/cafe-rainy-room'
-import { CafeWinterNightRoom } from './layouts/cafe-winter-night-room'
 import { CampRoom } from './layouts/camp-room'
 import { Chabio1Room } from './layouts/chabio1-room'
 import { Chabio2Room } from './layouts/chabio2-room'
-import { CityNightViewRoom } from './layouts/city-night-view-room'
 import { Freepik3Room } from './layouts/freepik3-room'
 import { Freepik5Room } from './layouts/freepik5-room'
 import { Freepik7Room } from './layouts/freepik7-room'
@@ -64,18 +62,8 @@ const prodAllRooms: AllRoomsConfig = {
 }
 
 const testAllRooms: AllRoomsConfig = {
-	generalBasicRooms: [
-		CafeWinterNightRoom,
-		CityNightViewRoom,
-		MoonNightRoom1,
-		MoonNightRoom2,
-	],
-	generalTemporaryRooms: [
-		CafeWinterNightRoom,
-		CityNightViewRoom,
-		MoonNightRoom1,
-		MoonNightRoom2,
-	],
+	generalBasicRooms: [MoonNightRoom1, MoonNightRoom2],
+	generalTemporaryRooms: [MoonNightRoom1, MoonNightRoom2],
 	memberBasicRooms: [ResortSeaRoom],
 	memberTemporaryRooms: [ResortSeaRoom],
 }


### PR DESCRIPTION
## Summary
- `YoutubeMembershipEnabled=false` のとき `desired_member_max_seats` を `0` で送るように修正し、`set_desired_max_seats` の `invalid parameter` を解消
- `cafe-winter-night` / `city-night-view` / `moon-night-1` / `moon-night-2` の新規レイアウトを追加
  - レイアウトが重複している部分があるが、意図的。
- `rooms-config` の dev/prod 構成に新規レイアウトを組み込み、テスト用ルーム構成も更新
  - prodのほうは一部ルームのみ追加とする。

## Test plan
- [x] `pnpm lint`
- [x] `pnpm tsc --noEmit`
- [x] `set_desired_max_seats` の POST が 200 になることを確認

Made with [Cursor](https://cursor.com)