### PR TITLE
feat(mypage): connect frontend auth flow to mypage API contract

### DIFF
--- a/mypage/src/features/auth/loginErrorMessage.test.ts
+++ b/mypage/src/features/auth/loginErrorMessage.test.ts
@@ -1,7 +1,12 @@
 import { FirebaseError } from 'firebase/app'
 import { describe, expect, it } from 'vitest'
 
-import { ApiError, UnauthorizedError } from '../mypage/api'
+import {
+	ApiError,
+	ChannelAlreadyLinkedError,
+	InvalidYouTubeAccessTokenError,
+	UnauthorizedError,
+} from '../mypage/api'
 import { MissingYouTubeAccessTokenError } from './errors'
 import { getLoginErrorMessage } from './loginErrorMessage'
 
@@ -25,6 +30,18 @@ describe('getLoginErrorMessage', () => {
 		expect(getLoginErrorMessage(new UnauthorizedError())).toContain(
 			'もう一度ログイン',
 		)
+	})
+
+	it('別アカウントに連携済みのチャンネルを案内する', () => {
+		expect(getLoginErrorMessage(new ChannelAlreadyLinkedError())).toContain(
+			'別のログインアカウントに連携済み',
+		)
+	})
+
+	it('YouTubeアクセストークンが無効な場合は再認可を案内する', () => {
+		expect(
+			getLoginErrorMessage(new InvalidYouTubeAccessTokenError()),
+		).toContain('YouTube情報の読み取りを許可')
 	})
 
 	it('APIの5xxを一時的なサービス障害として案内する', () => {

--- a/mypage/src/features/auth/loginErrorMessage.ts
+++ b/mypage/src/features/auth/loginErrorMessage.ts
@@ -1,6 +1,11 @@
 import { FirebaseError } from 'firebase/app'
 
-import { ApiError, UnauthorizedError } from '../mypage/api'
+import {
+	ApiError,
+	ChannelAlreadyLinkedError,
+	InvalidYouTubeAccessTokenError,
+	UnauthorizedError,
+} from '../mypage/api'
 import { MissingYouTubeAccessTokenError } from './errors'
 
 const permissionMessage =
@@ -29,6 +34,14 @@ export function getLoginErrorMessage(error: unknown): string {
 
 	if (error instanceof UnauthorizedError) {
 		return '認証の有効期限が切れました。もう一度ログインしてください。'
+	}
+
+	if (error instanceof ChannelAlreadyLinkedError) {
+		return 'このYouTubeチャンネルは別のログインアカウントに連携済みです。心当たりがない場合は問い合わせてください。'
+	}
+
+	if (error instanceof InvalidYouTubeAccessTokenError) {
+		return permissionMessage
 	}
 
 	if (error instanceof ApiError) {

--- a/mypage/src/features/mypage/api.ts
+++ b/mypage/src/features/mypage/api.ts
@@ -17,6 +17,20 @@ export class LinkRequiredError extends Error {
 	}
 }
 
+export class ChannelAlreadyLinkedError extends Error {
+	constructor() {
+		super('YouTube channel is already linked to another account')
+		this.name = 'ChannelAlreadyLinkedError'
+	}
+}
+
+export class InvalidYouTubeAccessTokenError extends Error {
+	constructor() {
+		super('Invalid YouTube access token')
+		this.name = 'InvalidYouTubeAccessTokenError'
+	}
+}
+
 export class ApiError extends Error {
 	readonly status: number
 
@@ -90,6 +104,26 @@ export async function linkYouTube(options: LinkYouTubeOptions): Promise<void> {
 
 	if (response.status === 401) {
 		throw new UnauthorizedError()
+	}
+
+	if (response.status === 400) {
+		const body = (await response.json().catch(() => null)) as {
+			error?: { code?: string }
+		} | null
+
+		if (body?.error?.code === 'invalid_youtube_access_token') {
+			throw new InvalidYouTubeAccessTokenError()
+		}
+	}
+
+	if (response.status === 409) {
+		const body = (await response.json().catch(() => null)) as {
+			error?: { code?: string }
+		} | null
+
+		if (body?.error?.code === 'channel_already_linked') {
+			throw new ChannelAlreadyLinkedError()
+		}
 	}
 
 	if (!response.ok) {

--- a/mypage/src/lib/safeRedirect.test.ts
+++ b/mypage/src/lib/safeRedirect.test.ts
@@ -11,6 +11,10 @@ describe('sanitizeRedirectPath', () => {
 		{ input: '/login', expected: '/login' },
 		{ input: '/path?query=1', expected: '/path?query=1' },
 		{ input: '/path#section', expected: '/path#section' },
+		{
+			input: '/path?query=1#section',
+			expected: '/path?query=1#section',
+		},
 	])('allows safe relative paths: $input', ({ input, expected }) => {
 		expect(sanitizeRedirectPath(input)).toBe(expected)
 	})
@@ -36,13 +40,13 @@ describe('sanitizeRedirectPath', () => {
 		).toBe('/foo')
 		expect(
 			sanitizeRedirectPath(
-				'http://localhost:18081/login?reason=link_required',
+				'http://localhost:18081/login?reason=link_required#consent',
 				'/',
 				{
 					trustedOrigins,
 				},
 			),
-		).toBe('/login?reason=link_required')
+		).toBe('/login?reason=link_required#consent')
 	})
 
 	it('uses custom fallback when redirect is unsafe', () => {

--- a/mypage/src/lib/safeRedirect.test.ts
+++ b/mypage/src/lib/safeRedirect.test.ts
@@ -24,6 +24,8 @@ describe('sanitizeRedirectPath', () => {
 		'https://evil.com/path',
 		'//evil.com',
 		'//evil.com/path',
+		'/\\evil.com',
+		'/\\\\evil.com',
 		'javascript:alert(1)',
 		'data:text/html,hello',
 	])('rejects unsafe values: %s', (input) => {

--- a/mypage/src/lib/safeRedirect.ts
+++ b/mypage/src/lib/safeRedirect.ts
@@ -5,7 +5,9 @@ type SanitizeRedirectOptions = {
 }
 
 function isSafeRelativePath(value: string): boolean {
-	return value.startsWith('/') && !value.startsWith('//')
+	return (
+		value.startsWith('/') && !value.startsWith('//') && !value.includes('\\')
+	)
 }
 
 function pathnameFromTrustedURL(

--- a/mypage/src/routes/auth.callback.tsx
+++ b/mypage/src/routes/auth.callback.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react'
 import { sanitizeRedirectPath } from '../lib/safeRedirect'
 
 type CallbackSearch = {
-	redirect?: string
+	redirect: string
 }
 
 export const Route = createFileRoute('/auth/callback')({
@@ -24,7 +24,7 @@ function AuthCallbackPage() {
 
 	useEffect(() => {
 		void navigate({
-			to: search.redirect ?? '/',
+			to: search.redirect,
 			replace: true,
 		})
 	}, [navigate, search.redirect])

--- a/mypage/src/routes/auth.callback.tsx
+++ b/mypage/src/routes/auth.callback.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { useEffect } from 'react'
 
 import { sanitizeRedirectPath } from '../lib/safeRedirect'
@@ -19,15 +19,12 @@ export const Route = createFileRoute('/auth/callback')({
 })
 
 function AuthCallbackPage() {
-	const navigate = useNavigate()
+	const router = useRouter()
 	const search = Route.useSearch()
 
 	useEffect(() => {
-		void navigate({
-			to: search.redirect,
-			replace: true,
-		})
-	}, [navigate, search.redirect])
+		router.history.replace(search.redirect)
+	}, [router, search.redirect])
 
 	return (
 		<section className="cardStack">

--- a/mypage/src/routes/login.tsx
+++ b/mypage/src/routes/login.tsx
@@ -7,7 +7,7 @@ import { linkYouTube } from '../features/mypage/api'
 import { sanitizeRedirectPath } from '../lib/safeRedirect'
 
 type LoginSearch = {
-	redirect?: string
+	redirect: string
 	reason?: string
 }
 
@@ -42,7 +42,7 @@ function LoginPage() {
 			})
 
 			await navigate({
-				to: search.redirect ?? '/',
+				to: search.redirect,
 				replace: true,
 			})
 		} catch (error) {

--- a/mypage/src/routes/login.tsx
+++ b/mypage/src/routes/login.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { useState } from 'react'
 
 import { signInWithGoogleAndYouTube } from '../features/auth/auth'
@@ -24,7 +24,7 @@ export const Route = createFileRoute('/login')({
 })
 
 function LoginPage() {
-	const navigate = useNavigate()
+	const router = useRouter()
 	const search = Route.useSearch()
 	const [isSubmitting, setIsSubmitting] = useState(false)
 	const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -41,10 +41,7 @@ function LoginPage() {
 				youtubeAccessToken: result.youtubeAccessToken,
 			})
 
-			await navigate({
-				to: search.redirect,
-				replace: true,
-			})
+			router.history.replace(search.redirect)
 		} catch (error) {
 			console.error(error)
 			setErrorMessage(getLoginErrorMessage(error))

--- a/mypage/src/routes/logout.tsx
+++ b/mypage/src/routes/logout.tsx
@@ -18,6 +18,7 @@ function LogoutPage() {
 
 				await navigate({
 					to: '/login',
+					search: { redirect: '/' },
 					replace: true,
 				})
 			} catch {


### PR DESCRIPTION
## Summary
- Adds frontend handling for `channel_already_linked` and `invalid_youtube_access_token`.
- Sanitizes login/callback redirects.
- Preserves logout redirect back to `/`.

## Review Focus
- API error response parsing.
- open redirect protection.
- login/relink UX for invalid token and already-linked channel.

## Checks
- `cd mypage && pnpm lint`
- `cd mypage && pnpm test`
- `cd mypage && pnpm build`