### PR TITLE
refactor(workspaceapp): OrganizeDBResume を SeatDoc.ResumeWork に統一

### DIFF
--- a/system/core/workspaceapp/batch.go
+++ b/system/core/workspaceapp/batch.go
@@ -149,7 +149,6 @@ func (app *WorkspaceApp) OrganizeDBResume(ctx context.Context, isMemberRoom bool
 			// 以下書き込みのみ
 
 			if resume { // 作業再開処理
-				until := seat.Until
 				breakSegment, err := seat.GenerateWorkSegment(jstNow, isMemberRoom)
 				if err != nil {
 					return fmt.Errorf("in GenerateWorkSegment(): %w", err)
@@ -158,18 +157,9 @@ func (app *WorkspaceApp) OrganizeDBResume(ctx context.Context, isMemberRoom bool
 					return fmt.Errorf("in CreateWorkSegmentDoc(): %w", err)
 				}
 
-				// もし日付を跨いで休憩してたら、daily-cumulative-work-secは0にリセットする
-				breakSec := int(timeutil.NoNegativeDuration(jstNow.Sub(seat.CurrentStateStartedAt)).Seconds())
-				var dailyCumulativeWorkSec = seat.DailyCumulativeWorkSec
-				if breakSec > timeutil.SecondsOfDay(jstNow) {
-					dailyCumulativeWorkSec = 0
+				if err := seat.ResumeWork(jstNow, seat.WorkName); err != nil {
+					return fmt.Errorf("in ResumeWork(): %w", err)
 				}
-
-				seat.State = repository.WorkState
-				seat.CurrentStateStartedAt = jstNow
-				seat.CurrentStateUntil = until
-				seat.CurrentSegmentStartedAt = jstNow
-				seat.DailyCumulativeWorkSec = dailyCumulativeWorkSec
 				if err := app.Repository.UpdateSeat(ctx, tx, seat, isMemberRoom); err != nil {
 					return fmt.Errorf("in UpdateSeat(): %w", err)
 				}
@@ -186,7 +176,11 @@ func (app *WorkspaceApp) OrganizeDBResume(ctx context.Context, isMemberRoom bool
 				}
 				seatIDStr := presenter.SeatIDStr(seat.SeatID, isMemberRoom)
 
-				liveChatMessage = i18nmsg.CommandResumeWork(app.ProcessedUserDisplayName, seatIDStr, int(timeutil.NoNegativeDuration(until.Sub(jstNow)).Minutes()))
+				liveChatMessage = i18nmsg.CommandResumeWork(
+					app.ProcessedUserDisplayName,
+					seatIDStr,
+					seat.RemainingWorkMin(jstNow),
+				)
 			}
 			return nil
 		})


### PR DESCRIPTION
## 概要
休憩満了時の自動再開（`OrganizeDBResume`）で、座席状態の手書き更新を `SeatDoc.ResumeWork` に寄せました。`command_seat.go` の手動再開と同じドメイン操作になります。

## 変更内容
- 日跨ぎ時の `DailyCumulativeWorkSec` リセットや `State` / `CurrentState*` 更新は `ResumeWork` に集約
- ライブチャットの残り退室までの分は `seat.RemainingWorkMin(jstNow)`（`Until` 基準で従来と同値）
- **順序**: `GenerateWorkSegment` → `CreateWorkSegmentDoc` → `ResumeWork` → `UpdateSeat`（休憩セグメント記録のため `ResumeWork` より前にセグメント生成を維持）

## 検証
- `go test -shuffle=on ./core/workspaceapp/... ./core/repository/...`

Made with [Cursor](https://cursor.com)