### PR TITLE
fix(youtube-monitor): 時間帯別に作業・休憩ラベルの可読性を改善

### DIFF
--- a/youtube-monitor/src/lib/color-contrast.test.ts
+++ b/youtube-monitor/src/lib/color-contrast.test.ts
@@ -11,6 +11,7 @@ import {
 	AMBIENT_BGM_TEXT_COLOR,
 	AMBIENT_THEME_BREAK_ACCENT_COLORS,
 	AMBIENT_THEME_COLORS,
+	AMBIENT_THEME_STUDY_ACCENT_COLORS,
 	AMBIENT_THEME_TEXT_COLORS,
 	type AmbientSurfaceColors,
 	type AmbientTextColors,
@@ -18,6 +19,7 @@ import {
 	CONTRAST_BRIDGE_TEXT_COLORS,
 	TWILIGHT_TONE_BREAK_ACCENT_COLORS,
 	TWILIGHT_TONE_COLORS,
+	TWILIGHT_TONE_STUDY_ACCENT_COLORS,
 	TWILIGHT_TONE_TEXT_COLORS,
 } from './time-theme-colors'
 
@@ -66,6 +68,11 @@ const getBreakAccentColor = (theme: TimeTheme, tone: TextTone): RgbaColor =>
 		? TWILIGHT_TONE_BREAK_ACCENT_COLORS[tone]
 		: AMBIENT_THEME_BREAK_ACCENT_COLORS[theme]
 
+const getStudyAccentColor = (theme: TimeTheme, tone: TextTone): RgbaColor =>
+	theme === 'twilight'
+		? TWILIGHT_TONE_STUDY_ACCENT_COLORS[tone]
+		: AMBIENT_THEME_STUDY_ACCENT_COLORS[theme]
+
 const assertAllTextContrast = (
 	textColors: AmbientTextColors,
 	surface: RgbaColor,
@@ -110,7 +117,8 @@ const assertInterpolatedContrast = (
 	}
 }
 
-const assertInterpolatedBreakAccentContrast = (
+const assertInterpolatedAccentContrast = (
+	getAccentColor: (theme: TimeTheme, tone: TextTone) => RgbaColor,
 	fromTheme: TimeTheme,
 	fromTone: TextTone,
 	toTheme: TimeTheme,
@@ -120,8 +128,8 @@ const assertInterpolatedBreakAccentContrast = (
 	const fromSurface = getSurfaceColors(fromTheme, fromTone).panel
 	const toSurface = getSurfaceColors(toTheme, toTone).panel
 	const accentColors = [
-		getBreakAccentColor(fromTheme, fromTone),
-		getBreakAccentColor(toTheme, toTone),
+		getAccentColor(fromTheme, fromTone),
+		getAccentColor(toTheme, toTone),
 	]
 
 	for (let step = 0; step <= 20; step++) {
@@ -158,6 +166,39 @@ describe('ambient theme contrast', () => {
 		['twilight', 'light'],
 		['night', 'light'],
 		['midnight', 'light'],
+	])('%s の作業アクセントがパネル上で4.5:1以上になる', (theme, tone) => {
+		assertContrast(
+			getStudyAccentColor(theme, tone),
+			getSurfaceColors(theme, tone).panel,
+			4.5,
+		)
+	})
+
+	test.each<[TimeTheme, TextTone, TimeTheme, TextTone]>([
+		['dawn', 'dark', 'day', 'dark'],
+		['day', 'dark', 'sunset', 'dark'],
+		['sunset', 'dark', 'twilight', 'dark'],
+		['twilight', 'light', 'night', 'light'],
+		['night', 'light', 'midnight', 'light'],
+	])('%s (%s) → %s (%s) の背景遷移中も作業アクセントが3:1以上を保つ', (fromTheme, fromTone, toTheme, toTone) => {
+		assertInterpolatedAccentContrast(
+			getStudyAccentColor,
+			fromTheme,
+			fromTone,
+			toTheme,
+			toTone,
+			3,
+		)
+	})
+
+	test.each<[TimeTheme, TextTone]>([
+		['dawn', 'dark'],
+		['day', 'dark'],
+		['sunset', 'dark'],
+		['twilight', 'dark'],
+		['twilight', 'light'],
+		['night', 'light'],
+		['midnight', 'light'],
 	])('%s の休憩アクセントがパネル上で4.5:1以上になる', (theme, tone) => {
 		assertContrast(
 			getBreakAccentColor(theme, tone),
@@ -173,7 +214,8 @@ describe('ambient theme contrast', () => {
 		['twilight', 'light', 'night', 'light'],
 		['night', 'light', 'midnight', 'light'],
 	])('%s (%s) → %s (%s) の背景遷移中も休憩アクセントが3:1以上を保つ', (fromTheme, fromTone, toTheme, toTone) => {
-		assertInterpolatedBreakAccentContrast(
+		assertInterpolatedAccentContrast(
+			getBreakAccentColor,
 			fromTheme,
 			fromTone,
 			toTheme,

--- a/youtube-monitor/src/lib/color-contrast.test.ts
+++ b/youtube-monitor/src/lib/color-contrast.test.ts
@@ -9,12 +9,14 @@ import {
 import type { TextTone, TimeTheme } from './time-theme'
 import {
 	AMBIENT_BGM_TEXT_COLOR,
+	AMBIENT_THEME_BREAK_ACCENT_COLORS,
 	AMBIENT_THEME_COLORS,
 	AMBIENT_THEME_TEXT_COLORS,
 	type AmbientSurfaceColors,
 	type AmbientTextColors,
 	CONTRAST_BRIDGE_COLORS,
 	CONTRAST_BRIDGE_TEXT_COLORS,
+	TWILIGHT_TONE_BREAK_ACCENT_COLORS,
 	TWILIGHT_TONE_COLORS,
 	TWILIGHT_TONE_TEXT_COLORS,
 } from './time-theme-colors'
@@ -58,6 +60,11 @@ const getTextColors = (theme: TimeTheme, tone: TextTone): AmbientTextColors =>
 	theme === 'twilight'
 		? TWILIGHT_TONE_TEXT_COLORS[tone]
 		: AMBIENT_THEME_TEXT_COLORS[theme]
+
+const getBreakAccentColor = (theme: TimeTheme, tone: TextTone): RgbaColor =>
+	theme === 'twilight'
+		? TWILIGHT_TONE_BREAK_ACCENT_COLORS[tone]
+		: AMBIENT_THEME_BREAK_ACCENT_COLORS[theme]
 
 const assertAllTextContrast = (
 	textColors: AmbientTextColors,
@@ -103,6 +110,28 @@ const assertInterpolatedContrast = (
 	}
 }
 
+const assertInterpolatedBreakAccentContrast = (
+	fromTheme: TimeTheme,
+	fromTone: TextTone,
+	toTheme: TimeTheme,
+	toTone: TextTone,
+	minimum: number,
+) => {
+	const fromSurface = getSurfaceColors(fromTheme, fromTone).panel
+	const toSurface = getSurfaceColors(toTheme, toTone).panel
+	const accentColors = [
+		getBreakAccentColor(fromTheme, fromTone),
+		getBreakAccentColor(toTheme, toTone),
+	]
+
+	for (let step = 0; step <= 20; step++) {
+		const surface = interpolateColors(fromSurface, toSurface, step / 20)
+		for (const accentColor of accentColors) {
+			assertContrast(accentColor, surface, minimum)
+		}
+	}
+}
+
 describe('WCAG color utilities', () => {
 	test('black/white の相対輝度とコントラスト比を計算する', () => {
 		expect(getRelativeLuminance(rgba(0, 0, 0))).toBe(0)
@@ -121,6 +150,38 @@ describe('WCAG color utilities', () => {
 })
 
 describe('ambient theme contrast', () => {
+	test.each<[TimeTheme, TextTone]>([
+		['dawn', 'dark'],
+		['day', 'dark'],
+		['sunset', 'dark'],
+		['twilight', 'dark'],
+		['twilight', 'light'],
+		['night', 'light'],
+		['midnight', 'light'],
+	])('%s の休憩アクセントがパネル上で4.5:1以上になる', (theme, tone) => {
+		assertContrast(
+			getBreakAccentColor(theme, tone),
+			getSurfaceColors(theme, tone).panel,
+			4.5,
+		)
+	})
+
+	test.each<[TimeTheme, TextTone, TimeTheme, TextTone]>([
+		['dawn', 'dark', 'day', 'dark'],
+		['day', 'dark', 'sunset', 'dark'],
+		['sunset', 'dark', 'twilight', 'dark'],
+		['twilight', 'light', 'night', 'light'],
+		['night', 'light', 'midnight', 'light'],
+	])('%s (%s) → %s (%s) の背景遷移中も休憩アクセントが3:1以上を保つ', (fromTheme, fromTone, toTheme, toTone) => {
+		assertInterpolatedBreakAccentContrast(
+			fromTheme,
+			fromTone,
+			toTheme,
+			toTone,
+			3,
+		)
+	})
+
 	test.each<[TimeTheme, TextTone]>([
 		['dawn', 'dark'],
 		['day', 'dark'],

--- a/youtube-monitor/src/lib/time-theme-colors.ts
+++ b/youtube-monitor/src/lib/time-theme-colors.ts
@@ -19,6 +19,25 @@ export type AmbientTextColors = {
 	notice: RgbaColor
 }
 
+export const AMBIENT_THEME_STUDY_ACCENT_COLORS: Readonly<
+	Record<TimeTheme, RgbaColor>
+> = {
+	dawn: rgba(122, 46, 36),
+	day: rgba(118, 40, 24),
+	sunset: rgba(116, 43, 36),
+	// twilight前半の既定値。後半はTWILIGHT_TONE_STUDY_ACCENT_COLORS.lightを使います。
+	twilight: rgba(73, 29, 25),
+	night: rgba(255, 199, 188),
+	midnight: rgba(255, 208, 200),
+}
+
+export const TWILIGHT_TONE_STUDY_ACCENT_COLORS: Readonly<
+	Record<TextTone, RgbaColor>
+> = {
+	dark: AMBIENT_THEME_STUDY_ACCENT_COLORS.twilight,
+	light: rgba(255, 208, 200),
+}
+
 export const AMBIENT_THEME_BREAK_ACCENT_COLORS: Readonly<
 	Record<TimeTheme, RgbaColor>
 > = {

--- a/youtube-monitor/src/lib/time-theme-colors.ts
+++ b/youtube-monitor/src/lib/time-theme-colors.ts
@@ -19,6 +19,25 @@ export type AmbientTextColors = {
 	notice: RgbaColor
 }
 
+export const AMBIENT_THEME_BREAK_ACCENT_COLORS: Readonly<
+	Record<TimeTheme, RgbaColor>
+> = {
+	dawn: rgba(23, 90, 67),
+	day: rgba(15, 85, 56),
+	sunset: rgba(33, 75, 56),
+	// twilight前半の既定値。後半はTWILIGHT_TONE_BREAK_ACCENT_COLORS.lightを使います。
+	twilight: rgba(22, 48, 32),
+	night: rgba(183, 247, 197),
+	midnight: rgba(196, 249, 208),
+}
+
+export const TWILIGHT_TONE_BREAK_ACCENT_COLORS: Readonly<
+	Record<TextTone, RgbaColor>
+> = {
+	dark: AMBIENT_THEME_BREAK_ACCENT_COLORS.twilight,
+	light: rgba(196, 249, 208),
+}
+
 export const TWILIGHT_TONE_COLORS: Readonly<
 	Record<TextTone, AmbientSurfaceColors>
 > = {

--- a/youtube-monitor/src/styles/AmbientFrame.styles.ts
+++ b/youtube-monitor/src/styles/AmbientFrame.styles.ts
@@ -6,6 +6,7 @@ import {
 	AMBIENT_BGM_TEXT_COLOR,
 	AMBIENT_THEME_BREAK_ACCENT_COLORS,
 	AMBIENT_THEME_COLORS,
+	AMBIENT_THEME_STUDY_ACCENT_COLORS,
 	AMBIENT_THEME_TEXT_COLORS,
 	type AmbientSurfaceColors,
 	type AmbientTextColors,
@@ -13,6 +14,7 @@ import {
 	CONTRAST_BRIDGE_TEXT_COLORS,
 	TWILIGHT_TONE_BREAK_ACCENT_COLORS,
 	TWILIGHT_TONE_COLORS,
+	TWILIGHT_TONE_STUDY_ACCENT_COLORS,
 	TWILIGHT_TONE_TEXT_COLORS,
 } from '../lib/time-theme-colors'
 
@@ -34,6 +36,10 @@ const textVariables = (colors: AmbientTextColors) => css`
 	--ambient-notice: ${toCssRgba(colors.notice)};
 `
 
+const studyAccentVariable = (color: RgbaColor) => css`
+	--ambient-study-accent: ${toCssRgba(color)};
+`
+
 const breakAccentVariable = (color: RgbaColor) => css`
 	--ambient-break-accent: ${toCssRgba(color)};
 `
@@ -42,6 +48,7 @@ const themeSelector = (theme: TimeTheme) => css`
 	&[data-time-theme='${theme}'] {
 		${surfaceVariables(AMBIENT_THEME_COLORS[theme])}
 		${textVariables(AMBIENT_THEME_TEXT_COLORS[theme])}
+		${studyAccentVariable(AMBIENT_THEME_STUDY_ACCENT_COLORS[theme])}
 		${breakAccentVariable(AMBIENT_THEME_BREAK_ACCENT_COLORS[theme])}
 	}
 `
@@ -49,6 +56,7 @@ const themeSelector = (theme: TimeTheme) => css`
 export const themedRoot = css`
 	${surfaceVariables(AMBIENT_THEME_COLORS.day)}
 	${textVariables(AMBIENT_THEME_TEXT_COLORS.day)}
+	${studyAccentVariable(AMBIENT_THEME_STUDY_ACCENT_COLORS.day)}
 	${breakAccentVariable(AMBIENT_THEME_BREAK_ACCENT_COLORS.day)}
 	--ambient-bgm-text: ${toCssRgba(AMBIENT_BGM_TEXT_COLOR)};
 	--ambient-background-transition-duration: 30s;
@@ -67,12 +75,14 @@ export const themedRoot = css`
 	&[data-time-theme='twilight'][data-text-tone='dark'] {
 		${surfaceVariables(TWILIGHT_TONE_COLORS.dark)}
 		${textVariables(TWILIGHT_TONE_TEXT_COLORS.dark)}
+		${studyAccentVariable(TWILIGHT_TONE_STUDY_ACCENT_COLORS.dark)}
 		${breakAccentVariable(TWILIGHT_TONE_BREAK_ACCENT_COLORS.dark)}
 	}
 
 	&[data-time-theme='twilight'][data-text-tone='light'] {
 		${surfaceVariables(TWILIGHT_TONE_COLORS.light)}
 		${textVariables(TWILIGHT_TONE_TEXT_COLORS.light)}
+		${studyAccentVariable(TWILIGHT_TONE_STUDY_ACCENT_COLORS.light)}
 		${breakAccentVariable(TWILIGHT_TONE_BREAK_ACCENT_COLORS.light)}
 	}
 
@@ -87,11 +97,13 @@ export const themedRoot = css`
 	 */
 	&[data-contrast-bridge='true'][data-text-tone='dark'] {
 		${textVariables(CONTRAST_BRIDGE_TEXT_COLORS.dark)}
+		--ambient-study-accent: var(--ambient-text-primary);
 		--ambient-break-accent: var(--ambient-text-primary);
 	}
 
 	&[data-contrast-bridge='true'][data-text-tone='light'] {
 		${textVariables(CONTRAST_BRIDGE_TEXT_COLORS.light)}
+		--ambient-study-accent: var(--ambient-text-primary);
 		--ambient-break-accent: var(--ambient-text-primary);
 	}
 `

--- a/youtube-monitor/src/styles/AmbientFrame.styles.ts
+++ b/youtube-monitor/src/styles/AmbientFrame.styles.ts
@@ -1,15 +1,17 @@
 import { css, keyframes } from '@emotion/react'
-import { toCssRgba } from '../lib/color-contrast'
+import { type RgbaColor, toCssRgba } from '../lib/color-contrast'
 import { Constants } from '../lib/constants'
 import type { TimeTheme } from '../lib/time-theme'
 import {
 	AMBIENT_BGM_TEXT_COLOR,
+	AMBIENT_THEME_BREAK_ACCENT_COLORS,
 	AMBIENT_THEME_COLORS,
 	AMBIENT_THEME_TEXT_COLORS,
 	type AmbientSurfaceColors,
 	type AmbientTextColors,
 	CONTRAST_BRIDGE_COLORS,
 	CONTRAST_BRIDGE_TEXT_COLORS,
+	TWILIGHT_TONE_BREAK_ACCENT_COLORS,
 	TWILIGHT_TONE_COLORS,
 	TWILIGHT_TONE_TEXT_COLORS,
 } from '../lib/time-theme-colors'
@@ -32,16 +34,22 @@ const textVariables = (colors: AmbientTextColors) => css`
 	--ambient-notice: ${toCssRgba(colors.notice)};
 `
 
+const breakAccentVariable = (color: RgbaColor) => css`
+	--ambient-break-accent: ${toCssRgba(color)};
+`
+
 const themeSelector = (theme: TimeTheme) => css`
 	&[data-time-theme='${theme}'] {
 		${surfaceVariables(AMBIENT_THEME_COLORS[theme])}
 		${textVariables(AMBIENT_THEME_TEXT_COLORS[theme])}
+		${breakAccentVariable(AMBIENT_THEME_BREAK_ACCENT_COLORS[theme])}
 	}
 `
 
 export const themedRoot = css`
 	${surfaceVariables(AMBIENT_THEME_COLORS.day)}
 	${textVariables(AMBIENT_THEME_TEXT_COLORS.day)}
+	${breakAccentVariable(AMBIENT_THEME_BREAK_ACCENT_COLORS.day)}
 	--ambient-bgm-text: ${toCssRgba(AMBIENT_BGM_TEXT_COLOR)};
 	--ambient-background-transition-duration: 30s;
 
@@ -59,11 +67,13 @@ export const themedRoot = css`
 	&[data-time-theme='twilight'][data-text-tone='dark'] {
 		${surfaceVariables(TWILIGHT_TONE_COLORS.dark)}
 		${textVariables(TWILIGHT_TONE_TEXT_COLORS.dark)}
+		${breakAccentVariable(TWILIGHT_TONE_BREAK_ACCENT_COLORS.dark)}
 	}
 
 	&[data-time-theme='twilight'][data-text-tone='light'] {
 		${surfaceVariables(TWILIGHT_TONE_COLORS.light)}
 		${textVariables(TWILIGHT_TONE_TEXT_COLORS.light)}
+		${breakAccentVariable(TWILIGHT_TONE_BREAK_ACCENT_COLORS.light)}
 	}
 
 	&[data-contrast-bridge='true'] {
@@ -77,10 +87,12 @@ export const themedRoot = css`
 	 */
 	&[data-contrast-bridge='true'][data-text-tone='dark'] {
 		${textVariables(CONTRAST_BRIDGE_TEXT_COLORS.dark)}
+		--ambient-break-accent: var(--ambient-text-primary);
 	}
 
 	&[data-contrast-bridge='true'][data-text-tone='light'] {
 		${textVariables(CONTRAST_BRIDGE_TEXT_COLORS.light)}
+		--ambient-break-accent: var(--ambient-text-primary);
 	}
 `
 

--- a/youtube-monitor/src/styles/Timer.styles.ts
+++ b/youtube-monitor/src/styles/Timer.styles.ts
@@ -65,7 +65,8 @@ export const studyIcon = css`
 `
 
 export const breakIcon = css`
-    color: ${Constants.timerProgressBreakColor};
+	color: var(--ambient-break-accent);
+	transition: color 150ms linear;
 `
 
 export const stateLabelStudy = css`
@@ -73,7 +74,8 @@ export const stateLabelStudy = css`
 `
 
 export const stateLabelBreak = css`
-    color: ${Constants.timerProgressBreakColor};
+	color: var(--ambient-break-accent);
+	transition: color 150ms linear;
 `
 
 export const statePlaceholder = css`

--- a/youtube-monitor/src/styles/Timer.styles.ts
+++ b/youtube-monitor/src/styles/Timer.styles.ts
@@ -61,23 +61,23 @@ export const stateLabel = css`
 `
 
 export const studyIcon = css`
-	color: var(--ambient-study-accent);
-	transition: color 150ms linear;
+    color: var(--ambient-study-accent);
+    transition: color 150ms linear;
 `
 
 export const breakIcon = css`
-	color: var(--ambient-break-accent);
-	transition: color 150ms linear;
+    color: var(--ambient-break-accent);
+    transition: color 150ms linear;
 `
 
 export const stateLabelStudy = css`
-	color: var(--ambient-study-accent);
-	transition: color 150ms linear;
+    color: var(--ambient-study-accent);
+    transition: color 150ms linear;
 `
 
 export const stateLabelBreak = css`
-	color: var(--ambient-break-accent);
-	transition: color 150ms linear;
+    color: var(--ambient-break-accent);
+    transition: color 150ms linear;
 `
 
 export const statePlaceholder = css`

--- a/youtube-monitor/src/styles/Timer.styles.ts
+++ b/youtube-monitor/src/styles/Timer.styles.ts
@@ -61,23 +61,23 @@ export const stateLabel = css`
 `
 
 export const studyIcon = css`
-    color: var(--ambient-study-accent);
-    transition: color 150ms linear;
+	color: var(--ambient-study-accent);
+	transition: color 150ms linear;
 `
 
 export const breakIcon = css`
-    color: var(--ambient-break-accent);
-    transition: color 150ms linear;
+	color: var(--ambient-break-accent);
+	transition: color 150ms linear;
 `
 
 export const stateLabelStudy = css`
-    color: var(--ambient-study-accent);
-    transition: color 150ms linear;
+	color: var(--ambient-study-accent);
+	transition: color 150ms linear;
 `
 
 export const stateLabelBreak = css`
-    color: var(--ambient-break-accent);
-    transition: color 150ms linear;
+	color: var(--ambient-break-accent);
+	transition: color 150ms linear;
 `
 
 export const statePlaceholder = css`

--- a/youtube-monitor/src/styles/Timer.styles.ts
+++ b/youtube-monitor/src/styles/Timer.styles.ts
@@ -61,7 +61,8 @@ export const stateLabel = css`
 `
 
 export const studyIcon = css`
-    color: ${Constants.timerProgressStudyColor};
+	color: var(--ambient-study-accent);
+	transition: color 150ms linear;
 `
 
 export const breakIcon = css`
@@ -70,7 +71,8 @@ export const breakIcon = css`
 `
 
 export const stateLabelStudy = css`
-    color: ${Constants.timerProgressStudyColor};
+	color: var(--ambient-study-accent);
+	transition: color 150ms linear;
 `
 
 export const stateLabelBreak = css`


### PR DESCRIPTION
## 概要

- 暗い時間帯テーマで作業・休憩ラベルと小さい状態アイコンが背景へ沈む問題を改善しました
- プログレスリングの作業色 `#e03c00` と休憩色 `#008c36` は維持し、ラベルとアイコンだけをテーマ別の意味色へ変更しました
- ライトテーマでは深い赤茶／深緑、ダークテーマでは淡いコーラル／ミントを使用します
- Twilight は `TextTone` 別に色を切り替え、contrast bridge 中は `--ambient-text-primary` を使用して可読性を優先します
- 色の切り替えは 150ms とし、背景の30秒遷移は変更していません

## 採用色

| テーマ | 作業 | 休憩 |
| --- | --- | --- |
| Dawn | `#7A2E24` | `#175A43` |
| Day | `#762818` | `#0F5538` |
| Sunset | `#742B24` | `#214B38` |
| Twilight（dark） | `#491D19` | `#163020` |
| Twilight（light） | `#FFD0C8` | `#C4F9D0` |
| Night | `#FFC7BC` | `#B7F7C5` |
| Midnight | `#FFD0C8` | `#C4F9D0` |

休憩の Sunset は `sunset → twilight dark` の遷移中コントラストを確保するため、初期候補より少し深い色へ調整しています。

## テスト

- `pnpm check` ✅
- `pnpm test --runInBand` ✅（7 suites / 158 tests）
- `pnpm build` ✅
- 作業・休憩アクセントと各パネルを白・黒・明るいグレー・暗いグレーへ合成し、通常時4.5:1以上を検証
- 代表的な同極性遷移を5%刻みで補間し、遷移元・遷移先双方のアクセントが3:1以上になることを検証
- デバッグ画面で状態ラベル・アイコン・固定リング色と contrast bridge を確認

## デバッグ確認用URL

- `/?timeTheme=dawn`
- `/?timeTheme=day`
- `/?timeTheme=sunset`
- `/?timeTheme=twilight&textTone=dark`
- `/?timeTheme=twilight&textTone=light`
- `/?timeTheme=night`
- `/?timeTheme=midnight`
