### PR TITLE
chore: strengthen Biome and Go formatting checks

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -18,6 +18,12 @@
 	"formatter": {
 		"enabled": true,
 		"indentStyle": "tab"
+	},
+	"css": {
+		"formatter": {
+			"indentStyle": "space",
+			"indentWidth": 4
+		}
 	},
 	"assist": {
 		"actions": {
@@ -45,6 +51,7 @@
 		}
 	},
 	"javascript": {
+		"experimentalEmbeddedSnippetsEnabled": true,
 		"formatter": {
 			"quoteStyle": "single",
 			"semicolons": "asNeeded"

--- a/system/.golangci.yml
+++ b/system/.golangci.yml
@@ -2,7 +2,25 @@ version: "2"
 
 linters:
   default: standard
+  enable:
+    - nolintlint
+    - wrapcheck
   settings:
     errcheck:
       check-blank: true
       check-type-assertions: true
+    nolintlint:
+      allow-unused: false
+      require-explanation: true
+      require-specific: true
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      module-path: app.modules
+    goimports:
+      local-prefixes:
+        - app.modules

--- a/system/cmd/lambda/check_live_stream_status/main.go
+++ b/system/cmd/lambda/check_live_stream_status/main.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/aws/aws-lambda-go/lambda"
+	"google.golang.org/api/option"
+
 	"app.modules/core/utils"
 	"app.modules/core/workspaceapp"
 	"app.modules/internal/awsruntime"
 	"app.modules/internal/logging"
-	"github.com/aws/aws-lambda-go/lambda"
-	"google.golang.org/api/option"
 )
 
 func init() {

--- a/system/cmd/lambda/check_live_stream_status/main_test.go
+++ b/system/cmd/lambda/check_live_stream_status/main_test.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"testing"
 
-	"app.modules/internal/awsruntime"
 	"google.golang.org/api/option"
+
+	"app.modules/internal/awsruntime"
 )
 
 type mockCheckLiveStreamApp struct {

--- a/system/cmd/lambda/set_desired_max_seats/main.go
+++ b/system/cmd/lambda/set_desired_max_seats/main.go
@@ -40,12 +40,12 @@ func SetDesiredMaxSeats(ctx context.Context, request events.APIGatewayProxyReque
 
 	var params SetMaxSeatsParams
 	if err := json.Unmarshal([]byte(request.Body), &params); err != nil {
-		return events.APIGatewayProxyResponse{}, err
+		return events.APIGatewayProxyResponse{}, fmt.Errorf("unmarshal request body: %w", err)
 	}
 
 	clientOption, err := awsruntime.FirestoreClientOption()
 	if err != nil {
-		return events.APIGatewayProxyResponse{}, err
+		return events.APIGatewayProxyResponse{}, fmt.Errorf("load Firestore client option: %w", err)
 	}
 
 	app, err := workspaceapp.NewWorkspaceApp(gracefulCtx, false, clientOption)
@@ -53,13 +53,13 @@ func SetDesiredMaxSeats(ctx context.Context, request events.APIGatewayProxyReque
 		if errors.Is(err, context.DeadlineExceeded) {
 			return events.APIGatewayProxyResponse{}, fmt.Errorf("timeout during NewWorkspaceApp: %w", err)
 		}
-		return events.APIGatewayProxyResponse{}, err
+		return events.APIGatewayProxyResponse{}, fmt.Errorf("initialize workspace app: %w", err)
 	}
 	defer app.CloseFirestoreClient()
 
 	if app.Configs.Constants.YoutubeMembershipEnabled {
 		if params.DesiredMaxSeats <= 0 || params.DesiredMemberMaxSeats <= 0 {
-			body, _ := json.Marshal(SetMaxSeatsResponse{Result: "error", Message: "invalid parameter"}) //nolint:errcheck
+			body, _ := json.Marshal(SetMaxSeatsResponse{Result: "error", Message: "invalid parameter"}) //nolint:errcheck // This fixed string-only response cannot contain an unsupported JSON value.
 			return events.APIGatewayProxyResponse{
 				StatusCode: http.StatusBadRequest,
 				Headers:    map[string]string{"Access-Control-Allow-Origin": "*"},
@@ -68,7 +68,7 @@ func SetDesiredMaxSeats(ctx context.Context, request events.APIGatewayProxyReque
 		}
 	} else {
 		if params.DesiredMaxSeats <= 0 || params.DesiredMemberMaxSeats != 0 {
-			body, _ := json.Marshal(SetMaxSeatsResponse{Result: "error", Message: "invalid parameter"}) //nolint:errcheck
+			body, _ := json.Marshal(SetMaxSeatsResponse{Result: "error", Message: "invalid parameter"}) //nolint:errcheck // This fixed string-only response cannot contain an unsupported JSON value.
 			return events.APIGatewayProxyResponse{
 				StatusCode: http.StatusBadRequest,
 				Headers:    map[string]string{"Access-Control-Allow-Origin": "*"},
@@ -98,7 +98,7 @@ func SetDesiredMaxSeats(ctx context.Context, request events.APIGatewayProxyReque
 		return errorResponse(http.StatusInternalServerError, "failed UpdateDesiredMemberMaxSeats"), nil
 	}
 
-	body, _ := json.Marshal(SetMaxSeatsResponse{ //nolint:errcheck
+	body, _ := json.Marshal(SetMaxSeatsResponse{ //nolint:errcheck // This string-only response cannot contain an unsupported JSON value.
 		Result:  awsruntime.OK,
 		Message: "",
 	})
@@ -114,7 +114,7 @@ func SetDesiredMaxSeats(ctx context.Context, request events.APIGatewayProxyReque
 }
 
 func errorResponse(statusCode int, message string) events.APIGatewayProxyResponse {
-	body, _ := json.Marshal(SetMaxSeatsResponse{Result: "error", Message: message}) //nolint:errcheck
+	body, _ := json.Marshal(SetMaxSeatsResponse{Result: "error", Message: message}) //nolint:errcheck // This string-only response cannot contain an unsupported JSON value.
 	return events.APIGatewayProxyResponse{
 		StatusCode: statusCode,
 		Headers:    map[string]string{"Access-Control-Allow-Origin": "*"},

--- a/system/cmd/lambda/set_desired_max_seats/main.go
+++ b/system/cmd/lambda/set_desired_max_seats/main.go
@@ -8,12 +8,13 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+
 	"app.modules/core/utils"
 	"app.modules/core/workspaceapp"
 	"app.modules/internal/awsruntime"
 	"app.modules/internal/logging"
-	"github.com/aws/aws-lambda-go/events"
-	"github.com/aws/aws-lambda-go/lambda"
 )
 
 func init() {

--- a/system/cmd/lambda/sns_notify_discord/main.go
+++ b/system/cmd/lambda/sns_notify_discord/main.go
@@ -35,7 +35,7 @@ func handler(ctx context.Context, evt events.SNSEvent) error {
 	clientOption, err := awsruntime.FirestoreClientOption()
 	if err != nil {
 		slog.Error("failed to get Firestore client option", "err", err)
-		return err
+		return fmt.Errorf("load Firestore client option: %w", err)
 	}
 
 	app, err := workspaceapp.NewWorkspaceApp(gracefulCtx, false, clientOption)
@@ -46,7 +46,7 @@ func handler(ctx context.Context, evt events.SNSEvent) error {
 			return nil
 		}
 		slog.Error("failed to init WorkspaceApp", "err", err)
-		return err
+		return fmt.Errorf("initialize workspace app: %w", err)
 	}
 	defer app.CloseFirestoreClient()
 

--- a/system/cmd/lambda/start_daily_batch/main.go
+++ b/system/cmd/lambda/start_daily_batch/main.go
@@ -8,13 +8,14 @@ import (
 	"os"
 	"time"
 
-	"app.modules/internal/awsruntime"
-	"app.modules/internal/logging"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
 	sfntypes "github.com/aws/aws-sdk-go-v2/service/sfn/types"
+
+	"app.modules/internal/awsruntime"
+	"app.modules/internal/logging"
 )
 
 type stepFunctionsClient interface {

--- a/system/cmd/lambda/update_work_name_trend/main.go
+++ b/system/cmd/lambda/update_work_name_trend/main.go
@@ -6,12 +6,13 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/aws/aws-lambda-go/lambda"
+	"google.golang.org/api/option"
+
 	"app.modules/core/utils"
 	"app.modules/core/workspaceapp"
 	"app.modules/internal/awsruntime"
 	"app.modules/internal/logging"
-	"github.com/aws/aws-lambda-go/lambda"
-	"google.golang.org/api/option"
 )
 
 func init() {

--- a/system/cmd/lambda/youtube_organize_database/main.go
+++ b/system/cmd/lambda/youtube_organize_database/main.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/aws/aws-lambda-go/lambda"
+	"google.golang.org/api/option"
+
 	"app.modules/core/utils"
 	"app.modules/core/workspaceapp"
 	"app.modules/internal/awsruntime"
 	"app.modules/internal/logging"
-	"github.com/aws/aws-lambda-go/lambda"
-	"google.golang.org/api/option"
 )
 
 func init() {

--- a/system/cmd/lambda/youtube_organize_database/main_test.go
+++ b/system/cmd/lambda/youtube_organize_database/main_test.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"testing"
 
-	"app.modules/internal/awsruntime"
 	"google.golang.org/api/option"
+
+	"app.modules/internal/awsruntime"
 )
 
 type mockOrganizeDatabaseApp struct {

--- a/system/cmd/youtube-bot/main.go
+++ b/system/cmd/youtube-bot/main.go
@@ -39,7 +39,7 @@ func Init() (option.ClientOption, context.Context, error) {
 
 	creds, err := transport.Creds(ctx, clientOption)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("load Google credentials: %w", err)
 	}
 	fmt.Printf("Project ID: %s\n", creds.ProjectID)
 	fmt.Println("Is this the correct project ID? (yes/no)")

--- a/system/cmd/youtube-bot/main.go
+++ b/system/cmd/youtube-bot/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -11,20 +12,22 @@ import (
 
 	"app.modules/core/workspaceapp"
 
-	"app.modules/core/wordsreader"
-	"app.modules/core/youtubebot"
 	"github.com/kr/pretty"
 
-	"errors"
+	"app.modules/core/wordsreader"
+	"app.modules/core/youtubebot"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/transport"
 
 	"app.modules/core/timeutil"
 	"app.modules/core/utils"
-	"google.golang.org/api/option"
-	"google.golang.org/api/transport"
 )
 
-const MaxRetryIntervalSeconds = 300
-const RetryIntervalCalculationBase = 1.2
+const (
+	MaxRetryIntervalSeconds      = 300
+	RetryIntervalCalculationBase = 1.2
+)
 
 func Init() (option.ClientOption, context.Context, error) {
 	utils.LoadEnv(".env")

--- a/system/core/guardians/live_stream_checker.go
+++ b/system/core/guardians/live_stream_checker.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"log/slog"
 
-	"app.modules/core/moderatorbot"
-	"app.modules/core/repository"
-	"app.modules/core/youtubebot"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 	"google.golang.org/api/youtube/v3"
+
+	"app.modules/core/moderatorbot"
+	"app.modules/core/repository"
+	"app.modules/core/youtubebot"
 )
 
 type LiveStreamChecker struct {
@@ -24,7 +25,6 @@ func NewLiveStreamChecker(
 	youtubeLiveChatBot youtubebot.LiveChatBot,
 	messageBot moderatorbot.MessageBot,
 ) *LiveStreamChecker {
-
 	return &LiveStreamChecker{
 		YoutubeLiveChatBot:  youtubeLiveChatBot,
 		alertOwnerBot:       messageBot,

--- a/system/core/guardians/live_stream_checker.go
+++ b/system/core/guardians/live_stream_checker.go
@@ -35,7 +35,7 @@ func NewLiveStreamChecker(
 func (checker *LiveStreamChecker) Check(ctx context.Context) error {
 	credentials, err := checker.FirestoreController.ReadCredentialsConfig(ctx, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("read credentials config: %w", err)
 	}
 	config := &oauth2.Config{
 		ClientID:     credentials.YoutubeChannelClientID,

--- a/system/core/i18n/i18n.go
+++ b/system/core/i18n/i18n.go
@@ -2,6 +2,7 @@ package i18n
 
 import (
 	"embed"
+	"fmt"
 
 	engine "app.modules/core/i18n/internal/engine"
 )
@@ -28,10 +29,16 @@ func SetDefaultFallback(fallback Language) {
 }
 
 func LoadLocaleFileFS(f embed.FS, name string) error {
-	return engine.LoadLocaleFileFS(f, name)
+	if err := engine.LoadLocaleFileFS(f, name); err != nil {
+		return fmt.Errorf("load locale file %q: %w", name, err)
+	}
+	return nil
 }
 
 // LoadLocaleFolderFS loads all locale files from embedded filesystem.
 func LoadLocaleFolderFS() error {
-	return engine.LoadLocaleFolderFS(fs, LocalesFolderName)
+	if err := engine.LoadLocaleFolderFS(fs, LocalesFolderName); err != nil {
+		return fmt.Errorf("load locale folder %q: %w", LocalesFolderName, err)
+	}
+	return nil
 }

--- a/system/core/i18n/i18n_test.go
+++ b/system/core/i18n/i18n_test.go
@@ -4,10 +4,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"app.modules/core/i18n"
 	engine "app.modules/core/i18n/internal/engine"
 	i18nmsg "app.modules/core/i18n/typed"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestI18nRealWorldUsage(t *testing.T) {

--- a/system/core/i18n/internal/engine/engine.go
+++ b/system/core/i18n/internal/engine/engine.go
@@ -10,9 +10,7 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-var (
-	ErrLocaleFile = errors.New("i18n: wrong file name or struct")
-)
+var ErrLocaleFile = errors.New("i18n: wrong file name or struct")
 
 type Language string
 
@@ -23,9 +21,11 @@ const (
 
 type LocaleData map[string]map[string]string
 
-var localeData map[Language]LocaleData = make(map[Language]LocaleData)
-var defaultLanguage Language = LanguageJA
-var defaultFallback Language = LanguageJA
+var (
+	localeData      map[Language]LocaleData = make(map[Language]LocaleData)
+	defaultLanguage Language                = LanguageJA
+	defaultFallback Language                = LanguageJA
+)
 
 func SetDefaultLanguage(lang Language)     { defaultLanguage = lang }
 func SetDefaultFallback(fallback Language) { defaultFallback = fallback }

--- a/system/core/moderatorbot/discord.go
+++ b/system/core/moderatorbot/discord.go
@@ -23,7 +23,7 @@ type DiscordBot struct {
 func NewDiscordBot(token string, textChannelID string) (*DiscordBot, error) {
 	session, err := discordgo.New("Bot " + token)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create Discord session: %w", err)
 	}
 
 	// HTTPクライアントにタイムアウトを設定

--- a/system/core/mybigquery/bigquery_controller.go
+++ b/system/core/mybigquery/bigquery_controller.go
@@ -2,17 +2,17 @@ package mybigquery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
-	"errors"
-
-	"app.modules/core/repository"
-	"app.modules/core/timeutil"
 	"cloud.google.com/go/bigquery"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
+
+	"app.modules/core/repository"
+	"app.modules/core/timeutil"
 )
 
 type BigqueryController struct {
@@ -22,7 +22,8 @@ type BigqueryController struct {
 
 func NewBigqueryClient(ctx context.Context, projectID string, clientOption option.ClientOption,
 	workingRegion string) (*BigqueryController,
-	error) {
+	error,
+) {
 	client, err := bigquery.NewClient(ctx, projectID, clientOption)
 	if err != nil {
 		return nil, fmt.Errorf("in bigquery.NewClient: %w", err)
@@ -44,7 +45,8 @@ func (c *BigqueryController) CloseClient() {
 
 func (c *BigqueryController) ReadCollectionsFromGcs(ctx context.Context,
 	gcsFolderName string, bucketName string,
-	collections []string) error {
+	collections []string,
+) error {
 	for _, collectionName := range collections {
 		// GCSからbigqueryの一時テーブルにデータをバッチ読込
 		gcsRef := bigquery.NewGCSReference("gs://" + bucketName + "/" + gcsFolderName + "/all_namespaces/kind_" +

--- a/system/core/mybigquery/bigquery_controller.go
+++ b/system/core/mybigquery/bigquery_controller.go
@@ -67,7 +67,7 @@ func (c *BigqueryController) ReadCollectionsFromGcs(ctx context.Context,
 			return fmt.Errorf("in job.Wait: %w", err)
 		}
 		if err = status.Err(); err != nil {
-			return err
+			return fmt.Errorf("load collection %q into BigQuery: %w", collectionName, err)
 		}
 		if status.State == bigquery.Done {
 			slog.Info("GCSからbqの一時テーブルまでデータの読込が完了", "collection", collectionName)

--- a/system/core/mystorage/storage_controller.go
+++ b/system/core/mystorage/storage_controller.go
@@ -2,13 +2,15 @@ package mystorage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 
-	"app.modules/core/timeutil"
 	"cloud.google.com/go/storage"
-	"errors"
+
+	"app.modules/core/timeutil"
+
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -19,7 +21,8 @@ type StorageController struct {
 }
 
 func NewStorageClient(ctx context.Context, clientOption option.ClientOption,
-	workingRegion string) (*StorageController, error) {
+	workingRegion string,
+) (*StorageController, error) {
 	client, err := storage.NewClient(ctx, clientOption)
 	if err != nil {
 		return nil, fmt.Errorf("in storage.NewClient: %w", err)
@@ -39,7 +42,8 @@ func (controller *StorageController) CloseClient() {
 }
 
 func (controller *StorageController) GetGcsYesterdayExportFolderName(ctx context.Context, bucketName string) (string,
-	error) {
+	error,
+) {
 	jstNow := timeutil.JstNow()
 	yesterday := jstNow.AddDate(0, 0, -1)
 	searchPrefix := yesterday.Format("2006-01-02")

--- a/system/core/repository/firestore_controller.go
+++ b/system/core/repository/firestore_controller.go
@@ -37,47 +37,74 @@ func (c *FirestoreControllerImplements) FirestoreClient() DBClient {
 
 func (c *FirestoreControllerImplements) get(ctx context.Context, tx *firestore.Transaction, ref *firestore.DocumentRef) (*firestore.DocumentSnapshot, error) {
 	if tx != nil {
-		return tx.Get(ref)
-	} else {
-		return ref.Get(ctx)
+		doc, err := tx.Get(ref)
+		if err != nil {
+			return nil, fmt.Errorf("get document in transaction: %w", err)
+		}
+		return doc, nil
 	}
+	doc, err := ref.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get document: %w", err)
+	}
+	return doc, nil
 }
 
 func (c *FirestoreControllerImplements) create(ctx context.Context, tx *firestore.Transaction, ref *firestore.DocumentRef, data interface{}) error {
 	if tx != nil {
-		return tx.Create(ref, data)
-	} else {
-		_, err := ref.Create(ctx, data)
-		return err
+		if err := tx.Create(ref, data); err != nil {
+			return fmt.Errorf("create document in transaction: %w", err)
+		}
+		return nil
 	}
+	if _, err := ref.Create(ctx, data); err != nil {
+		return fmt.Errorf("create document: %w", err)
+	}
+	return nil
 }
 
 func (c *FirestoreControllerImplements) set(ctx context.Context, tx *firestore.Transaction, ref *firestore.DocumentRef, data interface{}, opts ...firestore.SetOption) error {
 	if tx != nil {
-		return tx.Set(ref, data, opts...)
-	} else {
-		_, err := ref.Set(ctx, data, opts...)
-		return err
+		if err := tx.Set(ref, data, opts...); err != nil {
+			return fmt.Errorf("set document in transaction: %w", err)
+		}
+		return nil
 	}
+	if _, err := ref.Set(ctx, data, opts...); err != nil {
+		return fmt.Errorf("set document: %w", err)
+	}
+	return nil
 }
 
 func (c *FirestoreControllerImplements) update(ctx context.Context, tx *firestore.Transaction, ref *firestore.DocumentRef, data []firestore.Update, opts ...firestore.Precondition) error {
 	if tx != nil {
-		return tx.Update(ref, data, opts...)
-	} else {
-		_, err := ref.Update(ctx, data, opts...)
-		return err
+		return updateInTransaction(tx, ref, data, opts...)
 	}
+	if _, err := ref.Update(ctx, data, opts...); err != nil {
+		return fmt.Errorf("update document: %w", err)
+	}
+	return nil
+}
+
+func updateInTransaction(tx *firestore.Transaction, ref *firestore.DocumentRef, data []firestore.Update, opts ...firestore.Precondition) error {
+	if err := tx.Update(ref, data, opts...); err != nil {
+		return fmt.Errorf("update document in transaction: %w", err)
+	}
+	return nil
 }
 
 // delete deletes the document. If the document doesn't exist, it does nothing and returns no error.
 func (c *FirestoreControllerImplements) delete(ctx context.Context, tx *firestore.Transaction, ref *firestore.DocumentRef, opts ...firestore.Precondition) error {
 	if tx != nil {
-		return tx.Delete(ref, opts...)
-	} else {
-		_, err := ref.Delete(ctx, opts...)
-		return err
+		if err := tx.Delete(ref, opts...); err != nil {
+			return fmt.Errorf("delete document in transaction: %w", err)
+		}
+		return nil
 	}
+	if _, err := ref.Delete(ctx, opts...); err != nil {
+		return fmt.Errorf("delete document: %w", err)
+	}
+	return nil
 }
 
 func (c *FirestoreControllerImplements) configCollection() *firestore.CollectionRef {
@@ -147,12 +174,7 @@ func (c *FirestoreControllerImplements) workNameTrendCollection() *firestore.Col
 func (c *FirestoreControllerImplements) DeleteDocRef(ctx context.Context, tx *firestore.Transaction,
 	ref *firestore.DocumentRef,
 ) error {
-	if tx != nil {
-		return tx.Delete(ref)
-	} else {
-		_, err := ref.Delete(ctx)
-		return err
-	}
+	return c.delete(ctx, tx, ref)
 }
 
 func (c *FirestoreControllerImplements) ReadCredentialsConfig(ctx context.Context, tx *firestore.Transaction) (CredentialsConfigDoc, error) {
@@ -203,7 +225,7 @@ func (c *FirestoreControllerImplements) UpdateNextPageToken(ctx context.Context,
 		{Path: NextPageTokenDocProperty, Value: nextPageToken},
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("update next page token: %w", err)
 	}
 	return nil
 }
@@ -244,7 +266,7 @@ func (c *FirestoreControllerImplements) ReadSeat(ctx context.Context, tx *firest
 func (c *FirestoreControllerImplements) ReadSeatWithUserID(ctx context.Context, userID string, isMemberSeat bool) (SeatDoc, error) {
 	docs, err := c.seatsCollection(isMemberSeat).Where(UserIDDocProperty, "==", userID).Documents(ctx).GetAll()
 	if err != nil {
-		return SeatDoc{}, err
+		return SeatDoc{}, fmt.Errorf("query seat by user ID: %w", err)
 	}
 	if len(docs) >= 2 {
 		return SeatDoc{}, errors.New("There are more than two seats with the user id = " + userID + " !!")
@@ -266,14 +288,14 @@ func (c *FirestoreControllerImplements) ReadActiveWorkNameSeats(ctx context.Cont
 
 func (c *FirestoreControllerImplements) UpdateUserLastEnteredDate(tx *firestore.Transaction, userID string, enteredDate time.Time) error {
 	ref := c.usersCollection().Doc(userID)
-	return tx.Update(ref, []firestore.Update{
+	return updateInTransaction(tx, ref, []firestore.Update{
 		{Path: LastEnteredDocProperty, Value: enteredDate},
 	})
 }
 
 func (c *FirestoreControllerImplements) UpdateUserLastExitedDate(tx *firestore.Transaction, userID string, exitedDate time.Time) error {
 	ref := c.usersCollection().Doc(userID)
-	return tx.Update(ref, []firestore.Update{
+	return updateInTransaction(tx, ref, []firestore.Update{
 		{Path: LastExitedDocProperty, Value: exitedDate},
 	})
 }
@@ -282,21 +304,21 @@ func (c *FirestoreControllerImplements) UpdateUserRankVisible(tx *firestore.Tran
 	rankVisible bool,
 ) error {
 	ref := c.usersCollection().Doc(userID)
-	return tx.Update(ref, []firestore.Update{
+	return updateInTransaction(tx, ref, []firestore.Update{
 		{Path: RankVisibleDocProperty, Value: rankVisible},
 	})
 }
 
 func (c *FirestoreControllerImplements) UpdateUserDefaultStudyMin(tx *firestore.Transaction, userID string, defaultStudyMin int) error {
 	ref := c.usersCollection().Doc(userID)
-	return tx.Update(ref, []firestore.Update{
+	return updateInTransaction(tx, ref, []firestore.Update{
 		{Path: DefaultStudyMinDocProperty, Value: defaultStudyMin},
 	})
 }
 
 func (c *FirestoreControllerImplements) UpdateUserFavoriteColor(tx *firestore.Transaction, userID string, colorCode string) error {
 	ref := c.usersCollection().Doc(userID)
-	return tx.Update(ref, []firestore.Update{
+	return updateInTransaction(tx, ref, []firestore.Update{
 		{Path: FavoriteColorDocProperty, Value: colorCode},
 	})
 }
@@ -321,7 +343,7 @@ func (c *FirestoreControllerImplements) UpdateUserTotalTime(
 	newDailyTotalTimeSec int,
 ) error {
 	ref := c.usersCollection().Doc(userID)
-	return tx.Update(ref, []firestore.Update{
+	return updateInTransaction(tx, ref, []firestore.Update{
 		{Path: DailyTotalStudySecDocProperty, Value: newDailyTotalTimeSec},
 		{Path: TotalStudySecDocProperty, Value: newTotalTimeSec},
 	})
@@ -329,14 +351,14 @@ func (c *FirestoreControllerImplements) UpdateUserTotalTime(
 
 func (c *FirestoreControllerImplements) UpdateUserRankPoint(tx *firestore.Transaction, userID string, rp int) error {
 	ref := c.usersCollection().Doc(userID)
-	return tx.Update(ref, []firestore.Update{
+	return updateInTransaction(tx, ref, []firestore.Update{
 		{Path: RankPointDocProperty, Value: rp},
 	})
 }
 
 func (c *FirestoreControllerImplements) UpdateUserLastRPProcessed(tx *firestore.Transaction, userID string, date time.Time) error {
 	ref := c.usersCollection().Doc(userID)
-	return tx.Update(ref, []firestore.Update{
+	return updateInTransaction(tx, ref, []firestore.Update{
 		{Path: LastRPProcessedDocProperty, Value: date},
 	})
 }
@@ -359,7 +381,11 @@ func (c *FirestoreControllerImplements) UpdateWorkNameTrend(ctx context.Context,
 }
 
 func (c *FirestoreControllerImplements) GetAllUserDocRefs(ctx context.Context) ([]*firestore.DocumentRef, error) {
-	return c.usersCollection().DocumentRefs(ctx).GetAll()
+	refs, err := c.usersCollection().DocumentRefs(ctx).GetAll()
+	if err != nil {
+		return nil, fmt.Errorf("get all user document references: %w", err)
+	}
+	return refs, nil
 }
 
 func (c *FirestoreControllerImplements) GetAllNonDailyZeroUserDocs(ctx context.Context) *firestore.DocumentIterator {
@@ -370,7 +396,10 @@ func (c *FirestoreControllerImplements) ResetDailyTotalStudyTime(ctx context.Con
 	_, err := userRef.Update(ctx, []firestore.Update{
 		{Path: DailyTotalStudySecDocProperty, Value: 0},
 	})
-	return err
+	if err != nil {
+		return fmt.Errorf("reset daily study time: %w", err)
+	}
+	return nil
 }
 
 func (c *FirestoreControllerImplements) UpdateLastResetDailyTotalStudyTime(ctx context.Context, timestamp time.Time) error {
@@ -378,7 +407,10 @@ func (c *FirestoreControllerImplements) UpdateLastResetDailyTotalStudyTime(ctx c
 	_, err := ref.Update(ctx, []firestore.Update{
 		{Path: LastResetDailyTotalStudySecDocProperty, Value: timestamp},
 	})
-	return err
+	if err != nil {
+		return fmt.Errorf("update last daily reset time: %w", err)
+	}
+	return nil
 }
 
 func (c *FirestoreControllerImplements) UpdateLastLongTimeSittingChecked(ctx context.Context, timestamp time.Time) error {
@@ -386,7 +418,10 @@ func (c *FirestoreControllerImplements) UpdateLastLongTimeSittingChecked(ctx con
 	_, err := ref.Update(ctx, []firestore.Update{
 		{Path: LastLongTimeSittingCheckedDocProperty, Value: timestamp},
 	})
-	return err
+	if err != nil {
+		return fmt.Errorf("update last long-sitting check time: %w", err)
+	}
+	return nil
 }
 
 func (c *FirestoreControllerImplements) UpdateLastTransferCollectionHistoryBigquery(ctx context.Context,
@@ -396,7 +431,10 @@ func (c *FirestoreControllerImplements) UpdateLastTransferCollectionHistoryBigqu
 	_, err := ref.Update(ctx, []firestore.Update{
 		{Path: LastTransferCollectionHistoryBigqueryDocProperty, Value: timestamp},
 	})
-	return err
+	if err != nil {
+		return fmt.Errorf("update last BigQuery transfer time: %w", err)
+	}
+	return nil
 }
 
 func (c *FirestoreControllerImplements) UpdateDesiredMaxSeats(ctx context.Context, tx *firestore.Transaction,
@@ -449,7 +487,10 @@ func (c *FirestoreControllerImplements) UpdateAccessTokenOfBotCredential(ctx con
 
 func (c *FirestoreControllerImplements) CreateSeat(tx *firestore.Transaction, seat SeatDoc, isMemberSeat bool) error {
 	ref := c.seatsCollection(isMemberSeat).Doc(strconv.Itoa(seat.SeatID))
-	return tx.Create(ref, seat)
+	if err := tx.Create(ref, seat); err != nil {
+		return fmt.Errorf("create seat in transaction: %w", err)
+	}
+	return nil
 }
 
 func (c *FirestoreControllerImplements) UpdateSeat(ctx context.Context, tx *firestore.Transaction, seat SeatDoc, isMemberSeat bool) error {
@@ -685,7 +726,7 @@ func (c *FirestoreControllerImplements) CountUserOrdersOfTheDay(ctx context.Cont
 	aggregationQuery := query.NewAggregationQuery().WithCount("all")
 	results, err := aggregationQuery.Get(ctx)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("count user orders for day: %w", err)
 	}
 
 	count, ok := results["all"]

--- a/system/core/repository/firestore_controller.go
+++ b/system/core/repository/firestore_controller.go
@@ -2,13 +2,14 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
 
 	"cloud.google.com/go/firestore"
 	"cloud.google.com/go/firestore/apiv1/firestorepb"
-	"errors"
+
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
@@ -106,6 +107,7 @@ func (c *FirestoreControllerImplements) orderHistoryCollection() *firestore.Coll
 func (c *FirestoreControllerImplements) generalSeatsCollection() *firestore.CollectionRef {
 	return c.firestoreClient.Collection(SEATS)
 }
+
 func (c *FirestoreControllerImplements) memberSeatsCollection() *firestore.CollectionRef {
 	return c.firestoreClient.Collection(MemberSeats)
 }
@@ -143,7 +145,8 @@ func (c *FirestoreControllerImplements) workNameTrendCollection() *firestore.Col
 }
 
 func (c *FirestoreControllerImplements) DeleteDocRef(ctx context.Context, tx *firestore.Transaction,
-	ref *firestore.DocumentRef) error {
+	ref *firestore.DocumentRef,
+) error {
 	if tx != nil {
 		return tx.Delete(ref)
 	} else {
@@ -209,6 +212,7 @@ func (c *FirestoreControllerImplements) ReadGeneralSeats(ctx context.Context) ([
 	iter := c.generalSeatsCollection().Documents(ctx)
 	return getDocDataFromIterator[SeatDoc](iter)
 }
+
 func (c *FirestoreControllerImplements) ReadMemberSeats(ctx context.Context) ([]SeatDoc, error) {
 	iter := c.memberSeatsCollection().Documents(ctx)
 	return getDocDataFromIterator[SeatDoc](iter)
@@ -275,7 +279,8 @@ func (c *FirestoreControllerImplements) UpdateUserLastExitedDate(tx *firestore.T
 }
 
 func (c *FirestoreControllerImplements) UpdateUserRankVisible(tx *firestore.Transaction, userID string,
-	rankVisible bool) error {
+	rankVisible bool,
+) error {
 	ref := c.usersCollection().Doc(userID)
 	return tx.Update(ref, []firestore.Update{
 		{Path: RankVisibleDocProperty, Value: rankVisible},
@@ -385,7 +390,8 @@ func (c *FirestoreControllerImplements) UpdateLastLongTimeSittingChecked(ctx con
 }
 
 func (c *FirestoreControllerImplements) UpdateLastTransferCollectionHistoryBigquery(ctx context.Context,
-	timestamp time.Time) error {
+	timestamp time.Time,
+) error {
 	ref := c.configCollection().Doc(SystemConstantsConfigDocName)
 	_, err := ref.Update(ctx, []firestore.Update{
 		{Path: LastTransferCollectionHistoryBigqueryDocProperty, Value: timestamp},
@@ -394,14 +400,17 @@ func (c *FirestoreControllerImplements) UpdateLastTransferCollectionHistoryBigqu
 }
 
 func (c *FirestoreControllerImplements) UpdateDesiredMaxSeats(ctx context.Context, tx *firestore.Transaction,
-	desiredMaxSeats int) error {
+	desiredMaxSeats int,
+) error {
 	ref := c.configCollection().Doc(SystemConstantsConfigDocName)
 	return c.update(ctx, tx, ref, []firestore.Update{
 		{Path: DesiredMaxSeatsDocProperty, Value: desiredMaxSeats},
 	})
 }
+
 func (c *FirestoreControllerImplements) UpdateDesiredMemberMaxSeats(ctx context.Context, tx *firestore.Transaction,
-	desiredMemberMaxSeats int) error {
+	desiredMemberMaxSeats int,
+) error {
 	ref := c.configCollection().Doc(SystemConstantsConfigDocName)
 	return c.update(ctx, tx, ref, []firestore.Update{
 		{Path: DesiredMemberMaxSeatsDocProperty, Value: desiredMemberMaxSeats},
@@ -414,6 +423,7 @@ func (c *FirestoreControllerImplements) UpdateMaxSeats(ctx context.Context, tx *
 		{Path: MaxSeatsDocProperty, Value: maxSeats},
 	})
 }
+
 func (c *FirestoreControllerImplements) UpdateMemberMaxSeats(ctx context.Context, tx *firestore.Transaction, memberMaxSeats int) error {
 	ref := c.configCollection().Doc(SystemConstantsConfigDocName)
 	return c.update(ctx, tx, ref, []firestore.Update{
@@ -453,7 +463,8 @@ func (c *FirestoreControllerImplements) DeleteSeat(ctx context.Context, tx *fire
 }
 
 func (c *FirestoreControllerImplements) CreateLiveChatHistoryDoc(ctx context.Context, tx *firestore.Transaction,
-	liveChatHistoryDoc LiveChatHistoryDoc) error {
+	liveChatHistoryDoc LiveChatHistoryDoc,
+) error {
 	ref := c.liveChatHistoryCollection().NewDoc()
 	return c.create(ctx, tx, ref, liveChatHistoryDoc)
 }
@@ -488,7 +499,8 @@ func (c *FirestoreControllerImplements) GetAllUserActivityDocIDsAfterDate(ctx co
 }
 
 func (c *FirestoreControllerImplements) GetAllUserActivityDocIDsAfterDateForUserAndSeat(ctx context.Context,
-	date time.Time, userID string, seatID int, isMemberSeat bool) ([]UserActivityDoc, error) {
+	date time.Time, userID string, seatID int, isMemberSeat bool,
+) ([]UserActivityDoc, error) {
 	iter := c.userActivitiesCollection().Where(TakenAtDocProperty, ">=",
 		date).Where(UserIDDocProperty, "==", userID).Where(SeatIDDocProperty, "==", seatID).
 		Where(IsMemberSeatDocProperty, "==", isMemberSeat).OrderBy(TakenAtDocProperty,
@@ -497,7 +509,8 @@ func (c *FirestoreControllerImplements) GetAllUserActivityDocIDsAfterDateForUser
 }
 
 func (c *FirestoreControllerImplements) GetEnterRoomUserActivityDocIDsAfterDateForUserAndSeat(ctx context.Context,
-	date time.Time, userID string, seatID int, isMemberSeat bool) ([]UserActivityDoc, error) {
+	date time.Time, userID string, seatID int, isMemberSeat bool,
+) ([]UserActivityDoc, error) {
 	iter := c.userActivitiesCollection().Where(TakenAtDocProperty, ">=", date).Where(UserIDDocProperty, "==", userID).
 		Where(SeatIDDocProperty, "==", seatID).Where(ActivityTypeDocProperty, "==", EnterRoomActivity).
 		Where(IsMemberSeatDocProperty, "==", isMemberSeat).
@@ -506,7 +519,8 @@ func (c *FirestoreControllerImplements) GetEnterRoomUserActivityDocIDsAfterDateF
 }
 
 func (c *FirestoreControllerImplements) GetExitRoomUserActivityDocIDsAfterDateForUserAndSeat(ctx context.Context,
-	date time.Time, userID string, seatID int, isMemberSeat bool) ([]UserActivityDoc, error) {
+	date time.Time, userID string, seatID int, isMemberSeat bool,
+) ([]UserActivityDoc, error) {
 	iter := c.userActivitiesCollection().Where(TakenAtDocProperty, ">=", date).Where(UserIDDocProperty, "==", userID).
 		Where(SeatIDDocProperty, "==", seatID).Where(ActivityTypeDocProperty, "==", ExitRoomActivity).
 		Where(IsMemberSeatDocProperty, "==", isMemberSeat).
@@ -534,7 +548,8 @@ func (c *FirestoreControllerImplements) ReadWorkStateSegmentsBySessionID(ctx con
 }
 
 func (c *FirestoreControllerImplements) UpdateUserIsContinuousActiveAndCurrentActivityStateStarted(
-	ctx context.Context, tx *firestore.Transaction, userID string, isContinuousActive bool, currentActivityStateStarted time.Time) error {
+	ctx context.Context, tx *firestore.Transaction, userID string, isContinuousActive bool, currentActivityStateStarted time.Time,
+) error {
 	ref := c.usersCollection().Doc(userID)
 	return c.update(ctx, tx, ref, []firestore.Update{
 		{Path: IsContinuousActiveDocProperty, Value: isContinuousActive},
@@ -550,7 +565,8 @@ func (c *FirestoreControllerImplements) UpdateUserLastPenaltyImposedDays(ctx con
 }
 
 func (c *FirestoreControllerImplements) UpdateUserRPAndLastPenaltyImposedDays(ctx context.Context, tx *firestore.Transaction, userID string,
-	newRP int, newLastPenaltyImposedDays int) error {
+	newRP int, newLastPenaltyImposedDays int,
+) error {
 	ref := c.usersCollection().Doc(userID)
 	return c.update(ctx, tx, ref, []firestore.Update{
 		{Path: RankPointDocProperty, Value: newRP},

--- a/system/core/repository/seat_test.go
+++ b/system/core/repository/seat_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"app.modules/core/timeutil"
 	"github.com/stretchr/testify/assert"
+
+	"app.modules/core/timeutil"
 )
 
 const testTimeLayout = "2006-01-02 15:04:05"

--- a/system/core/studyspaceerror/error.go
+++ b/system/core/studyspaceerror/error.go
@@ -2,5 +2,7 @@ package studyspaceerror
 
 import "errors"
 
-var ErrUserNotInTheRoom = errors.New("user not in the room")
-var ErrNoSeatAvailable = errors.New("no seat available")
+var (
+	ErrUserNotInTheRoom = errors.New("user not in the room")
+	ErrNoSeatAvailable  = errors.New("no seat available")
+)

--- a/system/core/utils/parse_break_test.go
+++ b/system/core/utils/parse_break_test.go
@@ -1,9 +1,11 @@
 package utils
 
 import (
-	"app.modules/core/i18n"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"app.modules/core/i18n"
 )
 
 func TestParseBreak(t *testing.T) {
@@ -218,5 +220,4 @@ func TestParseBreak(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/system/core/utils/parse_change_test.go
+++ b/system/core/utils/parse_change_test.go
@@ -1,9 +1,11 @@
 package utils
 
 import (
-	"app.modules/core/i18n"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"app.modules/core/i18n"
 )
 
 func TestParseChange(t *testing.T) {
@@ -166,5 +168,4 @@ func TestParseChange(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/system/core/utils/parse_command_test.go
+++ b/system/core/utils/parse_command_test.go
@@ -3,8 +3,9 @@ package utils
 import (
 	"testing"
 
-	"app.modules/core/i18n"
 	"github.com/stretchr/testify/assert"
+
+	"app.modules/core/i18n"
 )
 
 const (
@@ -44,7 +45,6 @@ type ParseCommandTestCase struct {
 }
 
 func TestParseCommand(t *testing.T) {
-
 	testCases := []ParseCommandTestCase{
 		{
 			Name:  "非コマンド",
@@ -209,7 +209,8 @@ func TestParseCommand(t *testing.T) {
 			Name:     "メンバーによる絵文字席表示と詳細オプション",
 			Input:    TestEmojiSeat0 + " d",
 			IsMember: true,
-			Output: &CommandDetails{CommandType: Seat,
+			Output: &CommandDetails{
+				CommandType: Seat,
 				SeatOption: SeatOption{
 					ShowDetails: true,
 				},

--- a/system/core/utils/parse_in_test.go
+++ b/system/core/utils/parse_in_test.go
@@ -1,13 +1,14 @@
 package utils
 
 import (
-	"app.modules/core/i18n"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"app.modules/core/i18n"
 )
 
 func TestParseIn(t *testing.T) {
-
 	testCases := []ParseCommandTestCase{
 		{
 			Name:  "基本的な入室",
@@ -741,5 +742,4 @@ func TestParseIn(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/system/core/utils/parse_info_test.go
+++ b/system/core/utils/parse_info_test.go
@@ -1,9 +1,11 @@
 package utils
 
 import (
-	"app.modules/core/i18n"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"app.modules/core/i18n"
 )
 
 func TestParseInfo(t *testing.T) {
@@ -121,5 +123,4 @@ func TestParseInfo(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/system/core/utils/parse_more_test.go
+++ b/system/core/utils/parse_more_test.go
@@ -3,8 +3,9 @@ package utils
 import (
 	"testing"
 
-	"app.modules/core/i18n"
 	"github.com/stretchr/testify/assert"
+
+	"app.modules/core/i18n"
 )
 
 func TestParseMore(t *testing.T) {
@@ -169,5 +170,4 @@ func TestParseMore(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/system/core/utils/parse_my_test.go
+++ b/system/core/utils/parse_my_test.go
@@ -3,8 +3,9 @@ package utils
 import (
 	"testing"
 
-	"app.modules/core/i18n"
 	"github.com/stretchr/testify/assert"
+
+	"app.modules/core/i18n"
 )
 
 func TestParseMy(t *testing.T) {
@@ -364,5 +365,4 @@ func TestParseMy(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/system/core/utils/parse_work_test.go
+++ b/system/core/utils/parse_work_test.go
@@ -3,8 +3,9 @@ package utils
 import (
 	"testing"
 
-	"app.modules/core/i18n"
 	"github.com/stretchr/testify/assert"
+
+	"app.modules/core/i18n"
 )
 
 func TestParseWork(t *testing.T) {
@@ -167,5 +168,4 @@ func TestParseWork(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/system/core/utils/parser.go
+++ b/system/core/utils/parser.go
@@ -1,12 +1,11 @@
 package utils
 
 import (
+	"errors"
 	"log/slog"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"errors"
 
 	i18nmsg "app.modules/core/i18n/typed"
 )

--- a/system/core/utils/parser.go
+++ b/system/core/utils/parser.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"regexp"
 	"strconv"
@@ -717,7 +718,7 @@ func ReplaceEmojiMinToText(emojiString string) (string, error) {
 	if numString != "" {      // "min=xxx" emoji -> "min xxx"
 		num, err := strconv.Atoi(numString)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("parse emoji minutes: %w", err)
 		}
 		return TimeOptionKey + HalfWidthSpace + strconv.Itoa(num) + HalfWidthSpace, nil
 	}

--- a/system/core/utils/rank.go
+++ b/system/core/utils/rank.go
@@ -1,10 +1,9 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"time"
-
-	"errors"
 
 	"app.modules/core/timeutil"
 )

--- a/system/core/utils/rank_test.go
+++ b/system/core/utils/rank_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"app.modules/core/timeutil"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
+
+	"app.modules/core/timeutil"
 )
 
 type InputCalcRankPoint struct {

--- a/system/core/utils/seat_appearance.go
+++ b/system/core/utils/seat_appearance.go
@@ -1,12 +1,12 @@
 package utils
 
 import (
+	"errors"
 	"reflect"
 	"strconv"
 
 	"app.modules/core/repository"
 	"app.modules/core/timeutil"
-	"errors"
 )
 
 const (

--- a/system/core/utils/seat_appearance_test.go
+++ b/system/core/utils/seat_appearance_test.go
@@ -3,8 +3,9 @@ package utils
 import (
 	"testing"
 
-	"app.modules/core/repository"
 	"github.com/stretchr/testify/assert"
+
+	"app.modules/core/repository"
 )
 
 func TestGetSeatAppearance(t *testing.T) {

--- a/system/core/utils/utils.go
+++ b/system/core/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"reflect"
 	"regexp"
@@ -61,7 +62,7 @@ func GetSeatByUserID(seats []repository.SeatDoc, userID string) (repository.Seat
 func GetGcpProjectID(ctx context.Context, clientOption option.ClientOption) (string, error) {
 	creds, err := transport.Creds(ctx, clientOption)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("load Google credentials: %w", err)
 	}
 	return creds.ProjectID, nil
 }
@@ -79,7 +80,7 @@ func ContainsRegexWithIndex(s []string, e string) (bool, int, error) {
 	for i, a := range s {
 		r, err := regexp.Compile(a)
 		if err != nil {
-			return false, 0, err
+			return false, 0, fmt.Errorf("compile regex at index %d: %w", i, err)
 		}
 		if r.MatchString(e) {
 			return true, i, nil

--- a/system/core/utils/utils.go
+++ b/system/core/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"reflect"
 	"regexp"
@@ -13,7 +14,7 @@ import (
 
 	"app.modules/core/repository"
 	"app.modules/core/timeutil"
-	"errors"
+
 	"github.com/google/uuid"
 	"github.com/joho/godotenv"
 	"google.golang.org/api/option"

--- a/system/core/wordsreader/spreadsheet_controller.go
+++ b/system/core/wordsreader/spreadsheet_controller.go
@@ -2,11 +2,11 @@ package wordsreader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
-	"errors"
 	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 )

--- a/system/core/workspaceapp/batch.go
+++ b/system/core/workspaceapp/batch.go
@@ -9,6 +9,12 @@ import (
 	"strconv"
 	"time"
 
+	"cloud.google.com/go/firestore"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	i18nmsg "app.modules/core/i18n/typed"
 	"app.modules/core/mybigquery"
 	"app.modules/core/mystorage"
@@ -16,11 +22,6 @@ import (
 	"app.modules/core/timeutil"
 	"app.modules/core/utils"
 	"app.modules/core/workspaceapp/presenter"
-	"cloud.google.com/go/firestore"
-	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // OrganizeDB 1分ごとに処理を行う。

--- a/system/core/workspaceapp/command_moderation.go
+++ b/system/core/workspaceapp/command_moderation.go
@@ -6,13 +6,14 @@ import (
 	"log/slog"
 	"strconv"
 
+	"cloud.google.com/go/firestore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	i18nmsg "app.modules/core/i18n/typed"
 	"app.modules/core/timeutil"
 	"app.modules/core/utils"
 	"app.modules/core/workspaceapp/presenter"
-	"cloud.google.com/go/firestore"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func (app *WorkspaceApp) Report(ctx context.Context, reportOption *utils.ReportOption) error {

--- a/system/core/workspaceapp/command_seat.go
+++ b/system/core/workspaceapp/command_seat.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"time"
 
+	"cloud.google.com/go/firestore"
+
 	i18nmsg "app.modules/core/i18n/typed"
 	"app.modules/core/repository"
 	"app.modules/core/studyspaceerror"
@@ -14,7 +16,6 @@ import (
 	"app.modules/core/utils"
 	"app.modules/core/workspaceapp/presenter"
 	"app.modules/core/workspaceapp/usecase"
-	"cloud.google.com/go/firestore"
 )
 
 func (app *WorkspaceApp) In(ctx context.Context, inOption *utils.InOption) error {

--- a/system/core/workspaceapp/command_seat_test.go
+++ b/system/core/workspaceapp/command_seat_test.go
@@ -7,6 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/firestore"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"app.modules/core/i18n"
 	"app.modules/core/moderatorbot"
 	"app.modules/core/repository"
@@ -14,11 +20,6 @@ import (
 	"app.modules/core/timeutil"
 	"app.modules/core/utils"
 	mock_youtubebot "app.modules/core/youtubebot/mocks"
-	"cloud.google.com/go/firestore"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func TestSystem_In(t *testing.T) {
@@ -27,7 +28,7 @@ func TestSystem_In(t *testing.T) {
 
 	fixedNow := time.Date(2026, time.January, 1, 10, 0, 0, 0, timeutil.JapanLocation())
 
-	var inTestCases = []struct {
+	inTestCases := []struct {
 		name                          string
 		constantsConfig               repository.ConstantsConfigDoc
 		commandDetails                utils.CommandDetails
@@ -381,7 +382,7 @@ func TestSystem_Out(t *testing.T) {
 
 	fixedNow := time.Date(2026, time.January, 1, 10, 0, 0, 0, timeutil.JapanLocation())
 
-	var outTestCases = []struct {
+	outTestCases := []struct {
 		name                 string
 		constantsConfig      repository.ConstantsConfigDoc
 		commandDetails       utils.CommandDetails
@@ -465,7 +466,7 @@ func TestSystem_ShowSeatInfo(t *testing.T) {
 
 	fixedNow := time.Date(2026, time.January, 1, 10, 0, 0, 0, timeutil.JapanLocation())
 
-	var showSeatInfoTestCases = []struct {
+	showSeatInfoTestCases := []struct {
 		name                 string
 		constantsConfig      repository.ConstantsConfigDoc
 		commandDetails       utils.CommandDetails
@@ -637,7 +638,7 @@ func TestSystem_Change(t *testing.T) {
 
 	fixedNow := time.Date(2026, time.January, 1, 10, 0, 0, 0, timeutil.JapanLocation())
 
-	var changeTestCases = []struct {
+	changeTestCases := []struct {
 		name                 string
 		constantsConfig      repository.ConstantsConfigDoc
 		commandDetails       utils.CommandDetails
@@ -833,7 +834,7 @@ func TestSystem_More(t *testing.T) {
 
 	fixedNow := time.Date(2026, time.January, 1, 10, 0, 0, 0, timeutil.JapanLocation())
 
-	var moreTestCases = []struct {
+	moreTestCases := []struct {
 		name                 string
 		constantsConfig      repository.ConstantsConfigDoc
 		commandDetails       utils.CommandDetails
@@ -1009,7 +1010,7 @@ func TestSystem_Break(t *testing.T) {
 
 	fixedNow := time.Date(2026, time.January, 1, 10, 0, 0, 0, timeutil.JapanLocation())
 
-	var breakTestCases = []struct {
+	breakTestCases := []struct {
 		name                 string
 		constantsConfig      repository.ConstantsConfigDoc
 		commandDetails       utils.CommandDetails
@@ -1196,7 +1197,7 @@ func TestSystem_Resume(t *testing.T) {
 
 	fixedNow := time.Date(2026, time.January, 1, 10, 0, 0, 0, timeutil.JapanLocation())
 
-	var resumeTestCases = []struct {
+	resumeTestCases := []struct {
 		name                 string
 		constantsConfig      repository.ConstantsConfigDoc
 		commandDetails       utils.CommandDetails
@@ -1432,7 +1433,7 @@ func TestSystem_Order(t *testing.T) {
 		return menuDocs[i].Code < menuDocs[j].Code
 	})
 
-	var orderTestCases = []struct {
+	orderTestCases := []struct {
 		name                     string
 		constantsConfig          repository.ConstantsConfigDoc
 		commandDetails           utils.CommandDetails

--- a/system/core/workspaceapp/command_user_test.go
+++ b/system/core/workspaceapp/command_user_test.go
@@ -6,6 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/firestore"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"app.modules/core/i18n"
 	"app.modules/core/moderatorbot"
 	"app.modules/core/repository"
@@ -13,11 +19,6 @@ import (
 	"app.modules/core/timeutil"
 	"app.modules/core/utils"
 	mock_youtubebot "app.modules/core/youtubebot/mocks"
-	"cloud.google.com/go/firestore"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // TODO: 各ケースでちゃんとエラーがハンドリングされること（返されること、ハンドリングされること）
@@ -28,7 +29,7 @@ func TestSystem_ShowUserInfo(t *testing.T) {
 
 	fixedNow := time.Date(2026, time.January, 1, 10, 0, 0, 0, timeutil.JapanLocation())
 
-	var showUserInfoTestCases = []struct {
+	showUserInfoTestCases := []struct {
 		name                 string
 		constantsConfig      repository.ConstantsConfigDoc
 		commandDetails       utils.CommandDetails
@@ -112,7 +113,7 @@ func TestSystem_Rank(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	var rankTestCases = []struct {
+	rankTestCases := []struct {
 		name                 string
 		constantsConfig      repository.ConstantsConfigDoc
 		commandDetails       utils.CommandDetails
@@ -200,7 +201,7 @@ func TestSystem_My(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	var myTestCases = []struct {
+	myTestCases := []struct {
 		name                 string
 		constantsConfig      repository.ConstantsConfigDoc
 		commandDetails       utils.CommandDetails

--- a/system/core/workspaceapp/max_seats_adjustment.go
+++ b/system/core/workspaceapp/max_seats_adjustment.go
@@ -46,7 +46,7 @@ func (app *WorkspaceApp) adjustGeneralSeats(ctx context.Context, constants repos
 			// なくなる座席にいるユーザーは退出させる
 			seats, err := app.Repository.ReadGeneralSeats(ctx)
 			if err != nil {
-				return err
+				return fmt.Errorf("read general seats before shrinking: %w", err)
 			}
 			app.MessageToLiveChat(ctx, "座席数を"+strconv.Itoa(constants.DesiredMaxSeats)+"に固定します↘ 必要な場合は退出してもらうことがあります。")
 			for _, seat := range seats {

--- a/system/core/workspaceapp/ng_word_filter_test.go
+++ b/system/core/workspaceapp/ng_word_filter_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/mock/gomock"
+
 	"app.modules/core/timeutil"
 	mock_youtubebot "app.modules/core/youtubebot/mocks"
-	"go.uber.org/mock/gomock"
 )
 
 type spyMessageBot struct {
@@ -54,7 +55,6 @@ func TestCheckIfUnwantedWordIncluded_BlocksByChatMessageRegex(t *testing.T) {
 		"これは荒らしです",
 		"テストユーザー",
 	)
-
 	if err != nil {
 		t.Fatalf("CheckIfUnwantedWordIncluded() error = %v", err)
 	}
@@ -96,7 +96,6 @@ func TestCheckIfUnwantedWordIncluded_NotifiesByChatMessageRegex(t *testing.T) {
 		"これは要確認です",
 		"テストユーザー",
 	)
-
 	if err != nil {
 		t.Fatalf("CheckIfUnwantedWordIncluded() error = %v", err)
 	}
@@ -138,7 +137,6 @@ func TestCheckIfUnwantedWordIncluded_NoMatch(t *testing.T) {
 		"通常のメッセージです",
 		"テストユーザー",
 	)
-
 	if err != nil {
 		t.Fatalf("CheckIfUnwantedWordIncluded() error = %v", err)
 	}

--- a/system/core/workspaceapp/presenter/change.go
+++ b/system/core/workspaceapp/presenter/change.go
@@ -1,9 +1,10 @@
 package presenter
 
 import (
+	"strings"
+
 	i18nmsg "app.modules/core/i18n/typed"
 	"app.modules/core/workspaceapp/usecase"
-	"strings"
 )
 
 // BuildChangeMessage converts Change usecase events into a localized response.

--- a/system/core/workspaceapp/presenter/more.go
+++ b/system/core/workspaceapp/presenter/more.go
@@ -1,9 +1,10 @@
 package presenter
 
 import (
+	"strings"
+
 	i18nmsg "app.modules/core/i18n/typed"
 	"app.modules/core/workspaceapp/usecase"
-	"strings"
 )
 
 // BuildMoreMessage converts More events into a localized response.

--- a/system/core/workspaceapp/utils.go
+++ b/system/core/workspaceapp/utils.go
@@ -100,15 +100,25 @@ func (app *WorkspaceApp) CreateUser(ctx context.Context, tx *firestore.Transacti
 		TotalStudySec:      0,
 		RegistrationDate:   app.currentTime(),
 	}
-	return app.Repository.CreateUser(ctx, tx, app.ProcessedUserID, userData)
+	if err := app.Repository.CreateUser(ctx, tx, app.ProcessedUserID, userData); err != nil {
+		return fmt.Errorf("create user: %w", err)
+	}
+	return nil
 }
 
 func (app *WorkspaceApp) GetNextPageToken(ctx context.Context, tx *firestore.Transaction) (string, error) {
-	return app.Repository.ReadNextPageToken(ctx, tx)
+	pageToken, err := app.Repository.ReadNextPageToken(ctx, tx)
+	if err != nil {
+		return "", fmt.Errorf("read next page token: %w", err)
+	}
+	return pageToken, nil
 }
 
 func (app *WorkspaceApp) SaveNextPageToken(ctx context.Context, nextPageToken string) error {
-	return app.Repository.UpdateNextPageToken(ctx, nextPageToken)
+	if err := app.Repository.UpdateNextPageToken(ctx, nextPageToken); err != nil {
+		return fmt.Errorf("update next page token: %w", err)
+	}
+	return nil
 }
 
 func (app *WorkspaceApp) CurrentSeat(ctx context.Context, userID string, isMemberSeat bool) (repository.SeatDoc, error) {
@@ -243,7 +253,11 @@ func (app *WorkspaceApp) ExitAllUsersInRoom(ctx context.Context, isMemberRoom bo
 }
 
 func (app *WorkspaceApp) ListLiveChatMessages(ctx context.Context, pageToken string) ([]*youtube.LiveChatMessage, string, int, error) {
-	return app.LiveChatBot.ListMessages(ctx, pageToken)
+	messages, nextPageToken, pollingIntervalMillis, err := app.LiveChatBot.ListMessages(ctx, pageToken)
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("list live chat messages: %w", err)
+	}
+	return messages, nextPageToken, pollingIntervalMillis, nil
 }
 
 func (app *WorkspaceApp) MessageToLiveChat(ctx context.Context, message string) {
@@ -262,7 +276,10 @@ func (app *WorkspaceApp) MessageToOwner(ctx context.Context, message string) {
 // MessageToOwnerOrError はOwner通知を行い、通知失敗を呼び出し元へ返す。
 // 通知Lambdaのように、配送失敗自体をCloudWatch Alarmで検知したい用途で使う。
 func (app *WorkspaceApp) MessageToOwnerOrError(ctx context.Context, message string) error {
-	return app.alertOwnerBot.SendMessage(ctx, message)
+	if err := app.alertOwnerBot.SendMessage(ctx, message); err != nil {
+		return fmt.Errorf("send message to owner: %w", err)
+	}
+	return nil
 }
 
 func (app *WorkspaceApp) MessageToOwnerWithError(ctx context.Context, message string, argErr error) {
@@ -273,11 +290,17 @@ func (app *WorkspaceApp) MessageToOwnerWithError(ctx context.Context, message st
 }
 
 func (app *WorkspaceApp) MessageToModerators(ctx context.Context, message string) error {
-	return app.alertModeratorsBot.SendMessage(ctx, message)
+	if err := app.alertModeratorsBot.SendMessage(ctx, message); err != nil {
+		return fmt.Errorf("send message to moderators: %w", err)
+	}
+	return nil
 }
 
 func (app *WorkspaceApp) LogToModerators(ctx context.Context, logMessage string) error {
-	return app.logModeratorsBot.SendMessage(ctx, logMessage)
+	if err := app.logModeratorsBot.SendMessage(ctx, logMessage); err != nil {
+		return fmt.Errorf("send moderator log: %w", err)
+	}
+	return nil
 }
 
 // CheckLongTimeSitting 長時間入室しているユーザーを席移動させる。
@@ -299,7 +322,10 @@ func (app *WorkspaceApp) CheckLongTimeSitting(ctx context.Context, isMemberRoom 
 
 func (app *WorkspaceApp) CheckLiveStreamStatus(ctx context.Context) error {
 	checker := guardians.NewLiveStreamChecker(app.Repository, app.LiveChatBot, app.alertOwnerBot)
-	return checker.Check(ctx)
+	if err := checker.Check(ctx); err != nil {
+		return fmt.Errorf("check live stream status: %w", err)
+	}
+	return nil
 }
 
 func (app *WorkspaceApp) GetUserIDsToProcessRP(ctx context.Context) ([]string, error) {
@@ -415,7 +441,10 @@ func (app *WorkspaceApp) AddLiveChatHistoryDoc(ctx context.Context, chatMessage 
 		PublishedAt:           publishedAt,
 		Type:                  chatMessage.Snippet.Type,
 	}
-	return app.Repository.CreateLiveChatHistoryDoc(ctx, nil, liveChatHistoryDoc)
+	if err := app.Repository.CreateLiveChatHistoryDoc(ctx, nil, liveChatHistoryDoc); err != nil {
+		return fmt.Errorf("create live chat history: %w", err)
+	}
+	return nil
 }
 
 func (app *WorkspaceApp) DeleteCollectionHistoryBeforeDate(ctx context.Context, date time.Time) (int, int, int, error) {

--- a/system/core/workspaceapp/utils.go
+++ b/system/core/workspaceapp/utils.go
@@ -2,13 +2,19 @@ package workspaceapp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math/rand"
 	"strconv"
 	"time"
 
-	"errors"
+	"cloud.google.com/go/firestore"
+	"github.com/kr/pretty"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/youtube/v3"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"app.modules/core/guardians"
 	i18nmsg "app.modules/core/i18n/typed"
@@ -18,12 +24,6 @@ import (
 	"app.modules/core/utils"
 	"app.modules/core/workspaceapp/presenter"
 	"app.modules/core/youtubebot"
-	"cloud.google.com/go/firestore"
-	"github.com/kr/pretty"
-	"google.golang.org/api/iterator"
-	"google.golang.org/api/youtube/v3"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // IsSeatExist 席番号1～max-seatsの席かどうかを判定。
@@ -654,7 +654,8 @@ func (app *WorkspaceApp) GetUserRealtimeSeatAppearance(ctx context.Context, tx *
 // ルームの席が空いているならその中からランダムな席番号（該当ユーザーの入室上限にかからない範囲に限定）を、
 // 空いていないならmax-seatsを増やし、最小の空席番号を返す。
 func (app *WorkspaceApp) RandomAvailableSeatIDForUser(ctx context.Context, tx *firestore.Transaction, userID string, isMemberSeat bool) (int,
-	error) {
+	error,
+) {
 	var seats []repository.SeatDoc
 	var err error
 	if isMemberSeat {

--- a/system/core/workspaceapp/validator.go
+++ b/system/core/workspaceapp/validator.go
@@ -1,10 +1,11 @@
 package workspaceapp
 
 import (
+	"errors"
+
 	i18nmsg "app.modules/core/i18n/typed"
 	"app.modules/core/repository"
 	"app.modules/core/utils"
-	"errors"
 )
 
 func (app *WorkspaceApp) ValidateCommand(command utils.CommandDetails) string {
@@ -48,7 +49,6 @@ func (app *WorkspaceApp) ValidateCommand(command utils.CommandDetails) string {
 }
 
 func (app *WorkspaceApp) ValidateIn(command utils.CommandDetails) string {
-
 	// 作業時間の値
 	inputWorkMin := command.InOption.MinWorkOrderOption.DurationMin
 	if inputWorkMin != 0 {

--- a/system/core/workspaceapp/work_name_trend.go
+++ b/system/core/workspaceapp/work_name_trend.go
@@ -7,13 +7,14 @@ import (
 	"log/slog"
 	"strings"
 
-	"app.modules/core/repository"
-	"app.modules/core/utils"
 	"cloud.google.com/go/firestore"
 	"github.com/openai/openai-go/v2" // imported as openai
 	"github.com/openai/openai-go/v2/option"
 	"github.com/openai/openai-go/v2/responses"
 	"github.com/openai/openai-go/v2/shared"
+
+	"app.modules/core/repository"
+	"app.modules/core/utils"
 )
 
 func (app *WorkspaceApp) UpdateWorkNameTrend(ctx context.Context, apiKey string) error {

--- a/system/core/workspaceapp/work_name_trend_test.go
+++ b/system/core/workspaceapp/work_name_trend_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"app.modules/core/repository"
-	mock_myfirestore "app.modules/core/repository/mocks"
 	"cloud.google.com/go/firestore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	"app.modules/core/repository"
+	mock_myfirestore "app.modules/core/repository/mocks"
 )
 
 func TestUpdateWorkNameTrend_EmptyWorkNames(t *testing.T) {

--- a/system/core/workspaceapp/workspace_app.go
+++ b/system/core/workspaceapp/workspace_app.go
@@ -2,12 +2,14 @@ package workspaceapp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"reflect"
 	"time"
 
-	"errors"
+	"cloud.google.com/go/firestore"
+	"google.golang.org/api/option"
 
 	"app.modules/core/i18n"
 	i18nmsg "app.modules/core/i18n/typed"
@@ -16,8 +18,6 @@ import (
 	"app.modules/core/timeutil"
 	"app.modules/core/utils"
 	"app.modules/core/youtubebot"
-	"cloud.google.com/go/firestore"
-	"google.golang.org/api/option"
 )
 
 type WorkspaceApp struct {

--- a/system/core/workspaceapp/workspace_app.go
+++ b/system/core/workspaceapp/workspace_app.go
@@ -152,7 +152,10 @@ func (app *WorkspaceApp) currentTime() time.Time {
 }
 
 func (app *WorkspaceApp) RunTransaction(ctx context.Context, f func(ctx context.Context, tx *firestore.Transaction) error) error {
-	return app.Repository.FirestoreClient().RunTransaction(ctx, f)
+	if err := app.Repository.FirestoreClient().RunTransaction(ctx, f); err != nil {
+		return fmt.Errorf("run Firestore transaction: %w", err)
+	}
+	return nil
 }
 
 func (app *WorkspaceApp) SetProcessedUser(userID string, userDisplayName string, userProfileImageURL string, isChatModerator bool, isChatOwner bool, isChatMember bool) {
@@ -203,7 +206,7 @@ func (app *WorkspaceApp) CheckIfUnwantedWordIncluded(ctx context.Context, ngWord
 	// ブロック対象チェック
 	found, index, err := utils.ContainsRegexWithIndex(ngWordConfig.blockRegexesForChatMessage, message)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("check chat message against block regexes: %w", err)
 	}
 	if found {
 		if err := app.BanUser(ctx, userID); err != nil {

--- a/system/core/workspaceapp/workspace_app_private_test.go
+++ b/system/core/workspaceapp/workspace_app_private_test.go
@@ -12,11 +12,12 @@ import (
 
 	"google.golang.org/api/iterator"
 
+	"cloud.google.com/go/firestore"
+
 	"app.modules/core/moderatorbot"
 	"app.modules/core/repository"
 	"app.modules/core/timeutil"
 	"app.modules/core/utils"
-	"cloud.google.com/go/firestore"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/system/core/youtubebot/live_chat.go
+++ b/system/core/youtubebot/live_chat.go
@@ -3,6 +3,7 @@ package youtubebot
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strconv"
 	"unicode/utf8"
@@ -33,7 +34,7 @@ func NewYoutubeLiveChatBot(liveChatID string, controller repository.Repository, 
 	txErr := controller.FirestoreClient().RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
 		credentials, err := controller.ReadCredentialsConfig(ctx, tx)
 		if err != nil {
-			return err
+			return fmt.Errorf("read YouTube credentials: %w", err)
 		}
 
 		// channel
@@ -52,7 +53,7 @@ func NewYoutubeLiveChatBot(liveChatID string, controller repository.Repository, 
 		channelClientOption := option.WithTokenSource(channelTokenSource)
 		channelYoutubeService, err = youtube.NewService(ctx, channelClientOption)
 		if err != nil {
-			return err
+			return fmt.Errorf("create channel YouTube service: %w", err)
 		}
 
 		// bot
@@ -71,12 +72,12 @@ func NewYoutubeLiveChatBot(liveChatID string, controller repository.Repository, 
 		botClientOption := option.WithTokenSource(botTokenSource)
 		botYoutubeService, err = youtube.NewService(ctx, botClientOption)
 		if err != nil {
-			return err
+			return fmt.Errorf("create bot YouTube service: %w", err)
 		}
 		return nil
 	})
 	if txErr != nil {
-		return nil, txErr
+		return nil, fmt.Errorf("initialize YouTube services: %w", txErr)
 	}
 
 	return &YoutubeLiveChatBot{
@@ -140,7 +141,11 @@ func (b *YoutubeLiveChatBot) tryListMessages(nextPageToken string, liveChatID st
 		listCall = listCall.PageToken(nextPageToken)
 	}
 
-	return listCall.Do()
+	response, err := listCall.Do()
+	if err != nil {
+		return nil, fmt.Errorf("list live chat messages: %w", err)
+	}
+	return response, nil
 }
 
 func (b *YoutubeLiveChatBot) PostMessage(ctx context.Context, message string) error {
@@ -248,7 +253,10 @@ func (b *YoutubeLiveChatBot) tryPostMessage(message string, liveChatID string) e
 	liveChatMessageService := youtube.NewLiveChatMessagesService(b.BotYoutubeService)
 	insertCall := liveChatMessageService.Insert(part, &liveChatMessage)
 	_, err := insertCall.Do()
-	return err
+	if err != nil {
+		return fmt.Errorf("insert live chat message: %w", err)
+	}
+	return nil
 }
 
 // refreshLiveChatID live chat idを取得するとともに、firestoreに保存（更新）する
@@ -299,14 +307,17 @@ func (b *YoutubeLiveChatBot) fetchActiveBroadcasts() (*youtube.LiveBroadcastList
 		listCall = broadCastsService.List(part).BroadcastStatus("active")
 		response, err = listCall.Do()
 	}
-	return response, err
+	if err != nil {
+		return nil, fmt.Errorf("list active broadcasts: %w", err)
+	}
+	return response, nil
 }
 
 // updateLiveChatID LiveChatIDを更新する
 func (b *YoutubeLiveChatBot) updateLiveChatID(ctx context.Context, newLiveChatID string) error {
 	slog.Info("new live chat id: " + newLiveChatID)
 	if err := b.FirestoreController.UpdateLiveChatID(ctx, nil, newLiveChatID); err != nil {
-		return err
+		return fmt.Errorf("persist live chat ID: %w", err)
 	}
 	b.LiveChatID = newLiveChatID
 	return nil
@@ -352,5 +363,8 @@ func (b *YoutubeLiveChatBot) tryBanUser(userID string, liveChatID string) error 
 	insertCall := liveChatBanService.Insert(part, &liveChatBan)
 
 	_, err := insertCall.Do()
-	return err
+	if err != nil {
+		return fmt.Errorf("insert live chat ban: %w", err)
+	}
+	return nil
 }

--- a/system/core/youtubebot/live_chat.go
+++ b/system/core/youtubebot/live_chat.go
@@ -7,13 +7,14 @@ import (
 	"strconv"
 	"unicode/utf8"
 
-	"app.modules/core/repository"
-	"app.modules/core/utils"
 	"cloud.google.com/go/firestore"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 	"google.golang.org/api/youtube/v3"
+
+	"app.modules/core/repository"
+	"app.modules/core/utils"
 )
 
 const MaxLiveChatMessageLength = 200

--- a/system/core/youtubebot/live_chat_post_test.go
+++ b/system/core/youtubebot/live_chat_post_test.go
@@ -11,11 +11,12 @@ import (
 	"strings"
 	"testing"
 
-	mock_repository "app.modules/core/repository/mocks"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/api/option"
 	"google.golang.org/api/youtube/v3"
+
+	mock_repository "app.modules/core/repository/mocks"
 )
 
 func TestPostMessageLogsWarnAndSkipsLiveChatEnded(t *testing.T) {

--- a/system/core/youtubebot/types_live_chat.go
+++ b/system/core/youtubebot/types_live_chat.go
@@ -3,8 +3,9 @@ package youtubebot
 import (
 	"context"
 
-	"app.modules/core/repository"
 	"google.golang.org/api/youtube/v3"
+
+	"app.modules/core/repository"
 )
 
 type LiveChatBot interface {

--- a/system/internal/adminops/operations.go
+++ b/system/internal/adminops/operations.go
@@ -10,10 +10,11 @@ import (
 
 	"app.modules/core/workspaceapp"
 
-	"app.modules/core/timeutil"
-	"app.modules/core/utils"
 	"cloud.google.com/go/firestore"
 	"google.golang.org/api/option"
+
+	"app.modules/core/timeutil"
+	"app.modules/core/utils"
 )
 
 func ExitAllUsersInRoom(ctx context.Context, clientOption option.ClientOption) {
@@ -93,7 +94,7 @@ func ExportUsersCollectionJSON(ctx context.Context, clientOption option.ClientOp
 	}()
 
 	jsonEnc := json.NewEncoder(f)
-	//jsonEnc.SetIndent("", "\t")
+	// jsonEnc.SetIndent("", "\t")
 	if err := jsonEnc.Encode(allUsersTotalStudySecList); err != nil {
 		panic(err)
 	}

--- a/system/internal/awsruntime/credential.go
+++ b/system/internal/awsruntime/credential.go
@@ -1,8 +1,10 @@
 package awsruntime
 
 import (
-	"app.modules/internal/awsruntime/mydynamodb"
 	"fmt"
+
+	"app.modules/internal/awsruntime/mydynamodb"
+
 	"google.golang.org/api/option"
 )
 

--- a/tools/room-image-prompt/.golangci.yml
+++ b/tools/room-image-prompt/.golangci.yml
@@ -2,7 +2,25 @@ version: "2"
 
 linters:
   default: standard
+  enable:
+    - nolintlint
+    - wrapcheck
   settings:
     errcheck:
       check-blank: true
       check-type-assertions: true
+    nolintlint:
+      allow-unused: false
+      require-explanation: true
+      require-specific: true
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      module-path: github.com/kani3camp/youtube-study-space/tools/room-image-prompt
+    goimports:
+      local-prefixes:
+        - github.com/kani3camp/youtube-study-space/tools/room-image-prompt

--- a/tools/room-image-prompt/cmd/room-image-prompt/main.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main.go
@@ -191,7 +191,7 @@ func writeFileExclusive(path, body string) error {
 	}
 	closeErr := f.Close()
 	if writeErr != nil {
-		return writeErr
+		return fmt.Errorf("出力書き込み: %w", writeErr)
 	}
 	if closeErr != nil {
 		return fmt.Errorf("出力ファイルを閉じる: %w", closeErr)

--- a/tools/room-image-prompt/cmd/room-image-prompt/main.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main.go
@@ -91,11 +91,11 @@ func run() error {
 
 	th, err := theme.BuildTheme(fsys, rng)
 	if err != nil {
-		return err
+		return fmt.Errorf("テーマ構築: %w", err)
 	}
 	tmpl, err := theme.ReadTemplate(fsys)
 	if err != nil {
-		return err
+		return fmt.Errorf("テンプレート読込: %w", err)
 	}
 	body := theme.RenderFinal(tmpl, th.FormatThemeBlock())
 
@@ -161,7 +161,7 @@ func writeDefaultOutput(wd, body string) (string, error) {
 	for attempt := range defaultOutputMaxAttempts {
 		dest := filepath.Join(outputDir, defaultOutputFileName(time.Now(), attempt))
 		if err := writeFileExclusive(dest, body); err != nil {
-			if os.IsExist(err) {
+			if errors.Is(err, os.ErrExist) {
 				continue
 			}
 			return "", fmt.Errorf("出力書き込み: %w", err)
@@ -182,7 +182,7 @@ func defaultOutputFileName(now time.Time, attempt int) string {
 func writeFileExclusive(path, body string) error {
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
-		return err
+		return fmt.Errorf("出力ファイル作成: %w", err)
 	}
 
 	n, writeErr := f.WriteString(body)
@@ -193,7 +193,10 @@ func writeFileExclusive(path, body string) error {
 	if writeErr != nil {
 		return writeErr
 	}
-	return closeErr
+	if closeErr != nil {
+		return fmt.Errorf("出力ファイルを閉じる: %w", closeErr)
+	}
+	return nil
 }
 
 func newRNG(seedStr string) (*rand.Rand, error) {

--- a/tools/room-image-prompt/cmd/room-image-prompt/main.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/atotto/clipboard"
+
 	"github.com/kani3camp/youtube-study-space/tools/room-image-prompt/data"
 	"github.com/kani3camp/youtube-study-space/tools/room-image-prompt/internal/theme"
 )

--- a/tools/room-image-prompt/cmd/room-image-prompt/main_e2e_test.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main_e2e_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -90,7 +91,7 @@ func TestWriteFileExclusiveDoesNotOverwriteExisting(t *testing.T) {
 	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := writeFileExclusive(path, "new"); !os.IsExist(err) {
+	if err := writeFileExclusive(path, "new"); !errors.Is(err, os.ErrExist) {
 		t.Fatalf("expected exist error, got %v", err)
 	}
 	got, err := os.ReadFile(path)

--- a/youtube-monitor/src/components/SeatBox.tsx
+++ b/youtube-monitor/src/components/SeatBox.tsx
@@ -261,8 +261,8 @@ const SeatBox: FC<SeatProps> = (props) => {
               );
           `
 		: css`
-                background-color: rgba(0, 0, 0, 0);
-            `
+				background-color: rgba(0, 0, 0, 0);
+			`
 
 	const seatIdLabel = props.isUsed
 		? `${props.globalSeatId}`

--- a/youtube-monitor/src/styles/BackgroundImage.styles.ts
+++ b/youtube-monitor/src/styles/BackgroundImage.styles.ts
@@ -8,8 +8,8 @@ export const blurLayer = css`
 `
 
 export const backgroundImage = css`
-    position: absolute;
-    top: 0;
-    left: 0;
-    z-index: -1;
+	position: absolute;
+	top: 0;
+	left: 0;
+	z-index: -1;
 `

--- a/youtube-monitor/src/styles/BgmPlayer.styles.ts
+++ b/youtube-monitor/src/styles/BgmPlayer.styles.ts
@@ -40,16 +40,16 @@ export const bgmPlayer = css`
 `
 
 export const audioCanvasDiv = css`
-    z-index: 10;
-    clip-path: inset(0, 0, 0, 0);
+	z-index: 10;
+	clip-path: inset(0, 0, 0, 0);
 `
 
 export const audioCanvas = css`
-    height: 30%;
-    width: 100%;
-    background-color: #77777700;
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    z-index: 15;
+	height: 30%;
+	width: 100%;
+	background-color: #77777700;
+	position: absolute;
+	right: 0;
+	bottom: 0;
+	z-index: 15;
 `

--- a/youtube-monitor/src/styles/Clock.styles.ts
+++ b/youtube-monitor/src/styles/Clock.styles.ts
@@ -25,13 +25,13 @@ export const clockStyle = css`
 `
 
 export const dateStringStyle = css`
-    font-size: 0.6rem;
-    text-align: center;
+	font-size: 0.6rem;
+	text-align: center;
 `
 
 export const timeStringStyle = css`
-    font-size: 1.4rem;
-    text-align: center;
-    font-weight: 800;
-    line-height: 1.6rem;
+	font-size: 1.4rem;
+	text-align: center;
+	font-weight: 800;
+	line-height: 1.6rem;
 `

--- a/youtube-monitor/src/styles/ColorBar.styles.ts
+++ b/youtube-monitor/src/styles/ColorBar.styles.ts
@@ -45,19 +45,19 @@ export const title = css`
 `
 
 export const scaleWrapper = css`
-    position: relative;
-    width: calc(100% - 1.2rem);
-    padding-top: 0.8rem;
-    margin: 0 0.6rem;
-    box-sizing: border-box;
+	position: relative;
+	width: calc(100% - 1.2rem);
+	padding-top: 0.8rem;
+	margin: 0 0.6rem;
+	box-sizing: border-box;
 `
 
 export const labels = css`
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 0.75rem;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 0.75rem;
 `
 
 export const label = css`
@@ -99,6 +99,6 @@ export const colorBarStrip = css`
 `
 
 export const colorBox = css`
-    flex: 1;
-    height: 100%;
+	flex: 1;
+	height: 100%;
 `

--- a/youtube-monitor/src/styles/Menu.styles.ts
+++ b/youtube-monitor/src/styles/Menu.styles.ts
@@ -28,56 +28,57 @@ export const menu = css`
 `
 
 export const menuTitle = css`
-    margin: 0.1rem;
+	margin: 0.1rem;
 `
 
 export const list = css`
-    display: flex;
-    justify-content: space-around;
-    align-items: center;
+	display: flex;
+	justify-content: space-around;
+	align-items: center;
 `
 
 export const listItem = css`
-    flex: 1;
+	flex: 1;
 `
 
 export const image = css`
-    position: relative;
+	position: relative;
 `
 
 export const name = css`
-    font-size: 0.7em;
-    font-weight: 500;
-    margin: 0.1rem;
-    line-height: 0.9rem;
+	font-size: 0.7em;
+	font-weight: 500;
+	margin: 0.1rem;
+	line-height: 0.9rem;
 
-    text-overflow: ellipsis;
-    overflow: hidden;
-    word-wrap: break-word;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	word-wrap: break-word;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
 `
 
 export const commandCode = css`
-    padding: 0.15rem;
-    background-color: var(--ambient-command-bg);
-    transition: background-color var(--ambient-background-transition-duration, 30s) linear;
-    border-radius: 0.2rem;
-    font-size: 0.75em;
-    font-weight: bold;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
+	padding: 0.15rem;
+	background-color: var(--ambient-command-bg);
+	transition: background-color
+		var(--ambient-background-transition-duration, 30s) linear;
+	border-radius: 0.2rem;
+	font-size: 0.75em;
+	font-weight: bold;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
 `
 
 export const notice = css`
-    font-size: 0.36rem;
-    position: absolute;
-    width: 94%;
-    bottom: 0.12rem;
-    color: var(--ambient-notice);
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
+	font-size: 0.36rem;
+	position: absolute;
+	width: 94%;
+	bottom: 0.12rem;
+	color: var(--ambient-notice);
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
 `

--- a/youtube-monitor/src/styles/Message.styles.ts
+++ b/youtube-monitor/src/styles/Message.styles.ts
@@ -11,26 +11,26 @@ export const shape = css`
 `
 
 export const message = css`
-    height: 80%;
-    width: 100%;
-    padding: 0 5%;
-    text-align: center;
-    font-size: 1.4rem;
-    display: flex;
-    flex-direction: row;
-    color: var(--ambient-text-primary);
+	height: 80%;
+	width: 100%;
+	padding: 0 5%;
+	text-align: center;
+	font-size: 1.4rem;
+	display: flex;
+	flex-direction: row;
+	color: var(--ambient-text-primary);
 `
 
 export const pageInfo = css`
-    width: 45%;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+	width: 45%;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 `
 
 export const pageIndex = css`
-    display: inline-block;
+	display: inline-block;
 `
 
 export const memberOnly = css`
@@ -46,14 +46,14 @@ export const memberOnly = css`
 `
 
 export const numStudyingPeople = css`
-    width: 45%;
-    height: 100%;
-    display: inline-block;
-    background-color: var(--ambient-panel-strong-bg);
-    border: 1px solid var(--ambient-border);
-    box-sizing: border-box;
-    border-radius: 0.6rem;
-    transition:
-        background-color var(--ambient-background-transition-duration, 30s) linear,
-        border-color var(--ambient-background-transition-duration, 30s) linear;
+	width: 45%;
+	height: 100%;
+	display: inline-block;
+	background-color: var(--ambient-panel-strong-bg);
+	border: 1px solid var(--ambient-border);
+	box-sizing: border-box;
+	border-radius: 0.6rem;
+	transition:
+		background-color var(--ambient-background-transition-duration, 30s) linear,
+		border-color var(--ambient-background-transition-duration, 30s) linear;
 `

--- a/youtube-monitor/src/styles/SeatBox.styles.ts
+++ b/youtube-monitor/src/styles/SeatBox.styles.ts
@@ -25,15 +25,15 @@ export const seat = css`
 `
 
 export const accentBar = css`
-    position: absolute;
-    top: 0;
-    left: 0;
-    display: flex;
-    align-items: flex-start;
-    justify-content: flex-end;
-    width: 100%;
-    box-sizing: border-box;
-    pointer-events: none;
+	position: absolute;
+	top: 0;
+	left: 0;
+	display: flex;
+	align-items: flex-start;
+	justify-content: flex-end;
+	width: 100%;
+	box-sizing: border-box;
+	pointer-events: none;
 `
 
 export const seatBody = css`
@@ -46,18 +46,18 @@ export const seatBody = css`
 `
 
 export const headerRow = css`
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    height: 0.7rem;
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	height: 0.7rem;
 `
 
 export const headerLeft = css`
-    display: flex;
-    align-items: center;
-    align-self: stretch;
-    min-width: 0;
-    gap: 0.2rem;
+	display: flex;
+	align-items: center;
+	align-self: stretch;
+	min-width: 0;
+	gap: 0.2rem;
 `
 
 export const generalSeatId = css`
@@ -79,8 +79,8 @@ export const memberSeatId = css`
 `
 
 export const menuItem = css`
-    flex-shrink: 0;
-    opacity: 0.72;
+	flex-shrink: 0;
+	opacity: 0.72;
 `
 
 export const breakBadge = css`
@@ -104,33 +104,33 @@ export const starsBadge = css`
 `
 
 export const memberContent = css`
-    position: relative;
-    display: flex;
-    gap: 0.2rem;
-    flex: 1;
-    flex-direction: column;
-    min-height: 0;
+	position: relative;
+	display: flex;
+	gap: 0.2rem;
+	flex: 1;
+	flex-direction: column;
+	min-height: 0;
 `
 
 export const memberMain = css`
-    display: flex;
-    flex: 1;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    gap: 0.14em;
-    min-height: 0;
-    text-align: center;
-    margin-top: auto;
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	gap: 0.14em;
+	min-height: 0;
+	text-align: center;
+	margin-top: auto;
 `
 
 export const emptyContent = css`
-    display: flex;
-    flex: 1;
-    justify-content: center;
-    align-items: center;
-    min-height: 0;
-    text-align: center;
+	display: flex;
+	flex: 1;
+	justify-content: center;
+	align-items: center;
+	min-height: 0;
+	text-align: center;
 `
 
 export const emptySeatCommand = css`
@@ -142,15 +142,14 @@ export const emptySeatCommand = css`
 `
 
 export const memberWorkNameFrame = css`
-    align-self: center;
-    min-width: 50%;
-    padding: 0.1em 0.22em;
-    box-sizing: border-box;
-    border-radius: 0.3rem;
-    background-color: rgba(255, 255, 255, 0.63);
-    text-align: center;
-    padding-top: 0.2em;
-
+	align-self: center;
+	min-width: 50%;
+	padding: 0.1em 0.22em;
+	box-sizing: border-box;
+	border-radius: 0.3rem;
+	background-color: rgba(255, 255, 255, 0.63);
+	text-align: center;
+	padding-top: 0.2em;
 `
 
 export const memberWorkName = css`
@@ -166,14 +165,14 @@ export const memberWorkName = css`
 `
 
 export const generalContent = css`
-    display: flex;
-    flex: 1;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 0.3rem;
-    min-height: 0;
-    text-align: center;
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 0.3rem;
+	min-height: 0;
+	text-align: center;
 `
 
 export const generalWorkName = css`
@@ -198,11 +197,11 @@ export const generalDisplayName = css`
 `
 
 export const memberIdentityRow = css`
-    display: flex;
-    align-items: center;
-    overflow: hidden;
-    gap: 0.22em;
-    max-width: 100%;
+	display: flex;
+	align-items: center;
+	overflow: hidden;
+	gap: 0.22em;
+	max-width: 100%;
 `
 
 export const memberDisplayName = css`
@@ -216,22 +215,21 @@ export const memberDisplayName = css`
 `
 
 export const profileImage = css`
-    border-radius: 999px;
-    object-fit: cover;
-    opacity: 0.92;
-    flex-shrink: 0;
+	border-radius: 999px;
+	object-fit: cover;
+	opacity: 0.92;
+	flex-shrink: 0;
 `
 
 export const timeElapsed = css`
-    color: rgba(46, 41, 36, 0.72);
-    font-size: 0.42em;
-    line-height: 1;
-    white-space: nowrap;
-    padding-left: 0;
-    position: absolute;
-    left: 0.2rem;
-    bottom: 0.2rem;
-
+	color: rgba(46, 41, 36, 0.72);
+	font-size: 0.42em;
+	line-height: 1;
+	white-space: nowrap;
+	padding-left: 0;
+	position: absolute;
+	left: 0.2rem;
+	bottom: 0.2rem;
 `
 
 export const timeRemaining = css`

--- a/youtube-monitor/src/styles/SeatsPage.styles.ts
+++ b/youtube-monitor/src/styles/SeatsPage.styles.ts
@@ -13,6 +13,6 @@ export const roomLayout = css`
 `
 
 export const partition = css`
-    position: absolute;
-    background-color: #2d2b41;
+	position: absolute;
+	background-color: #2d2b41;
 `

--- a/youtube-monitor/src/styles/TickerBoard.styles.ts
+++ b/youtube-monitor/src/styles/TickerBoard.styles.ts
@@ -14,105 +14,120 @@ export const shape = css`
 `
 
 export const container = css`
-    height: 80%;
-    width: 100%;
-    backdrop-filter: blur(3px) saturate(1.05);
-    box-sizing: border-box;
-    overflow: hidden;
-    pointer-events: auto;
-    padding: 0 10px;
-    font-size: 0.8rem;
-    color: var(--ambient-text-primary);
-    mask-image: linear-gradient(to right, transparent 0%, black 6%, black 94%, transparent 100%);
+	height: 80%;
+	width: 100%;
+	backdrop-filter: blur(3px) saturate(1.05);
+	box-sizing: border-box;
+	overflow: hidden;
+	pointer-events: auto;
+	padding: 0 10px;
+	font-size: 0.8rem;
+	color: var(--ambient-text-primary);
+	mask-image: linear-gradient(
+		to right,
+		transparent 0%,
+		black 6%,
+		black 94%,
+		transparent 100%
+	);
 `
 
 export const marquee = css`
-    height: 100%;
-    width: 100%;
-    display: flex;
-    align-items: center;
+	height: 100%;
+	width: 100%;
+	display: flex;
+	align-items: center;
 `
 
 export const genreItem = css`
-    display: inline-flex;
-    align-items: center;
-    margin: 0 0.6rem;
-    padding: 0.28rem 0.6rem;
-    border-radius: 100vh;
-    background-color: var(--ambient-panel-strong-bg);
-    background-image: linear-gradient(180deg, rgba(255,255,255,0.14) 0%, transparent 100%);
-    border: 1px solid var(--ambient-border);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
-    gap: 0.5rem;
-    white-space: nowrap;
-    color: var(--ambient-text-primary);
-    transition:
-        background-color var(--ambient-background-transition-duration, 30s) linear,
-        border-color var(--ambient-background-transition-duration, 30s) linear;
+	display: inline-flex;
+	align-items: center;
+	margin: 0 0.6rem;
+	padding: 0.28rem 0.6rem;
+	border-radius: 100vh;
+	background-color: var(--ambient-panel-strong-bg);
+	background-image: linear-gradient(
+		180deg,
+		rgba(255, 255, 255, 0.14) 0%,
+		transparent 100%
+	);
+	border: 1px solid var(--ambient-border);
+	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+	gap: 0.5rem;
+	white-space: nowrap;
+	color: var(--ambient-text-primary);
+	transition:
+		background-color var(--ambient-background-transition-duration, 30s) linear,
+		border-color var(--ambient-background-transition-duration, 30s) linear;
 `
 
 export const rankBadge = css`
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 1.4rem;
-    height: 1.4rem;
-    padding: 0 0.2rem;
-    border-radius: 9999px;
-    background: linear-gradient(135deg, #fad888 0%, #fbb759 100%);
-    color: #3b2c00;
-    font-weight: 700;
-    box-shadow: inset 0 1px 0 rgba(255,255,255,0.6), 0 1px 2px rgba(0,0,0,0.08);
-    font-variant-numeric: tabular-nums;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 1.4rem;
+	height: 1.4rem;
+	padding: 0 0.2rem;
+	border-radius: 9999px;
+	background: linear-gradient(135deg, #fad888 0%, #fbb759 100%);
+	color: #3b2c00;
+	font-weight: 700;
+	box-shadow:
+		inset 0 1px 0 rgba(255, 255, 255, 0.6),
+		0 1px 2px rgba(0, 0, 0, 0.08);
+	font-variant-numeric: tabular-nums;
 `
 
 export const genre = css`
-    font-weight: 700;
-    font-size: 0.95rem;
+	font-weight: 700;
+	font-size: 0.95rem;
 `
 
 export const count = css`
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.1rem 0.4rem;
-    border-radius: 999px;
-    background: var(--ambient-command-bg);
-    color: var(--ambient-text-primary);
-    font-weight: 600;
-    transition: background-color var(--ambient-background-transition-duration, 30s) linear;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	padding: 0.1rem 0.4rem;
+	border-radius: 999px;
+	background: var(--ambient-command-bg);
+	color: var(--ambient-text-primary);
+	font-weight: 600;
+	transition: background-color
+		var(--ambient-background-transition-duration, 30s) linear;
 `
 
 export const peopleIcon = css`
-    font-size: 0.9rem;
-    line-height: 1;
+	font-size: 0.9rem;
+	line-height: 1;
 `
 
 export const examplesWrapper = css`
-    display: inline-flex;
-    align-items: center;
-    gap: 0.2rem;
-    margin-left: 0.2rem;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.2rem;
+	margin-left: 0.2rem;
 `
 
 export const exampleChip = css`
-    display: inline-flex;
-    align-items: center;
-    padding: 0.1rem 0.25rem;
-    border-radius: 0.3rem;
-    background: var(--ambient-ticker-chip-bg);
-    color: var(--ambient-text-primary);
-    font-size: 0.7rem;
-    transition: background-color var(--ambient-background-transition-duration, 30s) linear;
+	display: inline-flex;
+	align-items: center;
+	padding: 0.1rem 0.25rem;
+	border-radius: 0.3rem;
+	background: var(--ambient-ticker-chip-bg);
+	color: var(--ambient-text-primary);
+	font-size: 0.7rem;
+	transition: background-color
+		var(--ambient-background-transition-duration, 30s) linear;
 `
 
 export const updatedAt = css`
-    padding: 0.08rem 0.3rem;
-    border-radius: 0.3rem;
-    background: var(--ambient-panel-strong-bg);
-    color: var(--ambient-text-primary);
-    opacity: 0.9;
-    white-space: nowrap;
-    font-size: 0.5rem;
-    transition: background-color var(--ambient-background-transition-duration, 30s) linear;
+	padding: 0.08rem 0.3rem;
+	border-radius: 0.3rem;
+	background: var(--ambient-panel-strong-bg);
+	color: var(--ambient-text-primary);
+	opacity: 0.9;
+	white-space: nowrap;
+	font-size: 0.5rem;
+	transition: background-color
+		var(--ambient-background-transition-duration, 30s) linear;
 `

--- a/youtube-monitor/src/styles/Timer.styles.ts
+++ b/youtube-monitor/src/styles/Timer.styles.ts
@@ -32,32 +32,32 @@ export const timer = css`
 `
 
 export const progressBarContainer = css`
-    width: 180px;
-    height: 180px;
-    margin: 0 auto;
+	width: 180px;
+	height: 180px;
+	margin: 0 auto;
 `
 
 export const progressInner = css`
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 0.2rem;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 0.2rem;
 `
 
 export const stateRow = css`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.3rem;
-    line-height: 1.1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 0.3rem;
+	line-height: 1.1;
 `
 
 export const stateLabel = css`
-    font-size: 0.95rem;
-    vertical-align: middle;
-    font-weight: bold;
+	font-size: 0.95rem;
+	vertical-align: middle;
+	font-weight: bold;
 `
 
 export const studyIcon = css`
@@ -77,9 +77,9 @@ export const stateLabelBreak = css`
 `
 
 export const statePlaceholder = css`
-    font-size: 1.1rem;
-    font-weight: bold;
-    opacity: 0.45;
+	font-size: 1.1rem;
+	font-weight: bold;
+	opacity: 0.45;
 `
 
 export const remaining = css`
@@ -95,29 +95,29 @@ export const remaining = css`
 `
 
 export const remainingMinutes = css`
-    width: 2ch;
-    text-align: right;
+	width: 2ch;
+	text-align: right;
 `
 
 export const remainingDivider = css`
-    width: 0.6ch;
-    text-align: center;
+	width: 0.6ch;
+	text-align: center;
 `
 
 export const remainingSeconds = css`
-    width: 2ch;
-    text-align: left;
+	width: 2ch;
+	text-align: left;
 `
 
 export const remainingPlaceholder = css`
-    display: inline-block;
-    width: 4.6ch;
-    text-align: center;
-    opacity: 0.45;
+	display: inline-block;
+	width: 4.6ch;
+	text-align: center;
+	opacity: 0.45;
 `
 
 export const nextRow = css`
-    font-size: 0.65rem;
-    text-align: center;
-    line-height: 1.2;
+	font-size: 0.65rem;
+	text-align: center;
+	line-height: 1.2;
 `

--- a/youtube-monitor/src/styles/Usage.styles.ts
+++ b/youtube-monitor/src/styles/Usage.styles.ts
@@ -32,28 +32,29 @@ export const usage = css`
 `
 
 export const description = css`
-    margin: 0.2rem;
-    font-weight: bold;
+	margin: 0.2rem;
+	font-weight: bold;
 `
 
 export const command = css`
-    margin: 0.0rem;
+	margin: 0rem;
 `
 
 export const commandCode = css`
-    font-weight: 700;
-    font-size: 0.8rem;
-    letter-spacing: 0.01em;
-    font-variant-ligatures: none;
-    display: inline-block;
-    background-color: var(--ambient-command-bg);
-    transition: background-color var(--ambient-background-transition-duration, 30s) linear;
-    border-radius: 0.22rem;
-    padding: 0.12rem 0.5rem;
-    margin: 0.0rem 0.18rem;
-    line-height: 1.35;
+	font-weight: 700;
+	font-size: 0.8rem;
+	letter-spacing: 0.01em;
+	font-variant-ligatures: none;
+	display: inline-block;
+	background-color: var(--ambient-command-bg);
+	transition: background-color
+		var(--ambient-background-transition-duration, 30s) linear;
+	border-radius: 0.22rem;
+	padding: 0.12rem 0.5rem;
+	margin: 0rem 0.18rem;
+	line-height: 1.35;
 `
 
 export const commandDesc = css`
-    font-size: 0.8rem;
+	font-size: 0.8rem;
 `


### PR DESCRIPTION
## 概要

GitHub Copilotレビューで繰り返されていたフォーマット・import整理・説明不足の `//nolint`・未ラップの外部エラーを、レビュー前にCIで検出できるようにします。アプリケーション仕様は変更せず、フォーマット・静的解析・必要最低限のエラーラップに限定しています。

## 変更内容

- Biome
  - schemaをインストール済みのBiome 2.5.0へ同期
  - `javascript.experimentalEmbeddedSnippetsEnabled` を有効化
  - CSS formatterは既存方針に合わせて4スペースを明示
- Go（`system` / `tools/room-image-prompt`）
  - `gofumpt` と `goimports` をformatterとして追加
  - `nolintlint`（specific・explanation必須、unused禁止）を追加
  - `wrapcheck` を標準動作で追加
- 機械的フォーマット
  - Biome 12ファイル、Go 51ファイル、計63ファイル
  - 意味のあるエラー処理修正とは別コミットに分離
- lint修正
  - `nolintlint`: 4箇所の既存 `//nolint:errcheck` に、string-only JSON marshalが失敗しない技術的理由を追加
  - `wrapcheck`: 初回検出68箇所を `fmt.Errorf(...: %w)` で修正
  - 主な境界: Firestore CRUD/transaction、YouTube API、Discord、BigQuery、Google credentials、i18n loader、room-image-promptのファイル/テーマ処理
  - 排他ファイル作成はラップ後も判定を維持するため、`os.IsExist` をエラー連鎖対応の `errors.Is(err, os.ErrExist)` へ更新

## CIについて

既存の `golangci-lint run` がformatter違反も検出することを、意図的なgofumpt違反で実測しました（`File is not properly formatted (gofumpt)`）。そのため、重複するformatter専用ジョブやworkflow変更は追加していません。

今回あえて以下は導入していません。

- `gofumpt.extra-rules`: 初回導入の差分を必要以上に広げないため
- `wrapcheck.report-internal-errors: true`: リポジトリ内部エラーまで一括対象にしないため
- 独自のテンプレートリテラル解析lint: 壊れやすい正規表現ベースの実装を避けるため
- wrapcheck除外・新規nolint: 広範な回避を行わず、すべてコード上で解消

## Biome埋め込みCSSの実測

`youtube-monitor/src/styles/Timer.styles.ts` で確認しました。

- 補間なしのEmotion `css` テンプレート: フォーマット対象
- `${Constants.xxx}` 等を含むテンプレート: Biome 2.5.0では未対応のため対象外
- クラッシュ・不正コード生成: なし
- `biome check --write` の再実行: 差分hash不変で冪等
- `biome check .`: 成功

なお、Biome 2.5.0では埋め込みCSSのインデントが `css.formatter` ではなくホストJavaScriptのタブ設定に従う実挙動でした。TypeScript側の既存タブ方針を維持した結果、処理対象の補間なしスニペットはタブへ正規化されています。補間付きスニペットと同様、今後のBiome対応待ちの制約です。

## 検証

- `youtube-monitor`
  - `pnpm install --frozen-lockfile`: 成功（Node 24.14.0）
  - `pnpm exec biome check .`: 成功（118 files）
  - `pnpm exec biome check --write .` の冪等性: 確認済み
  - `pnpm test`: 成功（7 suites / 134 tests）
  - `pnpm build`: 成功
- `system`
  - golangci-lint v2.11.3 `config verify`: 成功
  - `golangci-lint fmt` の冪等性: 確認済み
  - `golangci-lint run --timeout=5m`: 成功（0 issues）
  - `go test -shuffle=on ./...`: 成功
  - `I18N_BASELINE=ja go generate ./...`: 成功、追加差分なし
- `tools/room-image-prompt`
  - golangci-lint v2.11.3 `config verify`: 成功
  - `golangci-lint fmt` の冪等性: 確認済み
  - `golangci-lint run --timeout=5m`: 成功（0 issues）
  - `go test -shuffle=on ./...`: 成功
  - `go build ./cmd/room-image-prompt`: 成功
- `git diff --check`: 成功
