### PR TITLE
chore(deps): change Dependabot update schedule from weekly to monthly for multiple ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,7 @@ updates:
   - package-ecosystem: docker
     directory: /system
     schedule:
-      interval: weekly
-      day: monday
+      interval: monthly
       time: "09:00"
       timezone: Asia/Tokyo
     commit-message:
@@ -28,8 +27,7 @@ updates:
   - package-ecosystem: gomod
     directory: /system
     schedule:
-      interval: weekly
-      day: monday
+      interval: monthly
       time: "09:00"
       timezone: Asia/Tokyo
     commit-message:
@@ -58,8 +56,7 @@ updates:
       - /tools/video-maker/1000-minutes-simulator
       - /tools/figma-plugin/room-layout-analyzer
     schedule:
-      interval: weekly
-      day: monday
+      interval: monthly
       time: "09:00"
       timezone: Asia/Tokyo
     commit-message:
@@ -82,8 +79,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: monthly
       time: "09:00"
       timezone: Asia/Tokyo
     commit-message:


### PR DESCRIPTION
Updated the Dependabot configuration to change the update schedule for Docker, Go modules, GitHub Actions, and other package ecosystems from a weekly to a monthly interval. This adjustment aims to optimize dependency management and reduce the frequency of updates.