### PR TITLE
[codex] Move NG word loading to bot startup

### DIFF
--- a/system/cmd/youtube-bot/main.go
+++ b/system/cmd/youtube-bot/main.go
@@ -81,7 +81,7 @@ func Bot(ctx context.Context, clientOption option.ClientOption) {
 		return
 	}
 
-	app.MessageToOwner(ctx, "Botが起動しました。\n"+app.GetInfoString(ngWordConfig))
+	app.MessageToOwner(ctx, fmt.Sprintf("Botが起動しました。\n全規制ワード数: %d", ngWordConfig.Count()))
 	defer func() { // when error occurred
 		app.MessageToLiveChat(ctx, "エラーが起きたため終了します。お手数ですが管理者に連絡してください。")
 		app.MessageToOwner(ctx, "app stopped!!")

--- a/system/cmd/youtube-bot/main.go
+++ b/system/cmd/youtube-bot/main.go
@@ -11,6 +11,7 @@ import (
 
 	"app.modules/core/workspaceapp"
 
+	"app.modules/core/wordsreader"
 	"app.modules/core/youtubebot"
 	"github.com/kr/pretty"
 
@@ -53,7 +54,7 @@ func Init() (option.ClientOption, context.Context, error) {
 func CheckLongTimeSitting(ctx context.Context, clientOption option.ClientOption) {
 	app, err := workspaceapp.NewWorkspaceApp(ctx, false, clientOption)
 	if err != nil {
-		app.MessageToOwnerWithError(ctx, "failed core.NewWorkspaceApp()", err)
+		slog.ErrorContext(ctx, "failed core.NewWorkspaceApp()", "error", err)
 		return
 	}
 
@@ -69,13 +70,19 @@ func CalculateRetryIntervalSec(base float64, numContinuousFailed int) float64 {
 func Bot(ctx context.Context, clientOption option.ClientOption) {
 	app, err := workspaceapp.NewWorkspaceApp(ctx, true, clientOption)
 	if err != nil {
-		app.MessageToOwnerWithError(ctx, "failed core.NewWorkspaceApp()", err)
+		slog.ErrorContext(ctx, "failed core.NewWorkspaceApp()", "error", err)
+		return
+	}
+	defer app.CloseFirestoreClient()
+
+	ngWordConfig, err := loadNGWordConfig(ctx, clientOption, app.Configs.Constants.BotConfigSpreadsheetID)
+	if err != nil {
+		app.MessageToOwnerWithError(ctx, "failed loadNGWordConfig()", err)
 		return
 	}
 
-	app.MessageToOwner(ctx, "Botが起動しました。\n"+app.GetInfoString())
+	app.MessageToOwner(ctx, "Botが起動しました。\n"+app.GetInfoString(ngWordConfig))
 	defer func() { // when error occurred
-		app.CloseFirestoreClient()
 		app.MessageToLiveChat(ctx, "エラーが起きたため終了します。お手数ですが管理者に連絡してください。")
 		app.MessageToOwner(ctx, "app stopped!!")
 	}()
@@ -189,7 +196,7 @@ func Bot(ctx context.Context, clientOption option.ClientOption) {
 			isOwner := youtubebot.IsChatMessageByOwner(chatMessage)
 			isMember := isOwner || youtubebot.IsChatMessageByMember(chatMessage)
 			slog.Info(chatMessage.AuthorDetails.ChannelId + " (" + chatMessage.AuthorDetails.DisplayName + "): " + message)
-			if err := app.ProcessMessage(ctx, message, channelID, displayName, profileImageURL, isModerator, isOwner, isMember); err != nil {
+			if err := app.ProcessMessage(ctx, ngWordConfig, message, channelID, displayName, profileImageURL, isModerator, isOwner, isMember); err != nil {
 				app.MessageToOwnerWithError(ctx, "error in ProcessMessage()", err)
 			}
 		}
@@ -201,6 +208,40 @@ func Bot(ctx context.Context, clientOption option.ClientOption) {
 		slog.Info(fmt.Sprintf("waiting for %.2f seconds...\n\n", sleepInterval.Seconds()))
 		time.Sleep(sleepInterval)
 	}
+}
+
+func loadNGWordConfig(
+	ctx context.Context,
+	clientOption option.ClientOption,
+	spreadsheetID string,
+) (workspaceapp.NGWordConfig, error) {
+	slog.InfoContext(ctx, "initializing spreadsheet reader...")
+
+	wordsReader, err := wordsreader.NewSpreadsheetReader(ctx, clientOption, spreadsheetID, "01", "02")
+	if err != nil {
+		return workspaceapp.NGWordConfig{}, fmt.Errorf("in NewSpreadsheetReader(): %w", err)
+	}
+
+	slog.InfoContext(ctx, "reading block regexes...")
+
+	blockRegexesForChatMessage, blockRegexesForChannelName, err := wordsReader.ReadBlockRegexes(ctx)
+	if err != nil {
+		return workspaceapp.NGWordConfig{}, fmt.Errorf("in ReadBlockRegexes(): %w", err)
+	}
+
+	slog.InfoContext(ctx, "reading notification regexes...")
+
+	notificationRegexesForChatMessage, notificationRegexesForChannelName, err := wordsReader.ReadNotificationRegexes(ctx)
+	if err != nil {
+		return workspaceapp.NGWordConfig{}, fmt.Errorf("in ReadNotificationRegexes(): %w", err)
+	}
+
+	return workspaceapp.NewNGWordConfig(
+		blockRegexesForChatMessage,
+		blockRegexesForChannelName,
+		notificationRegexesForChatMessage,
+		notificationRegexesForChannelName,
+	), nil
 }
 
 func main() {

--- a/system/core/workspaceapp/ng_word_config.go
+++ b/system/core/workspaceapp/ng_word_config.go
@@ -1,0 +1,31 @@
+package workspaceapp
+
+import "slices"
+
+type NGWordConfig struct {
+	blockRegexesForChatMessage        []string
+	blockRegexesForChannelName        []string
+	notificationRegexesForChatMessage []string
+	notificationRegexesForChannelName []string
+}
+
+func NewNGWordConfig(
+	blockRegexesForChatMessage []string,
+	blockRegexesForChannelName []string,
+	notificationRegexesForChatMessage []string,
+	notificationRegexesForChannelName []string,
+) NGWordConfig {
+	return NGWordConfig{
+		blockRegexesForChatMessage:        slices.Clone(blockRegexesForChatMessage),
+		blockRegexesForChannelName:        slices.Clone(blockRegexesForChannelName),
+		notificationRegexesForChatMessage: slices.Clone(notificationRegexesForChatMessage),
+		notificationRegexesForChannelName: slices.Clone(notificationRegexesForChannelName),
+	}
+}
+
+func (c NGWordConfig) Count() int {
+	return len(c.blockRegexesForChatMessage) +
+		len(c.blockRegexesForChannelName) +
+		len(c.notificationRegexesForChatMessage) +
+		len(c.notificationRegexesForChannelName)
+}

--- a/system/core/workspaceapp/ng_word_config_test.go
+++ b/system/core/workspaceapp/ng_word_config_test.go
@@ -1,0 +1,43 @@
+package workspaceapp
+
+import "testing"
+
+func TestNGWordConfig_Count(t *testing.T) {
+	cfg := NewNGWordConfig(
+		[]string{"a", "b"},
+		[]string{"c"},
+		[]string{"d", "e", "f"},
+		[]string{"g"},
+	)
+
+	if got, want := cfg.Count(), 7; got != want {
+		t.Fatalf("Count() = %d, want %d", got, want)
+	}
+}
+
+func TestNewNGWordConfig_ClonesSlices(t *testing.T) {
+	blockChat := []string{"before"}
+	blockChannel := []string{"before"}
+	notificationChat := []string{"before"}
+	notificationChannel := []string{"before"}
+
+	cfg := NewNGWordConfig(blockChat, blockChannel, notificationChat, notificationChannel)
+
+	blockChat[0] = "after"
+	blockChannel[0] = "after"
+	notificationChat[0] = "after"
+	notificationChannel[0] = "after"
+
+	if got, want := cfg.blockRegexesForChatMessage[0], "before"; got != want {
+		t.Fatalf("blockRegexesForChatMessage[0] = %q, want %q", got, want)
+	}
+	if got, want := cfg.blockRegexesForChannelName[0], "before"; got != want {
+		t.Fatalf("blockRegexesForChannelName[0] = %q, want %q", got, want)
+	}
+	if got, want := cfg.notificationRegexesForChatMessage[0], "before"; got != want {
+		t.Fatalf("notificationRegexesForChatMessage[0] = %q, want %q", got, want)
+	}
+	if got, want := cfg.notificationRegexesForChannelName[0], "before"; got != want {
+		t.Fatalf("notificationRegexesForChannelName[0] = %q, want %q", got, want)
+	}
+}

--- a/system/core/workspaceapp/ng_word_filter_test.go
+++ b/system/core/workspaceapp/ng_word_filter_test.go
@@ -1,0 +1,169 @@
+package workspaceapp
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"app.modules/core/timeutil"
+	mock_youtubebot "app.modules/core/youtubebot/mocks"
+	"go.uber.org/mock/gomock"
+)
+
+type spyMessageBot struct {
+	messages          []string
+	messagesWithError []string
+}
+
+func (b *spyMessageBot) SendMessage(_ context.Context, message string) error {
+	b.messages = append(b.messages, message)
+	return nil
+}
+
+func (b *spyMessageBot) SendMessageWithError(_ context.Context, message string, _ error) error {
+	b.messagesWithError = append(b.messagesWithError, message)
+	return nil
+}
+
+func TestCheckIfUnwantedWordIncluded_BlocksByChatMessageRegex(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	mockLiveChatBot := mock_youtubebot.NewMockLiveChatBot(ctrl)
+	mockLiveChatBot.EXPECT().
+		BanUser(gomock.Any(), "test_user_id").
+		Return(nil).
+		Times(1)
+
+	logBot := &spyMessageBot{}
+	alertBot := &spyMessageBot{}
+	app := newTestNGWordFilterApp(mockLiveChatBot, logBot, alertBot)
+	ngWordConfig := NewNGWordConfig(
+		[]string{"荒らし"},
+		nil,
+		nil,
+		nil,
+	)
+
+	blocked, err := app.CheckIfUnwantedWordIncluded(
+		ctx,
+		ngWordConfig,
+		"test_user_id",
+		"これは荒らしです",
+		"テストユーザー",
+	)
+
+	if err != nil {
+		t.Fatalf("CheckIfUnwantedWordIncluded() error = %v", err)
+	}
+	if !blocked {
+		t.Fatal("blocked = false, want true")
+	}
+	if got, want := len(logBot.messages), 1; got != want {
+		t.Fatalf("log messages len = %d, want %d", got, want)
+	}
+	if !strings.Contains(logBot.messages[0], "禁止ワード: `荒らし`") {
+		t.Fatalf("log message does not contain matched regex: %q", logBot.messages[0])
+	}
+	if got, want := len(alertBot.messages), 0; got != want {
+		t.Fatalf("alert messages len = %d, want %d", got, want)
+	}
+}
+
+func TestCheckIfUnwantedWordIncluded_NotifiesByChatMessageRegex(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	mockLiveChatBot := mock_youtubebot.NewMockLiveChatBot(ctrl)
+
+	logBot := &spyMessageBot{}
+	alertBot := &spyMessageBot{}
+	app := newTestNGWordFilterApp(mockLiveChatBot, logBot, alertBot)
+	ngWordConfig := NewNGWordConfig(
+		nil,
+		nil,
+		[]string{"要確認"},
+		nil,
+	)
+
+	blocked, err := app.CheckIfUnwantedWordIncluded(
+		ctx,
+		ngWordConfig,
+		"test_user_id",
+		"これは要確認です",
+		"テストユーザー",
+	)
+
+	if err != nil {
+		t.Fatalf("CheckIfUnwantedWordIncluded() error = %v", err)
+	}
+	if blocked {
+		t.Fatal("blocked = true, want false")
+	}
+	if got, want := len(alertBot.messages), 1; got != want {
+		t.Fatalf("alert messages len = %d, want %d", got, want)
+	}
+	if !strings.Contains(alertBot.messages[0], "禁止ワード: `要確認`") {
+		t.Fatalf("alert message does not contain matched regex: %q", alertBot.messages[0])
+	}
+	if got, want := len(logBot.messages), 0; got != want {
+		t.Fatalf("log messages len = %d, want %d", got, want)
+	}
+}
+
+func TestCheckIfUnwantedWordIncluded_NoMatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	mockLiveChatBot := mock_youtubebot.NewMockLiveChatBot(ctrl)
+
+	logBot := &spyMessageBot{}
+	alertBot := &spyMessageBot{}
+	app := newTestNGWordFilterApp(mockLiveChatBot, logBot, alertBot)
+	ngWordConfig := NewNGWordConfig(
+		[]string{"荒らし"},
+		[]string{"スパム"},
+		[]string{"要確認"},
+		[]string{"注意"},
+	)
+
+	blocked, err := app.CheckIfUnwantedWordIncluded(
+		ctx,
+		ngWordConfig,
+		"test_user_id",
+		"通常のメッセージです",
+		"テストユーザー",
+	)
+
+	if err != nil {
+		t.Fatalf("CheckIfUnwantedWordIncluded() error = %v", err)
+	}
+	if blocked {
+		t.Fatal("blocked = true, want false")
+	}
+	if got, want := len(logBot.messages), 0; got != want {
+		t.Fatalf("log messages len = %d, want %d", got, want)
+	}
+	if got, want := len(alertBot.messages), 0; got != want {
+		t.Fatalf("alert messages len = %d, want %d", got, want)
+	}
+}
+
+func newTestNGWordFilterApp(
+	liveChatBot *mock_youtubebot.MockLiveChatBot,
+	logBot *spyMessageBot,
+	alertBot *spyMessageBot,
+) WorkspaceApp {
+	fixedNow := time.Date(2026, time.January, 1, 10, 0, 0, 0, timeutil.JapanLocation())
+
+	return WorkspaceApp{
+		LiveChatBot:        liveChatBot,
+		alertModeratorsBot: alertBot,
+		logModeratorsBot:   logBot,
+		nowFunc:            func() time.Time { return fixedNow },
+	}
+}

--- a/system/core/workspaceapp/workspace_app.go
+++ b/system/core/workspaceapp/workspace_app.go
@@ -171,10 +171,6 @@ func (app *WorkspaceApp) CloseFirestoreClient() {
 	}
 }
 
-func (app *WorkspaceApp) GetInfoString(ngWordConfig NGWordConfig) string {
-	return fmt.Sprintf("全規制ワード数: %d", ngWordConfig.Count())
-}
-
 // GoroutineCheckLongTimeSitting 長時間座席占有検出ループ
 func (app *WorkspaceApp) GoroutineCheckLongTimeSitting(ctx context.Context) {
 	minimumInterval := time.Duration(app.Configs.Constants.MinimumCheckLongTimeSittingIntervalMinutes) * time.Minute

--- a/system/core/workspaceapp/workspace_app.go
+++ b/system/core/workspaceapp/workspace_app.go
@@ -15,7 +15,6 @@ import (
 	"app.modules/core/repository"
 	"app.modules/core/timeutil"
 	"app.modules/core/utils"
-	"app.modules/core/wordsreader"
 	"app.modules/core/youtubebot"
 	"cloud.google.com/go/firestore"
 	"google.golang.org/api/option"
@@ -24,7 +23,6 @@ import (
 type WorkspaceApp struct {
 	Configs            *Configs
 	Repository         repository.Repository
-	WordsReader        wordsreader.WordsReader
 	LiveChatBot        youtubebot.LiveChatBot
 	alertOwnerBot      moderatorbot.MessageBot
 	alertModeratorsBot moderatorbot.MessageBot
@@ -35,11 +33,6 @@ type WorkspaceApp struct {
 	ProcessedUserProfileImageURL    string
 	ProcessedUserIsModeratorOrOwner bool
 	ProcessedUserIsMember           bool
-
-	blockRegexesForChatMessage        []string
-	blockRegexesForChannelName        []string
-	notificationRegexesForChatMessage []string
-	notificationRegexesForChannelName []string
 
 	SortedMenuItems []repository.MenuDoc // メニューコードで昇順ソートして格納
 
@@ -133,22 +126,6 @@ func NewWorkspaceApp(ctx context.Context, interactive bool, clientOption option.
 		}
 	}
 
-	slog.InfoContext(ctx, "initializing spreadsheet reader...")
-	wordsReader, err := wordsreader.NewSpreadsheetReader(ctx, clientOption, configs.Constants.BotConfigSpreadsheetID, "01", "02")
-	if err != nil {
-		return nil, fmt.Errorf("in NewSpreadsheetReader(): %w", err)
-	}
-	slog.InfoContext(ctx, "reading block regexes...")
-	blockRegexesForChatMessage, blockRegexesForChannelName, err := wordsReader.ReadBlockRegexes(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("in ReadBlockRegexes(): %w", err)
-	}
-	slog.InfoContext(ctx, "reading notification regexes...")
-	notificationRegexesForChatMessage, notificationRegexesForChannelName, err := wordsReader.ReadNotificationRegexes(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("in ReadNotificationRegexes(): %w", err)
-	}
-
 	slog.InfoContext(ctx, "reading menu docs...")
 	sortedMenuItems, err := firestoreController.ReadAllMenuDocsOrderByCode(ctx)
 	if err != nil {
@@ -156,19 +133,14 @@ func NewWorkspaceApp(ctx context.Context, interactive bool, clientOption option.
 	}
 
 	return &WorkspaceApp{
-		Configs:                           &configs,
-		Repository:                        firestoreController,
-		WordsReader:                       wordsReader,
-		LiveChatBot:                       liveChatBot,
-		alertOwnerBot:                     discordOwnerBot,
-		alertModeratorsBot:                discordSharedBot,
-		logModeratorsBot:                  discordSharedLogBot,
-		blockRegexesForChannelName:        blockRegexesForChannelName,
-		blockRegexesForChatMessage:        blockRegexesForChatMessage,
-		notificationRegexesForChatMessage: notificationRegexesForChatMessage,
-		notificationRegexesForChannelName: notificationRegexesForChannelName,
-		SortedMenuItems:                   sortedMenuItems,
-		nowFunc:                           nil,
+		Configs:            &configs,
+		Repository:         firestoreController,
+		LiveChatBot:        liveChatBot,
+		alertOwnerBot:      discordOwnerBot,
+		alertModeratorsBot: discordSharedBot,
+		logModeratorsBot:   discordSharedLogBot,
+		SortedMenuItems:    sortedMenuItems,
+		nowFunc:            nil,
 	}, nil
 }
 
@@ -199,9 +171,8 @@ func (app *WorkspaceApp) CloseFirestoreClient() {
 	}
 }
 
-func (app *WorkspaceApp) GetInfoString() string {
-	numAllFilteredRegex := len(app.blockRegexesForChatMessage) + len(app.blockRegexesForChannelName) + len(app.notificationRegexesForChatMessage) + len(app.notificationRegexesForChannelName)
-	return fmt.Sprintf("全規制ワード数: %d", numAllFilteredRegex)
+func (app *WorkspaceApp) GetInfoString(ngWordConfig NGWordConfig) string {
+	return fmt.Sprintf("全規制ワード数: %d", ngWordConfig.Count())
 }
 
 // GoroutineCheckLongTimeSitting 長時間座席占有検出ループ
@@ -232,9 +203,9 @@ func (app *WorkspaceApp) GoroutineCheckLongTimeSitting(ctx context.Context) {
 	}
 }
 
-func (app *WorkspaceApp) CheckIfUnwantedWordIncluded(ctx context.Context, userID, message, channelName string) (bool, error) {
+func (app *WorkspaceApp) CheckIfUnwantedWordIncluded(ctx context.Context, ngWordConfig NGWordConfig, userID, message, channelName string) (bool, error) {
 	// ブロック対象チェック
-	found, index, err := utils.ContainsRegexWithIndex(app.blockRegexesForChatMessage, message)
+	found, index, err := utils.ContainsRegexWithIndex(ngWordConfig.blockRegexesForChatMessage, message)
 	if err != nil {
 		return false, err
 	}
@@ -243,13 +214,13 @@ func (app *WorkspaceApp) CheckIfUnwantedWordIncluded(ctx context.Context, userID
 			return false, fmt.Errorf("in BanUser(): %w", err)
 		}
 		return true, app.LogToModerators(ctx, "発言から禁止ワードを検出、ユーザーをブロックしました。"+
-			"\n禁止ワード: `"+app.blockRegexesForChatMessage[index]+"`"+
+			"\n禁止ワード: `"+ngWordConfig.blockRegexesForChatMessage[index]+"`"+
 			"\nチャンネル名: `"+channelName+"`"+
 			"\nチャンネルURL: https://youtube.com/channel/"+userID+
 			"\nチャット内容: `"+message+"`"+
 			"\n日時: "+app.currentTime().String())
 	}
-	found, index, err = utils.ContainsRegexWithIndex(app.blockRegexesForChannelName, channelName)
+	found, index, err = utils.ContainsRegexWithIndex(ngWordConfig.blockRegexesForChannelName, channelName)
 	if err != nil {
 		return false, fmt.Errorf("in ContainsRegexWithIndex(): %w", err)
 	}
@@ -258,7 +229,7 @@ func (app *WorkspaceApp) CheckIfUnwantedWordIncluded(ctx context.Context, userID
 			return false, fmt.Errorf("in BanUser(): %w", err)
 		}
 		return true, app.LogToModerators(ctx, "チャンネル名から禁止ワードを検出、ユーザーをブロックしました。"+
-			"\n禁止ワード: `"+app.blockRegexesForChannelName[index]+"`"+
+			"\n禁止ワード: `"+ngWordConfig.blockRegexesForChannelName[index]+"`"+
 			"\nチャンネル名: `"+channelName+"`"+
 			"\nチャンネルURL: https://youtube.com/channel/"+userID+
 			"\nチャット内容: `"+message+"`"+
@@ -266,25 +237,25 @@ func (app *WorkspaceApp) CheckIfUnwantedWordIncluded(ctx context.Context, userID
 	}
 
 	// 通知対象チェック
-	found, index, err = utils.ContainsRegexWithIndex(app.notificationRegexesForChatMessage, message)
+	found, index, err = utils.ContainsRegexWithIndex(ngWordConfig.notificationRegexesForChatMessage, message)
 	if err != nil {
 		return false, fmt.Errorf("in ContainsRegexWithIndex(): %w", err)
 	}
 	if found {
 		return false, app.MessageToModerators(ctx, "発言から禁止ワードを検出しました。（通知のみ）"+
-			"\n禁止ワード: `"+app.notificationRegexesForChatMessage[index]+"`"+
+			"\n禁止ワード: `"+ngWordConfig.notificationRegexesForChatMessage[index]+"`"+
 			"\nチャンネル名: `"+channelName+"`"+
 			"\nチャンネルURL: https://youtube.com/channel/"+userID+
 			"\nチャット内容: `"+message+"`"+
 			"\n日時: "+app.currentTime().String())
 	}
-	found, index, err = utils.ContainsRegexWithIndex(app.notificationRegexesForChannelName, channelName)
+	found, index, err = utils.ContainsRegexWithIndex(ngWordConfig.notificationRegexesForChannelName, channelName)
 	if err != nil {
 		return false, fmt.Errorf("in ContainsRegexWithIndex(): %w", err)
 	}
 	if found {
 		return false, app.MessageToModerators(ctx, "チャンネルから禁止ワードを検出しました。（通知のみ）"+
-			"\n禁止ワード: `"+app.notificationRegexesForChannelName[index]+"`"+
+			"\n禁止ワード: `"+ngWordConfig.notificationRegexesForChannelName[index]+"`"+
 			"\nチャンネル名: `"+channelName+"`"+
 			"\nチャンネルURL: https://youtube.com/channel/"+userID+
 			"\nチャット内容: `"+message+"`"+
@@ -296,6 +267,7 @@ func (app *WorkspaceApp) CheckIfUnwantedWordIncluded(ctx context.Context, userID
 // ProcessMessage 入力コマンドを解析して実行
 func (app *WorkspaceApp) ProcessMessage(
 	ctx context.Context,
+	ngWordConfig NGWordConfig,
 	commandString string,
 	userID string,
 	userDisplayName string,
@@ -314,7 +286,7 @@ func (app *WorkspaceApp) ProcessMessage(
 
 	// check if an unwanted word included
 	if !isChatModerator && !isChatOwner {
-		blocked, err := app.CheckIfUnwantedWordIncluded(ctx, userID, commandString, userDisplayName)
+		blocked, err := app.CheckIfUnwantedWordIncluded(ctx, ngWordConfig, userID, commandString, userDisplayName)
 		if err != nil {
 			app.MessageToOwnerWithError(ctx, "in CheckIfUnwantedWordIncluded", err)
 			// continue


### PR DESCRIPTION
## Summary
- Move NG word spreadsheet loading out of workspaceapp.NewWorkspaceApp and into cmd/youtube-bot startup.
- Add NGWordConfig and pass it explicitly through GetInfoString, ProcessMessage, and CheckIfUnwantedWordIncluded.
- Add tests for NGWordConfig count and slice cloning.

## Impact
- Lambda, batch, adminops, and long-sitting paths that construct WorkspaceApp no longer call the Google Sheets API for NG words.
- Existing NG word block and notification behavior remains in WorkspaceApp.CheckIfUnwantedWordIncluded.

## Validation
- go test ./...
