### PR TITLE
chore(youtube-monitor): 背景画像を変更

### DIFF
--- a/youtube-monitor/src/components/BackgroundImage.tsx
+++ b/youtube-monitor/src/components/BackgroundImage.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react'
 import { Constants } from '../lib/constants'
 import * as styles from '../styles/BackgroundImage.styles'
 
-const BACKGROUND_IMAGE_URL = '/images/background/20549579_6334500.jpg'
+const BACKGROUND_IMAGE_URL = '/images/background/4167307_214.jpg'
 
 const BackgroundImage: FC = () => {
 	return (


### PR DESCRIPTION
## 変更内容

- トップページの背景画像を `4167307_214.jpg` に変更

## 目的

- 指定された背景画像へ差し替えるため

## 影響範囲

- YouTube Monitor のトップページ背景表示のみ

## 確認

- `pnpm exec biome check src/components/BackgroundImage.tsx`