### PR TITLE
[codex] Address PR 819 review feedback

### DIFF
--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -615,11 +615,6 @@ export class AwsCdkStack extends cdk.Stack {
 		;(setDesiredMaxSeatsFunction.role as iam.Role).addToPolicy(
 			dynamoDBAccessPolicy,
 		)
-		createLambdaErrorAlarm(
-			setDesiredMaxSeatsFunction,
-			'SetDesiredMaxSeatsErrorsAlarm',
-			'Lambda set_desired_max_seats errors > 0',
-		)
 
 		const youtubeOrganizeDatabaseFunction = new lambda.DockerImageFunction(
 			this,
@@ -634,11 +629,6 @@ export class AwsCdkStack extends cdk.Stack {
 		;(youtubeOrganizeDatabaseFunction.role as iam.Role).addToPolicy(
 			dynamoDBAccessPolicy,
 		)
-		createLambdaErrorAlarm(
-			youtubeOrganizeDatabaseFunction,
-			'YoutubeOrganizeDatabaseErrorsAlarm',
-			'Lambda youtube_organize_database errors > 0',
-		)
 
 		const checkLiveStreamStatusFunction = new lambda.DockerImageFunction(
 			this,
@@ -652,11 +642,6 @@ export class AwsCdkStack extends cdk.Stack {
 		)
 		;(checkLiveStreamStatusFunction.role as iam.Role).addToPolicy(
 			dynamoDBAccessPolicy,
-		)
-		createLambdaErrorAlarm(
-			checkLiveStreamStatusFunction,
-			'CheckLiveStreamStatusErrorsAlarm',
-			'Lambda check_live_stream_status errors > 0',
 		)
 
 		const updateWorkNameTrendFunction = new lambda.DockerImageFunction(
@@ -675,11 +660,6 @@ export class AwsCdkStack extends cdk.Stack {
 		openaiApiKeySecret.grantRead(updateWorkNameTrendFunction)
 		;(updateWorkNameTrendFunction.role as iam.Role).addToPolicy(
 			dynamoDBAccessPolicy,
-		)
-		createLambdaErrorAlarm(
-			updateWorkNameTrendFunction,
-			'UpdateWorkNameTrendErrorsAlarm',
-			'Lambda update_work_name_trend errors > 0',
 		)
 
 		const errorLogNotifyDiscordFunction = new lambda.DockerImageFunction(

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -170,6 +170,16 @@ describe('AwsCdkStack', () => {
 		)
 		expect(descriptions).toContain('Lambda sns_notify_discord errors > 0')
 		expect(descriptions).toContain('Lambda start_daily_batch errors > 0')
+		expect(descriptions).not.toContain('Lambda set_desired_max_seats errors > 0')
+		expect(descriptions).not.toContain(
+			'Lambda youtube_organize_database errors > 0',
+		)
+		expect(descriptions).not.toContain(
+			'Lambda check_live_stream_status errors > 0',
+		)
+		expect(descriptions).not.toContain(
+			'Lambda update_work_name_trend errors > 0',
+		)
 	})
 
 	test('creates error_log_notify_discord Lambda, errors alarm, and target ERROR subscription filters', () => {

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -170,16 +170,6 @@ describe('AwsCdkStack', () => {
 		)
 		expect(descriptions).toContain('Lambda sns_notify_discord errors > 0')
 		expect(descriptions).toContain('Lambda start_daily_batch errors > 0')
-		expect(descriptions).not.toContain('Lambda set_desired_max_seats errors > 0')
-		expect(descriptions).not.toContain(
-			'Lambda youtube_organize_database errors > 0',
-		)
-		expect(descriptions).not.toContain(
-			'Lambda check_live_stream_status errors > 0',
-		)
-		expect(descriptions).not.toContain(
-			'Lambda update_work_name_trend errors > 0',
-		)
 	})
 
 	test('creates error_log_notify_discord Lambda, errors alarm, and target ERROR subscription filters', () => {

--- a/system/Dockerfile.fargate
+++ b/system/Dockerfile.fargate
@@ -1,4 +1,4 @@
-FROM golang:1.26@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716 AS build
+FROM golang:1.25@sha256:3760478c76cfe25533e06176e983e7808293895d48d15d0981c0cbb9623834e7 AS build
 WORKDIR /src
 
 # 依存関係キャッシュを効かせるために先に go.mod/go.sum だけコピー
@@ -22,4 +22,3 @@ ENV TZ=Asia/Tokyo
 COPY --from=build /out/batch /app/batch
 USER nonroot:nonroot
 ENTRYPOINT ["/app/batch"]
-

--- a/system/Dockerfile.lambda
+++ b/system/Dockerfile.lambda
@@ -1,5 +1,5 @@
 # Digest is authoritative; this digest was verified against golang:1.25 when pinned.
-FROM golang:1.26@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716 AS build
+FROM golang:1.25@sha256:3760478c76cfe25533e06176e983e7808293895d48d15d0981c0cbb9623834e7 AS build
 WORKDIR /var/task
 
 # 依存関係キャッシュを効かせるために先に go.mod/go.sum だけコピー

--- a/youtube-monitor/src/components/SeatBox.test.tsx
+++ b/youtube-monitor/src/components/SeatBox.test.tsx
@@ -18,14 +18,13 @@ jest.mock('next/font/google', () => ({
 jest.mock('next/image', () => ({
 	__esModule: true,
 	default: (props: ComponentPropsWithoutRef<'img'>) => {
-		const { alt, src, ...rest } = props
+		const { alt, src } = props
 		return (
 			<span
 				role="img"
 				aria-label={alt}
 				data-next-image=""
 				data-src={typeof src === 'string' ? src : ''}
-				{...rest}
 			/>
 		)
 	},

--- a/youtube-monitor/src/styles/CenterLoading.styles.ts
+++ b/youtube-monitor/src/styles/CenterLoading.styles.ts
@@ -1,5 +1,11 @@
-import { css } from '@emotion/react'
+import { css, keyframes } from '@emotion/react'
 import { Constants } from '../lib/constants'
+
+const centerLoadingSpin = keyframes`
+    to {
+        transform: rotate(360deg);
+    }
+`
 
 export const CenterLoading = css`
     position: absolute;
@@ -22,11 +28,5 @@ export const spinner = css`
     border: 6px solid rgba(255, 255, 255, 0.2);
     border-top-color: ${Constants.primaryTextColor};
     border-radius: 9999px;
-    animation: spin 0.9s linear infinite;
-
-    @keyframes spin {
-        to {
-            transform: rotate(360deg);
-        }
-    }
+    animation: ${centerLoadingSpin} 0.9s linear infinite;
 `


### PR DESCRIPTION
## Summary
- Align Go Docker build images back to Go 1.25 to match go.mod and project docs
- Remove Lambda Errors alarms for handlers that intentionally convert handled failures into log/response paths, keeping ERROR log subscriptions as the alert route
- Scope the CenterLoading spinner keyframes through Emotion and stop spreading unsupported props in the next/image test mock

## Validation
- youtube-monitor: pnpm exec biome check src/styles/CenterLoading.styles.ts src/components/SeatBox.test.tsx
- youtube-monitor: pnpm test -- SeatBox.test.tsx --runInBand
- aws-cdk: pnpm test