### PR TITLE
restore: 定期 Lambda の createLambdaErrorAlarm を復元

### DIFF
--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -615,6 +615,11 @@ export class AwsCdkStack extends cdk.Stack {
 		;(setDesiredMaxSeatsFunction.role as iam.Role).addToPolicy(
 			dynamoDBAccessPolicy,
 		)
+		createLambdaErrorAlarm(
+			setDesiredMaxSeatsFunction,
+			'SetDesiredMaxSeatsErrorsAlarm',
+			'Lambda set_desired_max_seats errors > 0',
+		)
 
 		const youtubeOrganizeDatabaseFunction = new lambda.DockerImageFunction(
 			this,
@@ -629,6 +634,11 @@ export class AwsCdkStack extends cdk.Stack {
 		;(youtubeOrganizeDatabaseFunction.role as iam.Role).addToPolicy(
 			dynamoDBAccessPolicy,
 		)
+		createLambdaErrorAlarm(
+			youtubeOrganizeDatabaseFunction,
+			'YoutubeOrganizeDatabaseErrorsAlarm',
+			'Lambda youtube_organize_database errors > 0',
+		)
 
 		const checkLiveStreamStatusFunction = new lambda.DockerImageFunction(
 			this,
@@ -642,6 +652,11 @@ export class AwsCdkStack extends cdk.Stack {
 		)
 		;(checkLiveStreamStatusFunction.role as iam.Role).addToPolicy(
 			dynamoDBAccessPolicy,
+		)
+		createLambdaErrorAlarm(
+			checkLiveStreamStatusFunction,
+			'CheckLiveStreamStatusErrorsAlarm',
+			'Lambda check_live_stream_status errors > 0',
 		)
 
 		const updateWorkNameTrendFunction = new lambda.DockerImageFunction(
@@ -660,6 +675,11 @@ export class AwsCdkStack extends cdk.Stack {
 		openaiApiKeySecret.grantRead(updateWorkNameTrendFunction)
 		;(updateWorkNameTrendFunction.role as iam.Role).addToPolicy(
 			dynamoDBAccessPolicy,
+		)
+		createLambdaErrorAlarm(
+			updateWorkNameTrendFunction,
+			'UpdateWorkNameTrendErrorsAlarm',
+			'Lambda update_work_name_trend errors > 0',
 		)
 
 		const errorLogNotifyDiscordFunction = new lambda.DockerImageFunction(

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -241,16 +241,12 @@ describe('AwsCdkStack', () => {
 		}
 		const resources = json.Resources ?? {}
 
-		// 将来 Errors アラーム不要な Lambda が現れたらここに追加する
-		const EXEMPT_FUNCTION_NAMES: readonly string[] = []
-
 		// 対象 Lambda: スタックで明示的に FunctionName を付与しているユーザー Lambda のみ。
 		// CDK 内部の LogRetention 用 Lambda などは FunctionName を持たないため自然に除外される。
 		const targetLambdaEntries = Object.entries(resources).filter(
 			([, r]) =>
 				r.Type === 'AWS::Lambda::Function' &&
-				typeof r.Properties?.FunctionName === 'string' &&
-				!EXEMPT_FUNCTION_NAMES.includes(r.Properties.FunctionName as string),
+				typeof r.Properties?.FunctionName === 'string',
 		)
 		expect(targetLambdaEntries.length).toBeGreaterThan(0)
 

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -162,17 +162,7 @@ describe('AwsCdkStack', () => {
 		expect(emailSubscription?.Condition).toBe('HasAlarmEmail')
 	})
 
-	test('creates Lambda errors alarms for sns_notify_discord and start_daily_batch', () => {
-		const t = createTemplate()
-		const alarms = t.findResources('AWS::CloudWatch::Alarm')
-		const descriptions = Object.values(alarms).map(
-			(a) => (a as { Properties?: { AlarmDescription?: string } }).Properties?.AlarmDescription,
-		)
-		expect(descriptions).toContain('Lambda sns_notify_discord errors > 0')
-		expect(descriptions).toContain('Lambda start_daily_batch errors > 0')
-	})
-
-	test('creates error_log_notify_discord Lambda, errors alarm, and target ERROR subscription filters', () => {
+	test('creates error_log_notify_discord Lambda and target ERROR subscription filters', () => {
 		const t = createTemplate()
 		const json = t.toJSON() as {
 			Resources?: Record<
@@ -229,12 +219,75 @@ describe('AwsCdkStack', () => {
 				r.Properties?.Principal === 'logs.amazonaws.com',
 		)
 		expect(logsInvokePerms.length).toBeGreaterThanOrEqual(3)
+	})
 
-		const alarms = t.findResources('AWS::CloudWatch::Alarm')
-		const descriptions = Object.values(alarms).map(
-			(a) => (a as { Properties?: { AlarmDescription?: string } }).Properties?.AlarmDescription,
+	test('every Lambda function has an Errors > 0 alarm wired to AWS/Lambda metric', () => {
+		const t = createTemplate()
+		const json = t.toJSON() as {
+			Resources?: Record<
+				string,
+				{
+					Type?: string
+					Properties?: {
+						FunctionName?: string
+						MetricName?: string
+						Namespace?: string
+						Threshold?: number
+						ComparisonOperator?: string
+						Dimensions?: Array<{ Name?: string; Value?: unknown }>
+					}
+				}
+			>
+		}
+		const resources = json.Resources ?? {}
+
+		// 将来 Errors アラーム不要な Lambda が現れたらここに追加する
+		const EXEMPT_FUNCTION_NAMES: readonly string[] = []
+
+		// 対象 Lambda: スタックで明示的に FunctionName を付与しているユーザー Lambda のみ。
+		// CDK 内部の LogRetention 用 Lambda などは FunctionName を持たないため自然に除外される。
+		const targetLambdaEntries = Object.entries(resources).filter(
+			([, r]) =>
+				r.Type === 'AWS::Lambda::Function' &&
+				typeof r.Properties?.FunctionName === 'string' &&
+				!EXEMPT_FUNCTION_NAMES.includes(r.Properties.FunctionName as string),
 		)
-		expect(descriptions).toContain('Lambda error_log_notify_discord errors > 0')
+		expect(targetLambdaEntries.length).toBeGreaterThan(0)
+
+		const errorsAlarms = Object.values(resources).filter(
+			(r) =>
+				r.Type === 'AWS::CloudWatch::Alarm' &&
+				r.Properties?.MetricName === 'Errors' &&
+				r.Properties?.Namespace === 'AWS/Lambda' &&
+				r.Properties?.Threshold === 0 &&
+				r.Properties?.ComparisonOperator === 'GreaterThanThreshold',
+		)
+
+		const referencedLambdaLogicalIds = new Set<string>()
+		for (const alarm of errorsAlarms) {
+			for (const d of alarm.Properties?.Dimensions ?? []) {
+				if (d.Name !== 'FunctionName') continue
+				const value = d.Value as
+					| { Ref?: string; 'Fn::GetAtt'?: [string, string] }
+					| undefined
+				if (value && typeof value.Ref === 'string') {
+					referencedLambdaLogicalIds.add(value.Ref)
+				}
+				if (value && Array.isArray(value['Fn::GetAtt'])) {
+					referencedLambdaLogicalIds.add(value['Fn::GetAtt'][0])
+				}
+			}
+		}
+
+		for (const [lid, r] of targetLambdaEntries) {
+			expect({
+				functionName: r.Properties?.FunctionName,
+				hasErrorsAlarm: referencedLambdaLogicalIds.has(lid),
+			}).toEqual({
+				functionName: r.Properties?.FunctionName,
+				hasErrorsAlarm: true,
+			})
+		}
 	})
 })
 


### PR DESCRIPTION
## 概要
PR #822 で削除された `createLambdaErrorAlarm` を、定期実行系 Lambda 4つに対して復元します。

## 背景
`handler` が `err` を返さない設計でも、Lambda の `Errors > 0` は panic / timeout / init 失敗 / ペイロード不正などで発生し得ます。アプリ層の握り潰しとは独立した最終防衛線として CloudWatch アラームを残します。

## 変更
- `set_desired_max_seats`
- `youtube_organize_database`
- `check_live_stream_status`
- `update_work_name_trend`

## 関連
- #822

Made with [Cursor](https://cursor.com)