### PR TITLE
youtube-monitor の build CI を追加し、依存更新に追従する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,38 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+  youtube-monitor-build:
+    name: YouTube Monitor Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: youtube-monitor
+    env:
+      NEXT_PUBLIC_DEBUG: "false"
+      NEXT_PUBLIC_CHANNEL_GL: "false"
+      NEXT_PUBLIC_ROOM_CONFIG: "DEV"
+      NEXT_PUBLIC_API_ENDPOINT: "http://localhost:3000"
+      NEXT_PUBLIC_API_KEY: "ci-dummy-api-key"
+      NEXT_PUBLIC_FIREBASE_PROJECT_ID: "ci-dummy-project"
+      NEXT_PUBLIC_FIREBASE_API_KEY: "ci-dummy-firebase-api-key"
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          package_json_file: youtube-monitor/package.json
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: youtube-monitor/pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run build
+        run: pnpm build
+
   aws-cdk-test:
     name: AWS CDK Test
     runs-on: ubuntu-latest

--- a/youtube-monitor/package.json
+++ b/youtube-monitor/package.json
@@ -42,7 +42,6 @@
 		"react-dom": "^18.3.1",
 		"react-fast-marquee": "^1.6.5",
 		"react-icons": "^5.6.0",
-		"react-loader-spinner": "^8.0.2",
 		"react-redux": "^8.1.3",
 		"redux": "^5.0.1",
 		"redux-logger": "^3.0.6",

--- a/youtube-monitor/pnpm-lock.yaml
+++ b/youtube-monitor/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       react-icons:
         specifier: ^5.6.0
         version: 5.6.0(react@18.3.1)
-      react-loader-spinner:
-        specifier: ^8.0.2
-        version: 8.0.2(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-redux:
         specifier: ^8.1.3
         version: 8.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1)
@@ -2696,9 +2693,6 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  camelize@1.0.1:
-    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
-
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
 
@@ -2801,13 +2795,6 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
-
-  css-color-keywords@1.0.0:
-    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
-    engines: {node: '>=4'}
-
-  css-to-react-native@3.2.0:
-    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -3758,9 +3745,6 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
-  postcss-value-parser@4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3842,13 +3826,6 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
-
-  react-loader-spinner@8.0.2:
-    resolution: {integrity: sha512-N2gHEy88VKRaijzEFoRp/aHEPE6Lr6upkmPBPu9hfqZqdxftxsXd1B+lzOmVnn3BYHyXwvYrifWzMbR64lwQlw==}
-    engines: {node: '>= 12'}
-    peerDependencies:
-      react: '>=17.0.0 <20.0.0'
-      react-dom: '>=17.0.0 <20.0.0'
 
   react-redux@8.1.3:
     resolution: {integrity: sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==}
@@ -4104,22 +4081,6 @@ packages:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
 
-  styled-components@6.4.0:
-    resolution: {integrity: sha512-BL1EDFpt+q10eAeZB0q9ps6pSlPejaBQWBkiuM16pyoVTG4NhZrPrZK0cqNbrozxSsYwUsJ9SQYN6NyeKJYX9A==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      css-to-react-native: '>= 3.2.0'
-      react: '>= 16.8.0'
-      react-dom: '>= 16.8.0'
-      react-native: '>= 0.68.0'
-    peerDependenciesMeta:
-      css-to-react-native:
-        optional: true
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
-
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -4135,9 +4096,6 @@ packages:
 
   stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
-
-  stylis@4.3.6:
-    resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4194,9 +4152,6 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
-
-  tinycolor2@1.6.0:
-    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
@@ -7294,9 +7249,6 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  camelize@1.0.1:
-    optional: true
-
   caniuse-lite@1.0.30001788: {}
 
   chai@5.3.3:
@@ -7383,16 +7335,6 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  css-color-keywords@1.0.0:
-    optional: true
-
-  css-to-react-native@3.2.0:
-    dependencies:
-      camelize: 1.0.1
-      css-color-keywords: 1.0.0
-      postcss-value-parser: 4.2.0
-    optional: true
 
   css.escape@1.5.1: {}
 
@@ -8554,9 +8496,6 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  postcss-value-parser@4.2.0:
-    optional: true
-
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
@@ -8654,16 +8593,6 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
-
-  react-loader-spinner@8.0.2(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      styled-components: 6.4.0(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      tinycolor2: 1.6.0
-    transitivePeerDependencies:
-      - css-to-react-native
-      - react-native
 
   react-redux@8.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@5.0.1):
     dependencies:
@@ -8964,16 +8893,6 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
-  styled-components@6.4.0(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@emotion/is-prop-valid': 1.4.0
-      csstype: 3.2.3
-      react: 18.3.1
-      stylis: 4.3.6
-    optionalDependencies:
-      css-to-react-native: 3.2.0
-      react-dom: 18.3.1(react@18.3.1)
-
   styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
@@ -8983,8 +8902,6 @@ snapshots:
       babel-plugin-macros: 3.1.0
 
   stylis@4.2.0: {}
-
-  stylis@4.3.6: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -9034,8 +8951,6 @@ snapshots:
       minimatch: 3.1.5
 
   tiny-invariant@1.3.3: {}
-
-  tinycolor2@1.6.0: {}
 
   tinyglobby@0.2.16:
     dependencies:

--- a/youtube-monitor/pnpm-lock.yaml
+++ b/youtube-monitor/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 16.2.4(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0)
       next-i18next:
         specifier: ^16.0.5
-        version: 16.0.5(@types/react@18.3.28)(i18next@25.4.2(typescript@5.9.3))(next@16.2.4(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0))(react-i18next@15.7.3(i18next@25.4.2(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1)
+        version: 16.0.5(@types/react@18.3.28)(i18next@26.0.9(typescript@5.9.3))(next@16.2.4(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0))(react-i18next@17.0.6(i18next@26.0.9(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -3164,10 +3164,10 @@ packages:
   i18next-resources-to-backend@1.2.1:
     resolution: {integrity: sha512-okHbVA+HZ7n1/76MsfhPqDou0fptl2dAlhRDu2ideXloRRduzHsqDOznJBef+R3DFZnbvWoBW+KxJ7fnFjd6Yw==}
 
-  i18next@25.4.2:
-    resolution: {integrity: sha512-gD4T25a6ovNXsfXY1TwHXXXLnD/K2t99jyYMCSimSCBnBRJVQr5j+VAaU83RJCPzrTGhVQ6dqIga66xO2rtd5g==}
+  i18next@26.0.9:
+    resolution: {integrity: sha512-htjWlK5lGpjIDJxUdDLD6dO2jPl/RZHBpeZC80T5yr6Lci/tN3Oq9Doh9110ihliAIb4xmb45ngM76WcbP6GjA==}
     peerDependencies:
-      typescript: ^5
+      typescript: ^5 || ^6
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -3813,14 +3813,14 @@ packages:
       react: '>= 16.8.0 || ^18.0.0'
       react-dom: '>= 16.8.0 || ^18.0.0'
 
-  react-i18next@15.7.3:
-    resolution: {integrity: sha512-AANws4tOE+QSq/IeMF/ncoHlMNZaVLxpa5uUGW1wjike68elVYr0018L9xYoqBr1OFO7G7boDPrbn0HpMCJxTw==}
+  react-i18next@17.0.6:
+    resolution: {integrity: sha512-WzJ6SMKF+GTD7JZZqxSR1AKKmXjaSu39sClUrNlwxS4Tl7a99O+ltFy6yhPMO+wgZuxpQjJ2PZkfrQKmAqrLhw==}
     peerDependencies:
-      i18next: '>= 25.4.1'
+      i18next: '>= 26.0.1'
       react: '>= 16.8.0'
       react-dom: '*'
       react-native: '*'
-      typescript: ^5
+      typescript: ^5 || ^6
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -7779,9 +7779,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
 
-  i18next@25.4.2(typescript@5.9.3):
-    dependencies:
-      '@babel/runtime': 7.29.2
+  i18next@26.0.9(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
 
@@ -8420,15 +8418,15 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-i18next@16.0.5(@types/react@18.3.28)(i18next@25.4.2(typescript@5.9.3))(next@16.2.4(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0))(react-i18next@15.7.3(i18next@25.4.2(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1):
+  next-i18next@16.0.5(@types/react@18.3.28)(i18next@26.0.9(typescript@5.9.3))(next@16.2.4(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0))(react-i18next@17.0.6(i18next@26.0.9(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1):
     dependencies:
       '@types/hoist-non-react-statics': 3.3.7(@types/react@18.3.28)
       hoist-non-react-statics: 3.3.2
-      i18next: 25.4.2(typescript@5.9.3)
+      i18next: 26.0.9(typescript@5.9.3)
       i18next-resources-to-backend: 1.2.1
       next: 16.2.4(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.99.0)
       react: 18.3.1
-      react-i18next: 15.7.3(i18next@25.4.2(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      react-i18next: 17.0.6(i18next@26.0.9(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -8636,12 +8634,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-i18next@15.7.3(i18next@25.4.2(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
+  react-i18next@17.0.6(i18next@26.0.9(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.2
       html-parse-stringify: 3.0.1
-      i18next: 25.4.2(typescript@5.9.3)
+      i18next: 26.0.9(typescript@5.9.3)
       react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
       typescript: 5.9.3

--- a/youtube-monitor/src/components/CenterLoading.tsx
+++ b/youtube-monitor/src/components/CenterLoading.tsx
@@ -1,11 +1,9 @@
 import type { FC } from 'react'
-import { BallTriangle } from 'react-loader-spinner'
-import { Constants } from '../lib/constants'
 import * as styles from '../styles/CenterLoading.styles'
 
 const CenterLoading: FC = () => (
 	<div css={styles.CenterLoading}>
-		<BallTriangle color={Constants.primaryTextColor} height={130} width={130} />
+		<div css={styles.spinner} />
 		<div>Loading...</div>
 	</div>
 )

--- a/youtube-monitor/src/components/Clock.tsx
+++ b/youtube-monitor/src/components/Clock.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { useTranslation } from 'next-i18next'
+import { useTranslation } from 'next-i18next/pages'
 import { type FC, memo, useEffect, useState } from 'react'
 import { useInterval } from '../lib/common'
 import * as styles from '../styles/Clock.styles'

--- a/youtube-monitor/src/components/ColorBar.tsx
+++ b/youtube-monitor/src/components/ColorBar.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next'
+import { useTranslation } from 'next-i18next/pages'
 import type { FC } from 'react'
 import * as styles from '../styles/ColorBar.styles'
 import { componentBackground, componentStyle } from '../styles/common.style'

--- a/youtube-monitor/src/components/MenuDisplay.tsx
+++ b/youtube-monitor/src/components/MenuDisplay.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next'
+import { useTranslation } from 'next-i18next/pages'
 import { type FC, memo, useCallback, useEffect, useState } from 'react'
 import { useInterval } from '../lib/common'
 import { componentBackground, componentStyle } from '../styles/common.style'

--- a/youtube-monitor/src/components/Message.tsx
+++ b/youtube-monitor/src/components/Message.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next'
+import { useTranslation } from 'next-i18next/pages'
 import type { FC } from 'react'
 import { componentBackground, componentStyle } from '../styles/common.style'
 import * as styles from '../styles/Message.styles'

--- a/youtube-monitor/src/components/TickerBoard.tsx
+++ b/youtube-monitor/src/components/TickerBoard.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next'
+import { useTranslation } from 'next-i18next/pages'
 import type { FC } from 'react'
 import Marquee from 'react-fast-marquee'
 import { componentBackground } from '../styles/common.style'

--- a/youtube-monitor/src/components/Timer.tsx
+++ b/youtube-monitor/src/components/Timer.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { useTranslation } from 'next-i18next'
+import { useTranslation } from 'next-i18next/pages'
 import { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import {
 	buildStyles,

--- a/youtube-monitor/src/components/Usage.tsx
+++ b/youtube-monitor/src/components/Usage.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { useTranslation } from 'next-i18next'
+import { useTranslation } from 'next-i18next/pages'
 import { type FC, memo } from 'react'
 import { componentBackground, componentStyle } from '../styles/common.style'
 import * as styles from '../styles/Usage.styles'

--- a/youtube-monitor/src/pages/_app.tsx
+++ b/youtube-monitor/src/pages/_app.tsx
@@ -1,6 +1,6 @@
 import { Global } from '@emotion/react'
 import type { AppProps } from 'next/app'
-import { appWithTranslation } from 'next-i18next'
+import { appWithTranslation } from 'next-i18next/pages'
 import 'react-circular-progressbar/dist/styles.css'
 import { fontClassName } from '../lib/common'
 import { globalStyle } from '../styles/global.styles'

--- a/youtube-monitor/src/pages/index.tsx
+++ b/youtube-monitor/src/pages/index.tsx
@@ -6,7 +6,7 @@ import {
 	query,
 } from 'firebase/firestore'
 import type { GetStaticProps } from 'next'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
 import { type FC, useEffect, useState } from 'react'
 import BackgroundImage from '../components/BackgroundImage'
 import BgmPlayer from '../components/BgmPlayer'

--- a/youtube-monitor/src/styles/CenterLoading.styles.ts
+++ b/youtube-monitor/src/styles/CenterLoading.styles.ts
@@ -14,3 +14,19 @@ export const CenterLoading = css`
     color: ${Constants.primaryTextColor};
     font-size: 1.5rem;
 `
+
+export const spinner = css`
+    width: 72px;
+    height: 72px;
+    margin-bottom: 16px;
+    border: 6px solid rgba(255, 255, 255, 0.2);
+    border-top-color: ${Constants.primaryTextColor};
+    border-radius: 9999px;
+    animation: spin 0.9s linear infinite;
+
+    @keyframes spin {
+        to {
+            transform: rotate(360deg);
+        }
+    }
+`


### PR DESCRIPTION
## Summary
- `test.yml` に `youtube-monitor-build` job を追加し、`pnpm build` を PR CI で別 job として検証するようにしました。
- Next.js build に必要な `NEXT_PUBLIC_*` のダミー値を CI で設定し、外部サービスに依存しない形にしました。
- `youtube-monitor` の依存関係更新に合わせて、`next-i18next` の参照先変更と `react-loader-spinner` の削除、ローディング表示の置き換えを行いました。

## Testing
- `youtube-monitor` 配下で `pnpm build` を実行し、成功を確認しました。
- workflow YAML の構文確認を行い、問題がないことを確認しました。
- `git diff --check` で整形上の問題がないことを確認しました。