### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,7 +269,7 @@ Representative chat commands (full strings and member variants live in `system/c
 ## Cursor Cloud specific instructions
 
 ### Go Version
-- `system/go.mod` requires Go **1.25.0**. The VM update script installs this version automatically. Verify with `go version`.
+- Go プロジェクト（`system/`, `tools/room-image-prompt/`）はいずれも `go.mod` で Go **1.25.0** を要求する。Cursor Cloud の VM 起動時スクリプト（SetupVmEnvironment で設定）が自動インストールする。手動で確認する場合: `go version`。
 
 ### Subproject Layout
 - Node/pnpm サブプロジェクト（`youtube-monitor/`, `aws-cdk/`, `docs-site/`, `tools/menu-image-generator/`, `tools/figma-plugin/room-layout-analyzer/`, `tools/video-maker/1000-minutes-simulator/`）はそれぞれ独立した `pnpm-lock.yaml` を持つ（workspace-level pnpm monorepo ではない）。`pnpm install` は必要なディレクトリごとに個別実行する。Go プロジェクト（`system/`, `tools/room-image-prompt/`）は `go.mod` で管理。
@@ -278,10 +278,12 @@ Representative chat commands (full strings and member variants live in `system/c
 - **Go backend**: `cd system && go test -shuffle=on -v ./...` — uses mocks, no Firestore/YouTube credentials needed.
 - **Frontend**: `cd youtube-monitor && pnpm test` — Jest + jsdom, fully offline.
 - **AWS CDK**: `cd aws-cdk && pnpm test` — unit tests for schedule/infrastructure invariants.
-- **Docs site**: `cd docs-site && pnpm build` — static build verification.
+
+### Build Verification
+- **Docs site**: `cd docs-site && pnpm build` — static build verification (テストスクリプトはないため、ビルド成功で検証する)。
 
 ### Running Lint
-- **Go**: `cd system && golangci-lint run --timeout=5m --config=.golangci.yml` (golangci-lint v2.11.3 installed by update script).
+- **Go**: `cd system && golangci-lint run --timeout=5m --config=.golangci.yml` (golangci-lint v2.11.3; VM 起動時スクリプトが自動インストール)。
 - **Frontend**: `cd youtube-monitor && pnpm exec biome check .`
 - **Docs site**: `cd docs-site && pnpm lint`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,3 +265,38 @@ Representative chat commands (full strings and member variants live in `system/c
 ### Third-Party
 - **Discord**: Notification webhooks for moderation and failures
 - **OpenAI API**: Work name trend generation
+
+## Cursor Cloud specific instructions
+
+### Go Version
+- `system/go.mod` requires Go **1.25.0**. The VM update script installs this version automatically. Verify with `go version`.
+
+### Subproject Layout
+- Each subproject (`youtube-monitor/`, `aws-cdk/`, `docs-site/`, `tools/*`) has its own independent `pnpm-lock.yaml`; there is no workspace-level pnpm monorepo. Run `pnpm install` separately in each directory you need.
+
+### Running Tests (all offline — no external services required)
+- **Go backend**: `cd system && go test -shuffle=on -v ./...` — uses mocks, no Firestore/YouTube credentials needed.
+- **Frontend**: `cd youtube-monitor && pnpm test` — Jest + jsdom, fully offline.
+- **AWS CDK**: `cd aws-cdk && pnpm test` — unit tests for schedule/infrastructure invariants.
+- **Docs site**: `cd docs-site && pnpm build` — static build verification.
+
+### Running Lint
+- **Go**: `cd system && golangci-lint run --timeout=5m --config=.golangci.yml` (golangci-lint v2.11.3 installed by update script).
+- **Frontend**: `cd youtube-monitor && pnpm exec biome check .`
+- **Docs site**: `cd docs-site && pnpm lint`
+
+### Frontend Dev Server
+- The frontend (`youtube-monitor/`) requires `NEXT_PUBLIC_*` environment variables to start. For local/CI dev, use dummy values matching CI (see `.github/workflows/test.yml` `youtube-monitor-build` job for the full set). Example:
+  ```bash
+  NEXT_PUBLIC_DEBUG=false NEXT_PUBLIC_CHANNEL_GL=false NEXT_PUBLIC_ROOM_CONFIG=DEV \
+  NEXT_PUBLIC_API_ENDPOINT=http://localhost:3000 NEXT_PUBLIC_API_KEY=ci-dummy-api-key \
+  NEXT_PUBLIC_FIREBASE_PROJECT_ID=ci-dummy-project NEXT_PUBLIC_FIREBASE_API_KEY=ci-dummy-firebase-api-key \
+  pnpm dev
+  ```
+- The UI will load but remain in a "Loading…" state without a real Firestore backend — this is expected behavior for the dev environment without credentials.
+
+### Frontend Build
+- `pnpm build` in `youtube-monitor/` also requires the same `NEXT_PUBLIC_*` env vars to be set.
+
+### Docs Site
+- `cd docs-site && pnpm start --no-open` runs the Docusaurus dev server. No external credentials needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,7 +272,7 @@ Representative chat commands (full strings and member variants live in `system/c
 - `system/go.mod` requires Go **1.25.0**. The VM update script installs this version automatically. Verify with `go version`.
 
 ### Subproject Layout
-- Each subproject (`youtube-monitor/`, `aws-cdk/`, `docs-site/`, `tools/*`) has its own independent `pnpm-lock.yaml`; there is no workspace-level pnpm monorepo. Run `pnpm install` separately in each directory you need.
+- Node/pnpm サブプロジェクト（`youtube-monitor/`, `aws-cdk/`, `docs-site/`, `tools/menu-image-generator/`, `tools/figma-plugin/room-layout-analyzer/`, `tools/video-maker/1000-minutes-simulator/`）はそれぞれ独立した `pnpm-lock.yaml` を持つ（workspace-level pnpm monorepo ではない）。`pnpm install` は必要なディレクトリごとに個別実行する。Go プロジェクト（`system/`, `tools/room-image-prompt/`）は `go.mod` で管理。
 
 ### Running Tests (all offline — no external services required)
 - **Go backend**: `cd system && go test -shuffle=on -v ./...` — uses mocks, no Firestore/YouTube credentials needed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

AGENTS.md に Cursor Cloud 環境向けの開発セットアップ手順を追記しました。

### 追加内容
- Go 1.25.0 のバージョン要件
- サブプロジェクト構成（独立した pnpm-lock.yaml）の説明
- 各サービスのテスト・リント・ビルド・実行コマンド（すべてオフラインで動作）
- フロントエンド dev サーバーに必要な `NEXT_PUBLIC_*` 環境変数のダミー値例
- docs-site の起動方法

### 検証結果

| Service | Test | Lint | Build | Dev Server |
|---------|------|------|-------|------------|
| Go Backend (`system/`) | ✅ `go test` | ✅ `golangci-lint` | ✅ `go build` | N/A (requires credentials) |
| Frontend (`youtube-monitor/`) | ✅ `pnpm test` | ✅ `biome check` | ✅ `pnpm build` | ✅ `pnpm dev` (HTTP 200) |
| AWS CDK (`aws-cdk/`) | ✅ `pnpm test` | N/A | ✅ (via pretest) | N/A |
| Docs Site (`docs-site/`) | ✅ `pnpm lint` | ✅ | ✅ `pnpm build` | ✅ `pnpm start` (HTTP 200) |

### Demo

Frontend dev server running:
[Frontend study space UI](https://cursor.com/agents/bc-ff38e37e-4fa6-4634-96ee-75de0b36d2e9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffrontend_study_space_ui.webp)

Docs site running:
[Docs site homepage](https://cursor.com/agents/bc-ff38e37e-4fa6-4634-96ee-75de0b36d2e9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_site_homepage.webp)
[Docs site commands page](https://cursor.com/agents/bc-ff38e37e-4fa6-4634-96ee-75de0b36d2e9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_site_commands.webp)

[frontend_dev_server_demo.mp4](https://cursor.com/agents/bc-ff38e37e-4fa6-4634-96ee-75de0b36d2e9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffrontend_dev_server_demo.mp4)
[docs_site_demo.mp4](https://cursor.com/agents/bc-ff38e37e-4fa6-4634-96ee-75de0b36d2e9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_site_demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff38e37e-4fa6-4634-96ee-75de0b36d2e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff38e37e-4fa6-4634-96ee-75de0b36d2e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

