### PR TITLE
feat(cdk): expose mypage API through API Gateway HTTP API

### DIFF
--- a/aws-cdk/README.md
+++ b/aws-cdk/README.md
@@ -19,10 +19,16 @@ aws sts get-caller-identity --profile プロファイル名
 - `pnpm build` compile typescript to js
 - `pnpm watch` watch for changes and compile
 - `pnpm test` perform the jest unit tests
-- `pnpm cdk:bootstrap` 当該 AWS アカウント環境で初めての場合
-- `pnpm cdk:deploy` deploy this stack to your default AWS account/region
-- `pnpm cdk:diff` compare deployed stack with current state
-- `pnpm cdk:synth` emits the synthesized CloudFormation template
+- `pnpm cdk:bootstrap --context stage=STAGE --profile PROFILE` 当該 AWS アカウント環境で初めての場合
+- `pnpm cdk:deploy --context stage=STAGE --profile PROFILE` deploy this stack to your default AWS account/region
+- `pnpm cdk:diff --context stage=STAGE --profile PROFILE` compare deployed stack with current state
+- `pnpm cdk:synth --context stage=STAGE --profile PROFILE` emits the synthesized CloudFormation template
+
+`stage=prod` ではマイページAPIのCORS許可originを明示する。
+
+```bash
+pnpm cdk:diff --context stage=prod --context mypageAllowedOrigin=https://mypage.moku.work --profile PROFILE
+```
 
 ## 日次バッチと通知の運用メモ
 

--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -21,6 +21,9 @@ import * as subs from 'aws-cdk-lib/aws-sns-subscriptions'
 import * as cw_actions from 'aws-cdk-lib/aws-cloudwatch-actions'
 import * as scheduler from 'aws-cdk-lib/aws-scheduler'
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager'
+import * as apigatewayv2 from 'aws-cdk-lib/aws-apigatewayv2'
+import * as integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations'
+import { getStageConfig } from './stage-config'
 
 export type AwsCdkStackProps = cdk.StackProps & {
 	systemDir?: string
@@ -45,6 +48,12 @@ export class AwsCdkStack extends cdk.Stack {
 	constructor(scope: Construct, id: string, props?: AwsCdkStackProps) {
 		const { systemDir = DEFAULT_SYSTEM_DIR, ...stackProps } = props ?? {}
 		super(scope, id, stackProps)
+
+		const stage = this.node.tryGetContext('stage') as string | undefined
+		const mypageAllowedOrigin = this.node.tryGetContext(
+			'mypageAllowedOrigin',
+		) as string | undefined
+		const stageConfig = getStageConfig(stage, { mypageAllowedOrigin })
 
 		const alarmEmail = new cdk.CfnParameter(this, 'AlarmEmail', {
 			type: 'String',
@@ -700,6 +709,28 @@ export class AwsCdkStack extends cdk.Stack {
 			'Lambda error_log_notify_discord errors > 0',
 		)
 
+		const mypageApiFunction = new lambda.DockerImageFunction(
+			this,
+			'mypage_api',
+			{
+				functionName: stageConfig.mypageApiFunctionName,
+				code: createLambdaImageCode(systemDir, 'mypage_api'),
+				timeout: cdk.Duration.seconds(15),
+				reservedConcurrentExecutions: undefined,
+				environment: {
+					MYPAGE_ALLOWED_ORIGIN: stageConfig.mypageAllowedOrigin,
+				},
+			},
+		)
+		;(mypageApiFunction.role as iam.Role).addToPolicy(
+			dynamoDBAccessPolicy,
+		)
+		createLambdaErrorAlarm(
+			mypageApiFunction,
+			'MypageApiErrorsAlarm',
+			'Lambda mypage_api errors > 0',
+		)
+
 		const errorLogFilterPattern = logs.FilterPattern.stringValue(
 			'$.level',
 			'=',
@@ -741,6 +772,10 @@ export class AwsCdkStack extends cdk.Stack {
 		addErrorLogSubscriptionFilter(
 			'SnsNotifyDiscordErrorLogSubscription',
 			snsNotifyDiscordFunction,
+		)
+		addErrorLogSubscriptionFilter(
+			'MypageApiErrorLogSubscription',
+			mypageApiFunction,
 		)
 
 		// API Gateway用ロググループ
@@ -835,6 +870,52 @@ export class AwsCdkStack extends cdk.Stack {
 		new events.Rule(this, '15minutes', {
 			schedule: events.Schedule.rate(cdk.Duration.minutes(15)),
 			targets: [new targets.LambdaFunction(updateWorkNameTrendFunction)],
+		})
+
+		// =========================
+		// API Gateway HTTP API: Mypage API
+		// =========================
+		const mypageHttpApi = new apigatewayv2.HttpApi(this, 'MypageHttpApi', {
+			apiName: stageConfig.mypageApiName,
+			corsPreflight: {
+				allowOrigins: [stageConfig.mypageAllowedOrigin],
+				allowMethods: [
+					apigatewayv2.CorsHttpMethod.GET,
+					apigatewayv2.CorsHttpMethod.POST,
+					apigatewayv2.CorsHttpMethod.OPTIONS,
+				],
+				allowHeaders: [
+					'Authorization',
+					'Content-Type',
+					'X-Client-App',
+					'X-Client-Version',
+					'X-Client-Request-Id',
+					'X-Client-Build-Time',
+					'X-Client-Timezone',
+					'X-Client-Platform',
+				],
+			},
+		})
+
+		mypageHttpApi.addRoutes({
+			path: '/mypage/auth/youtube-link',
+			methods: [apigatewayv2.HttpMethod.POST],
+			integration: new integrations.HttpLambdaIntegration(
+				'MypageYouTubeLinkIntegration',
+				mypageApiFunction,
+			),
+		})
+		mypageHttpApi.addRoutes({
+			path: '/mypage/me',
+			methods: [apigatewayv2.HttpMethod.GET],
+			integration: new integrations.HttpLambdaIntegration(
+				'MypageMeIntegration',
+				mypageApiFunction,
+			),
+		})
+
+		new cdk.CfnOutput(this, 'MypageApiEndpointUrl', {
+			value: mypageHttpApi.apiEndpoint,
 		})
 	}
 }

--- a/aws-cdk/lib/stage-config.ts
+++ b/aws-cdk/lib/stage-config.ts
@@ -1,0 +1,57 @@
+export type StageName = 'dev' | 'prod'
+
+export type StageConfig = {
+	stage: StageName
+	mypageAllowedOrigin: string
+	mypageApiFunctionName: string
+	mypageApiName: string
+}
+
+export type StageConfigOptions = {
+	mypageAllowedOrigin?: string
+}
+
+const resolveAllowedOrigin = (
+	stage: StageName,
+	options?: StageConfigOptions,
+): string => {
+	if (options?.mypageAllowedOrigin) {
+		return options.mypageAllowedOrigin
+	}
+
+	if (stage === 'dev') {
+		return 'http://localhost:18081'
+	}
+
+	throw new Error(
+		'Context value "mypageAllowedOrigin" is required for prod stage',
+	)
+}
+
+export const getStageConfig = (
+	stage: string | undefined,
+	options?: StageConfigOptions,
+): StageConfig => {
+	switch (stage) {
+		case 'prod':
+			return {
+				stage: 'prod',
+				mypageAllowedOrigin: resolveAllowedOrigin('prod', options),
+				mypageApiFunctionName: 'mypage_api',
+				mypageApiName: 'mypage-api',
+			}
+
+		case 'dev':
+		case undefined:
+		case '':
+			return {
+				stage: 'dev',
+				mypageAllowedOrigin: resolveAllowedOrigin('dev', options),
+				mypageApiFunctionName: 'dev_mypage_api',
+				mypageApiName: 'dev-mypage-api',
+			}
+
+		default:
+			throw new Error(`Unknown stage: ${stage}`)
+	}
+}

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -9,8 +9,11 @@ import { AwsCdkStack, type AwsCdkStackProps } from '../lib/aws-cdk-stack'
 
 const REPO_SYSTEM_DIR = path.resolve(__dirname, '../../system')
 
-const createTemplate = (props?: AwsCdkStackProps) => {
-	const app = new cdk.App()
+const createTemplate = (
+	props?: AwsCdkStackProps,
+	context?: Record<string, string>,
+) => {
+	const app = new cdk.App({ context })
 	const stack = new AwsCdkStack(app, 'TestStack', props)
 
 	return Template.fromStack(stack)
@@ -284,6 +287,59 @@ describe('AwsCdkStack', () => {
 				hasErrorsAlarm: true,
 			})
 		}
+	})
+
+	test('creates mypage API Lambda and HTTP API route for default dev stage', () => {
+		const t = createTemplate()
+
+		t.hasResourceProperties('AWS::Lambda::Function', {
+			FunctionName: 'dev_mypage_api',
+		})
+
+		t.hasResourceProperties('AWS::ApiGatewayV2::Api', {
+			Name: 'dev-mypage-api',
+			ProtocolType: 'HTTP',
+		})
+
+		t.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+			RouteKey: 'GET /mypage/me',
+		})
+
+		t.hasOutput(
+			'MypageApiEndpointUrl',
+			Match.objectLike({
+				Export: Match.absent(),
+			}),
+		)
+	})
+
+	test('requires explicit mypage origin for prod stage', () => {
+		expect(() => createTemplate(undefined, { stage: 'prod' })).toThrow(
+			/Context value "mypageAllowedOrigin" is required/,
+		)
+	})
+
+	test('creates prod mypage API without CloudFormation endpoint export', () => {
+		const t = createTemplate(undefined, {
+			stage: 'prod',
+			mypageAllowedOrigin: 'https://mypage.moku.work',
+		})
+
+		t.hasResourceProperties('AWS::Lambda::Function', {
+			FunctionName: 'mypage_api',
+			Environment: {
+				Variables: Match.objectLike({
+					MYPAGE_ALLOWED_ORIGIN: 'https://mypage.moku.work',
+				}),
+			},
+		})
+
+		t.hasOutput(
+			'MypageApiEndpointUrl',
+			Match.objectLike({
+				Export: Match.absent(),
+			}),
+		)
 	})
 })
 


### PR DESCRIPTION
## Summary
- Adds stage config for the MyPage API.
- Adds `mypage_api` Lambda, HTTP API routes, CORS, alarms, error log subscription, and CDK tests.
- Requires `mypageAllowedOrigin` context for prod; leaves `MypageApiEndpointUrl` as an Output without CloudFormation export.

## Review Focus
- dev/prod config and CORS origin handling.
- HTTP API routes and Lambda wiring.
- no `exportName` on `MypageApiEndpointUrl`.
- alarm/log subscription coverage.

## Checks
- `cd aws-cdk && pnpm test`
- `cd aws-cdk && pnpm build`
- `cd aws-cdk && pnpm cdk:diff --context stage=dev` failed locally because no AWS account/environment was configured.