### PR TITLE
[codex] YouTubeチャット投稿失敗時のログレベルを見直す

### DIFF
--- a/system/core/youtubebot/errors.go
+++ b/system/core/youtubebot/errors.go
@@ -1,0 +1,36 @@
+package youtubebot
+
+import (
+	"errors"
+	"strings"
+
+	"google.golang.org/api/googleapi"
+)
+
+func isLiveChatEndedError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var googleErr *googleapi.Error
+	if !errors.As(err, &googleErr) {
+		return false
+	}
+
+	if googleErr.Code != 403 {
+		return false
+	}
+
+	for _, item := range googleErr.Errors {
+		if item.Reason == "liveChatEnded" {
+			return true
+		}
+	}
+
+	if len(googleErr.Errors) > 0 {
+		return false
+	}
+
+	return strings.Contains(googleErr.Message, "liveChatEnded") ||
+		strings.Contains(googleErr.Body, "liveChatEnded")
+}

--- a/system/core/youtubebot/errors_test.go
+++ b/system/core/youtubebot/errors_test.go
@@ -1,0 +1,107 @@
+package youtubebot
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/googleapi"
+)
+
+func TestIsLiveChatEndedError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "non googleapi error",
+			err:  errors.New("liveChatEnded"),
+			want: false,
+		},
+		{
+			name: "403 liveChatEnded reason",
+			err: &googleapi.Error{
+				Code: 403,
+				Errors: []googleapi.ErrorItem{
+					{Reason: "liveChatEnded"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "403 without reason",
+			err: &googleapi.Error{
+				Code: 403,
+			},
+			want: false,
+		},
+		{
+			name: "403 different reason",
+			err: &googleapi.Error{
+				Code: 403,
+				Errors: []googleapi.ErrorItem{
+					{Reason: "forbidden"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "fallback message",
+			err: &googleapi.Error{
+				Code:    403,
+				Message: "The specified live chat is no longer live., liveChatEnded",
+			},
+			want: true,
+		},
+		{
+			name: "fallback body",
+			err: &googleapi.Error{
+				Code: 403,
+				Body: `{"error":{"errors":[{"reason":"liveChatEnded"}]}}`,
+			},
+			want: true,
+		},
+		{
+			name: "does not use fallback when errors are present",
+			err: &googleapi.Error{
+				Code:    403,
+				Message: "liveChatEnded",
+				Errors: []googleapi.ErrorItem{
+					{Reason: "forbidden"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "non 403 with liveChatEnded text",
+			err: &googleapi.Error{
+				Code:    500,
+				Message: "liveChatEnded",
+			},
+			want: false,
+		},
+		{
+			name: "wrapped liveChatEnded error",
+			err: fmt.Errorf("wrapped: %w", &googleapi.Error{
+				Code: 403,
+				Errors: []googleapi.ErrorItem{
+					{Reason: "liveChatEnded"},
+				},
+			}),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isLiveChatEndedError(tt.err))
+		})
+	}
+}

--- a/system/core/youtubebot/live_chat.go
+++ b/system/core/youtubebot/live_chat.go
@@ -2,11 +2,10 @@ package youtubebot
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strconv"
 	"unicode/utf8"
-
-	"errors"
 
 	"app.modules/core/repository"
 	"app.modules/core/utils"
@@ -187,14 +186,19 @@ func (b *YoutubeLiveChatBot) postMessage(ctx context.Context, message string) er
 	}
 
 	// 2回目の試行
-	slog.Error("first post failed", "err", err)
+	slog.Warn("first post failed; retrying", "err", err)
 	err = b.tryPostMessage(message, b.LiveChatID)
 	if err == nil {
 		slog.Info("second post succeeded!")
 		return nil
 	}
 
-	slog.Error("second post failed", "err", err)
+	if isLiveChatEndedError(err) {
+		slog.Warn("post skipped because live chat ended", "err", err)
+		return nil
+	}
+
+	slog.Warn("second post failed; refreshing live chat id", "err", err)
 
 	// live chat idが変わっている可能性があるため、更新して再試行
 	if err := b.refreshLiveChatID(ctx); err != nil {
@@ -204,6 +208,10 @@ func (b *YoutubeLiveChatBot) postMessage(ctx context.Context, message string) er
 	// 3回目の試行（更新されたLiveChatIDで）
 	err = b.tryPostMessage(message, b.LiveChatID)
 	if err != nil {
+		if isLiveChatEndedError(err) {
+			slog.Warn("post skipped because live chat ended", "err", err)
+			return nil
+		}
 		slog.Error("third post failed", "err", err)
 		return err
 	}

--- a/system/core/youtubebot/live_chat.go
+++ b/system/core/youtubebot/live_chat.go
@@ -185,6 +185,10 @@ func (b *YoutubeLiveChatBot) postMessage(ctx context.Context, message string) er
 		return nil
 	}
 
+	if handleLiveChatEndedPostFailure(err) {
+		return nil
+	}
+
 	// 2回目の試行
 	slog.Warn("first post failed; retrying", "err", err)
 	err = b.tryPostMessage(message, b.LiveChatID)
@@ -193,8 +197,7 @@ func (b *YoutubeLiveChatBot) postMessage(ctx context.Context, message string) er
 		return nil
 	}
 
-	if isLiveChatEndedError(err) {
-		slog.Warn("post skipped because live chat ended", "err", err)
+	if handleLiveChatEndedPostFailure(err) {
 		return nil
 	}
 
@@ -208,8 +211,7 @@ func (b *YoutubeLiveChatBot) postMessage(ctx context.Context, message string) er
 	// 3回目の試行（更新されたLiveChatIDで）
 	err = b.tryPostMessage(message, b.LiveChatID)
 	if err != nil {
-		if isLiveChatEndedError(err) {
-			slog.Warn("post skipped because live chat ended", "err", err)
+		if handleLiveChatEndedPostFailure(err) {
 			return nil
 		}
 		slog.Error("third post failed", "err", err)
@@ -218,6 +220,15 @@ func (b *YoutubeLiveChatBot) postMessage(ctx context.Context, message string) er
 
 	slog.Info("third post succeeded!")
 	return nil
+}
+
+func handleLiveChatEndedPostFailure(err error) bool {
+	if !isLiveChatEndedError(err) {
+		return false
+	}
+
+	slog.Warn("post skipped because live chat ended", "err", err)
+	return true
 }
 
 // tryPostMessage 指定されたLiveChatIDでメッセージを送信する

--- a/system/core/youtubebot/live_chat_post_test.go
+++ b/system/core/youtubebot/live_chat_post_test.go
@@ -49,6 +49,33 @@ func TestPostMessageLogsWarnAndSkipsLiveChatEnded(t *testing.T) {
 	assert.False(t, hasLogLevel(entries, "ERROR"))
 }
 
+func TestPostMessageSkipsRetryWhenFirstPostFailsWithLiveChatEnded(t *testing.T) {
+	var insertCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/youtube/v3/liveChat/messages", r.URL.Path)
+		insertCount++
+		writeGoogleAPIError(t, w, http.StatusForbidden, "liveChatEnded")
+	}))
+	defer server.Close()
+
+	service := newTestYouTubeService(t, server)
+	bot := &YoutubeLiveChatBot{
+		LiveChatID:        "live-chat-id",
+		BotYoutubeService: service,
+	}
+	logs := captureSlog(t)
+
+	err := bot.postMessage(context.Background(), "hello")
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, insertCount)
+
+	entries := readLogEntries(t, logs)
+	assert.True(t, hasLogEntry(entries, "WARN", "post skipped because live chat ended"))
+	assert.False(t, hasLogEntry(entries, "WARN", "first post failed; retrying"))
+	assert.False(t, hasLogLevel(entries, "ERROR"))
+}
+
 func TestPostMessageLogsErrorAfterRefreshRetryFails(t *testing.T) {
 	var insertCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/system/core/youtubebot/live_chat_post_test.go
+++ b/system/core/youtubebot/live_chat_post_test.go
@@ -1,0 +1,182 @@
+package youtubebot
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	mock_repository "app.modules/core/repository/mocks"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/api/option"
+	"google.golang.org/api/youtube/v3"
+)
+
+func TestPostMessageLogsWarnAndSkipsLiveChatEnded(t *testing.T) {
+	var insertCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/youtube/v3/liveChat/messages", r.URL.Path)
+		insertCount++
+		if insertCount == 1 {
+			writeGoogleAPIError(t, w, http.StatusInternalServerError, "backendError")
+			return
+		}
+		writeGoogleAPIError(t, w, http.StatusForbidden, "liveChatEnded")
+	}))
+	defer server.Close()
+
+	service := newTestYouTubeService(t, server)
+	bot := &YoutubeLiveChatBot{
+		LiveChatID:        "live-chat-id",
+		BotYoutubeService: service,
+	}
+	logs := captureSlog(t)
+
+	err := bot.postMessage(context.Background(), "hello")
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, insertCount)
+
+	entries := readLogEntries(t, logs)
+	assert.True(t, hasLogEntry(entries, "WARN", "first post failed; retrying"))
+	assert.True(t, hasLogEntry(entries, "WARN", "post skipped because live chat ended"))
+	assert.False(t, hasLogLevel(entries, "ERROR"))
+}
+
+func TestPostMessageLogsErrorAfterRefreshRetryFails(t *testing.T) {
+	var insertCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/youtube/v3/liveChat/messages":
+			insertCount++
+			writeGoogleAPIError(t, w, http.StatusInternalServerError, "backendError")
+		case "/youtube/v3/liveBroadcasts":
+			w.Header().Set("Content-Type", "application/json")
+			writeResponseBody(t, w, `{"items":[{"snippet":{"liveChatId":"new-live-chat-id"}}]}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	repository := mock_repository.NewMockRepository(ctrl)
+	repository.EXPECT().
+		UpdateLiveChatID(gomock.Any(), nil, "new-live-chat-id").
+		Return(nil)
+
+	service := newTestYouTubeService(t, server)
+	bot := &YoutubeLiveChatBot{
+		LiveChatID:            "old-live-chat-id",
+		ChannelYoutubeService: service,
+		BotYoutubeService:     service,
+		FirestoreController:   repository,
+	}
+	logs := captureSlog(t)
+
+	err := bot.postMessage(context.Background(), "hello")
+
+	assert.Error(t, err)
+	assert.Equal(t, 3, insertCount)
+	assert.Equal(t, "new-live-chat-id", bot.LiveChatID)
+
+	entries := readLogEntries(t, logs)
+	assert.True(t, hasLogEntry(entries, "WARN", "first post failed; retrying"))
+	assert.True(t, hasLogEntry(entries, "WARN", "second post failed; refreshing live chat id"))
+	assert.True(t, hasLogEntry(entries, "ERROR", "third post failed"))
+}
+
+func newTestYouTubeService(t *testing.T, server *httptest.Server) *youtube.Service {
+	t.Helper()
+
+	service, err := youtube.NewService(
+		context.Background(),
+		option.WithEndpoint(server.URL+"/"),
+		option.WithHTTPClient(server.Client()),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("failed to create YouTube service: %v", err)
+	}
+	return service
+}
+
+func writeGoogleAPIError(t *testing.T, w http.ResponseWriter, statusCode int, reason string) {
+	t.Helper()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	writeResponseBody(
+		t,
+		w,
+		`{"error":{"code":%d,"message":"%s","errors":[{"reason":"%s","message":"%s"}]}}`,
+		statusCode,
+		reason,
+		reason,
+		reason,
+	)
+}
+
+func writeResponseBody(t *testing.T, w http.ResponseWriter, format string, args ...any) {
+	t.Helper()
+
+	if _, err := fmt.Fprintf(w, format, args...); err != nil {
+		t.Fatalf("failed to write response body: %v", err)
+	}
+}
+
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() {
+		slog.SetDefault(old)
+	})
+	return &buf
+}
+
+func readLogEntries(t *testing.T, logs *bytes.Buffer) []map[string]any {
+	t.Helper()
+
+	lines := strings.Split(strings.TrimSpace(logs.String()), "\n")
+	entries := make([]map[string]any, 0, len(lines))
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("log output is not valid JSON: %v, output=%s", err, line)
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func hasLogEntry(entries []map[string]any, level string, message string) bool {
+	for _, entry := range entries {
+		if entry["level"] == level && entry["msg"] == message {
+			return true
+		}
+	}
+	return false
+}
+
+func hasLogLevel(entries []map[string]any, level string) bool {
+	for _, entry := range entries {
+		if entry["level"] == level {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Adjust YouTube live chat post retry logs so intermediate failures are WARN instead of ERROR
- Treat liveChatEnded final failures as WARN and skip app-failure escalation
- Add googleapi.Error detection tests and postMessage log-level tests

## Validation
- go test ./core/youtubebot/...

Closes #792