### PR TITLE
ci: add Firestore Emulator integration test job

### DIFF
--- a/.github/scripts/detect-ci-paths.sh
+++ b/.github/scripts/detect-ci-paths.sh
@@ -10,6 +10,7 @@ readonly CI_GROUPS=(
 	docs_site
 	aws_cdk
 	node_projects
+	firestore_integration
 	all
 )
 
@@ -20,6 +21,7 @@ youtube_monitor=false
 docs_site=false
 aws_cdk=false
 node_projects=false
+firestore_integration=false
 all=false
 
 changed_paths=()
@@ -45,12 +47,13 @@ set_all_groups() {
 	docs_site=true
 	aws_cdk=true
 	node_projects=true
+	firestore_integration=true
 	all=true
 }
 
 path_is_ci_config() {
 	case "$1" in
-		.github/workflows/*|.github/scripts/detect-ci-paths.sh|.github/scripts/test-detect-ci-paths.sh|.github/actions/*)
+		.github/workflows/*|.github/scripts/detect-ci-paths.sh|.github/scripts/test-detect-ci-paths.sh|.github/scripts/run-firestore-integration-tests.sh|.github/actions/*)
 			return 0
 			;;
 		*)
@@ -71,6 +74,7 @@ classify_path() {
 	case "$path" in
 		system/*)
 			system=true
+			firestore_integration=true
 			if [[ "$path" == system/Dockerfile* || "$path" == system/.dockerignore ]]; then
 				aws_cdk=true
 			fi
@@ -90,6 +94,10 @@ classify_path() {
 			;;
 		docs-site/*)
 			docs_site=true
+			matched=true
+			;;
+		firebase/*)
+			firestore_integration=true
 			matched=true
 			;;
 		aws-cdk/*)
@@ -165,6 +173,7 @@ group_value() {
 		docs_site) printf '%s' "$docs_site" ;;
 		aws_cdk) printf '%s' "$aws_cdk" ;;
 		node_projects) printf '%s' "$node_projects" ;;
+		firestore_integration) printf '%s' "$firestore_integration" ;;
 		all) printf '%s' "$all" ;;
 		*)
 			echo "Unknown CI group: $1" >&2

--- a/.github/scripts/run-firestore-integration-tests.sh
+++ b/.github/scripts/run-firestore-integration-tests.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly project_id="demo-youtube-study-space-ci"
+readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly repo_root="$(cd -- "$script_dir/../.." && pwd)"
+
+if ! command -v firebase >/dev/null 2>&1; then
+	echo "firebase CLI is required; install firebase-tools@15.25.1 first" >&2
+	exit 1
+fi
+
+export GCLOUD_PROJECT="$project_id"
+export GOOGLE_CLOUD_PROJECT="$project_id"
+export FIREBASE_PROJECT_ID="$project_id"
+
+cd "$repo_root"
+
+echo "Running Firestore Emulator integration tests for project $project_id"
+firebase emulators:exec \
+	--config firebase/firebase.json \
+	--project "$project_id" \
+	--only firestore \
+	--log-verbosity INFO \
+	"cd system && go test -tags=integration -shuffle=on -count=1 -v ./core/workspaceapp/..."

--- a/.github/scripts/test-detect-ci-paths.sh
+++ b/.github/scripts/test-detect-ci-paths.sh
@@ -13,7 +13,7 @@ assert_exact_groups() {
 	local expected
 
 	output="$($detector --paths "$@")"
-	for group in system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects all; do
+	for group in system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects firestore_integration all; do
 		expected=false
 		case " $expected_groups " in
 			*" $group "*) expected=true ;;
@@ -26,25 +26,31 @@ assert_exact_groups() {
 }
 
 assert_exact_groups "" README.md
+assert_exact_groups firestore_integration firebase/firebase.json
+assert_exact_groups firestore_integration firebase/firestore.rules
+assert_exact_groups firestore_integration firebase/firestore.indexes.json
 assert_exact_groups youtube_monitor youtube-monitor/src/app.ts
 assert_exact_groups youtube_monitor biome.json
-assert_exact_groups system system/core/workspaceapp/app.go
-assert_exact_groups "system aws_cdk" system/Dockerfile.lambda
-assert_exact_groups "system aws_cdk" system/.dockerignore
+assert_exact_groups "system firestore_integration" system/core/workspaceapp/app.go
+assert_exact_groups "system firestore_integration" system/core/repository/firestore_controller.go
+assert_exact_groups "system firestore_integration" system/core/workspaceapp/workspace_app_private_test.go
+assert_exact_groups "system firestore_integration aws_cdk" system/Dockerfile.lambda
+assert_exact_groups "system firestore_integration aws_cdk" system/.dockerignore
 assert_exact_groups aws_cdk aws-cdk/lib/aws-cdk-stack.ts
 assert_exact_groups docs_site docs-site/docs/intro.md
 assert_exact_groups room_image_prompt tools/room-image-prompt/cmd/room-image-prompt/main.go
 assert_exact_groups menu_image_generator tools/menu-image-generator/src/index.ts
 assert_exact_groups node_projects .node-version
 assert_exact_groups node_projects .nvmrc
-assert_exact_groups "system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects all" .github/workflows/ci.yml
-assert_exact_groups "system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects all" .github/workflows/deploy-docs.yml
-assert_exact_groups "system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects all" .github/scripts/detect-ci-paths.sh
-assert_exact_groups "system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects all" .github/scripts/test-detect-ci-paths.sh
-assert_exact_groups "system youtube_monitor" system/core/app.go youtube-monitor/src/app.ts
+assert_exact_groups "system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects firestore_integration all" .github/workflows/ci.yml
+assert_exact_groups "system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects firestore_integration all" .github/workflows/deploy-docs.yml
+assert_exact_groups "system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects firestore_integration all" .github/scripts/detect-ci-paths.sh
+assert_exact_groups "system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects firestore_integration all" .github/scripts/test-detect-ci-paths.sh
+assert_exact_groups "system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects firestore_integration all" .github/scripts/run-firestore-integration-tests.sh
+assert_exact_groups "system firestore_integration youtube_monitor" system/core/app.go youtube-monitor/src/app.ts
 
 manual_output="$(GITHUB_EVENT_NAME=workflow_dispatch "$detector")"
-for group in system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects all; do
+for group in system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects firestore_integration all; do
 	if ! printf '%s\n' "$manual_output" | grep -Fxq "$group=true"; then
 		echo "Expected workflow_dispatch to select $group" >&2
 		exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       docs_site: ${{ steps.detect.outputs.docs_site }}
       aws_cdk: ${{ steps.detect.outputs.aws_cdk }}
       node_projects: ${{ steps.detect.outputs.node_projects }}
+      firestore_integration: ${{ steps.detect.outputs.firestore_integration }}
       all: ${{ steps.detect.outputs.all }}
     steps:
       - name: Checkout
@@ -142,6 +143,52 @@ jobs:
 
       - name: Run tests
         run: go test -shuffle=on -v ./...
+
+  system-firestore-emulator-test:
+    name: System Firestore Emulator Test
+    needs: changes
+    if: ${{ needs.changes.outputs.firestore_integration == 'true' || needs.changes.outputs.all == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: system/go.mod
+          cache: true
+          cache-dependency-path: |
+            system/go.sum
+            system/go.mod
+
+      - name: Download Go dependencies
+        working-directory: system
+        run: go mod download
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Install Firebase CLI
+        run: npm install --global firebase-tools@15.25.1
+
+      - name: Cache Firestore Emulator
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/firebase/emulators
+          key: ${{ runner.os }}-firebase-emulator-${{ hashFiles('firebase/firebase.json', 'firebase/firestore.rules', 'firebase/firestore.indexes.json') }}
+
+      - name: Run Firestore Emulator integration tests
+        run: bash .github/scripts/run-firestore-integration-tests.sh
 
   room-image-prompt-go-lint:
     name: Room Image Prompt Go Lint
@@ -408,6 +455,7 @@ jobs:
       - check-i18n-generate
       - go-lint
       - system-go-test
+      - system-firestore-emulator-test
       - room-image-prompt-go-lint
       - room-image-prompt-go-test
       - menu-image-generator-lint-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,10 +182,10 @@ jobs:
         run: npm install --global firebase-tools@15.25.1
 
       - name: Cache Firestore Emulator
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/firebase/emulators
-          key: ${{ runner.os }}-firebase-emulator-${{ hashFiles('firebase/firebase.json', 'firebase/firestore.rules', 'firebase/firestore.indexes.json') }}
+          key: ${{ runner.os }}-firestore-emulator-firebase-tools-15.25.1
 
       - name: Run Firestore Emulator integration tests
         run: bash .github/scripts/run-firestore-integration-tests.sh

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -1,3 +1,14 @@
+## Firestore Emulator統合テスト
+
+ローカルで統合テストを実行するには、Node.js、Java 21以上、固定版のFirebase CLIが必要です。
+
+```bash
+npm install -g firebase-tools@15.25.1
+bash .github/scripts/run-firestore-integration-tests.sh
+```
+
+このコマンドはFirestore Emulatorだけを起動し、`-tags=integration` を付けたGoテストを実行します。実在するFirebaseプロジェクトや認証情報は不要です。各テスト開始前にEmulator上のテストデータを削除します。通常の `cd system && go test -shuffle=on -v ./...` では、integrationタグ付きテストは実行されません。
+
 ## 前提条件
 - Node.jsがインストールされていること
 - npmがインストールされていること
@@ -6,7 +17,7 @@
 ## 手順
 ### Firebase CLIをインストールする
 ```bash
-npm install -g firebase-tools
+npm install -g firebase-tools@15.25.1
 ```
 
 ### Googleアカウントにログインする

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -1,6 +1,16 @@
 {
-  "firestore": {
-    "rules": "firestore.rules",
-    "indexes": "firestore.indexes.json"
-  }
+	"firestore": {
+		"rules": "firestore.rules",
+		"indexes": "firestore.indexes.json"
+	},
+	"emulators": {
+		"singleProjectMode": true,
+		"firestore": {
+			"host": "127.0.0.1",
+			"port": 8080
+		},
+		"ui": {
+			"enabled": false
+		}
+	}
 }

--- a/system/core/workspaceapp/workspace_app_private_test.go
+++ b/system/core/workspaceapp/workspace_app_private_test.go
@@ -1,12 +1,9 @@
 //go:build integration
 
-// TODO: GitHub ActionsでFirestore Emulatorを使用するようになったら、このファイルも自動テスト対象に変更する。
-
 package workspaceapp
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -18,6 +15,7 @@ import (
 	"app.modules/core/repository"
 	"app.modules/core/timeutil"
 	"app.modules/core/utils"
+	"app.modules/internal/integrationtest"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -25,10 +23,8 @@ import (
 func TestEnterRoom(t *testing.T) {
 	// 入室ができること
 
-	setEnvErr := os.Setenv("FIRESTORE_EMULATOR_HOST", "localhost:8080")
-	if setEnvErr != nil {
-		t.Fatal(setEnvErr)
-	}
+	integrationtest.RequireFirestoreEmulator(t)
+	integrationtest.ResetFirestore(t)
 
 	userID := "test_user_id"
 	userDisplayName := "test_user_display_name"
@@ -54,29 +50,17 @@ func TestEnterRoom(t *testing.T) {
 
 	ctx := context.Background()
 
-	client, clientErr := firestore.NewClient(ctx, firestore.DetectProjectID)
-	if clientErr != nil {
-		t.Fatal(clientErr)
-	}
+	firestoreController := integrationtest.NewFirestoreController(t)
 	app := WorkspaceApp{
-		Repository:    &repository.FirestoreControllerImplements{firestoreClient: client},
+		Repository:    firestoreController,
 		alertOwnerBot: moderatorbot.DummyMessageBot{},
 	}
-	t.Cleanup(func() {
-		app.CloseFirestoreClient()
-	})
 
 	// ユーザーデータを作成しておく
 	userErr := app.Repository.CreateUser(ctx, nil, userID, repository.UserDoc{})
 	if userErr != nil {
 		t.Fatal(userErr)
 	}
-	t.Cleanup(func() {
-		userRef := app.Repository.FirestoreClient.Collection(repository.USERS).Doc(userID)
-		if err := app.Repository.DeleteDocRef(ctx, nil, userRef); err != nil {
-			t.Fatal(err)
-		}
-	})
 
 	var resultUntilExitMin int
 	txErr := app.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
@@ -92,6 +76,7 @@ func TestEnterRoom(t *testing.T) {
 			"",
 			inOption.MinWorkOrderOption.DurationMin,
 			seatAppearance,
+			"",
 			repository.WorkState,
 			true,
 			time.Time{},
@@ -107,36 +92,34 @@ func TestEnterRoom(t *testing.T) {
 	if txErr != nil {
 		t.Fatal(txErr)
 	}
-	t.Cleanup(func() {
-		if err := app.Repository.DeleteSeat(ctx, nil, inOption.SeatID, inOption.IsMemberSeat); err != nil {
-			t.Fatal(err)
-		}
-	})
 
 	// 入室したことを確認
 	seat, seatErr := app.Repository.ReadSeat(ctx, nil, inOption.SeatID, inOption.IsMemberSeat)
 	if seatErr != nil {
 		t.Fatal(seatErr)
 	}
+	assert.NotEmpty(t, seat.SessionID)
 	assert.Equal(t, repository.SeatDoc{
-		SeatID:                 inOption.SeatID,
-		UserID:                 userID,
-		UserDisplayName:        userDisplayName,
-		WorkName:               inOption.MinWorkOrderOption.WorkName,
-		BreakWorkName:          "",
-		EnteredAt:              enteredAt.UTC(),
-		Until:                  expectedUntil.UTC(),
-		Appearance:             seatAppearance,
-		State:                  repository.WorkState,
-		CurrentStateStartedAt:  enteredAt.UTC(),
-		CurrentStateUntil:      expectedUntil.UTC(),
-		CumulativeWorkSec:      0,
-		DailyCumulativeWorkSec: 0,
-		UserProfileImageURL:    userProfileImageURL,
+		SeatID:                  inOption.SeatID,
+		UserID:                  userID,
+		SessionID:               seat.SessionID,
+		UserDisplayName:         userDisplayName,
+		WorkName:                inOption.MinWorkOrderOption.WorkName,
+		BreakWorkName:           "",
+		EnteredAt:               enteredAt.UTC(),
+		Until:                   expectedUntil.UTC(),
+		Appearance:              seatAppearance,
+		State:                   repository.WorkState,
+		CurrentStateStartedAt:   enteredAt.UTC(),
+		CurrentStateUntil:       expectedUntil.UTC(),
+		CurrentSegmentStartedAt: enteredAt.UTC(),
+		CumulativeWorkSec:       0,
+		DailyCumulativeWorkSec:  0,
+		UserProfileImageURL:     userProfileImageURL,
 	}, seat)
 
 	// 履歴が作成されたことを確認
-	iter := app.Repository.FirestoreClient.Collection(repository.UserActivities).Where(repository.UserIDDocProperty, "==", userID).Documents(ctx)
+	iter := app.Repository.FirestoreClient().Collection(repository.UserActivities).Where(repository.UserIDDocProperty, "==", userID).Documents(ctx)
 	var userActivities []repository.UserActivityDoc
 	for {
 		doc, err := iter.Next()
@@ -151,12 +134,6 @@ func TestEnterRoom(t *testing.T) {
 		if dataErr != nil {
 			t.Fatal(dataErr)
 		}
-		t.Cleanup(func() {
-			userActivityRef := app.Repository.FirestoreClient.Collection(repository.UserActivities).Doc(doc.Ref.ID)
-			if err := app.Repository.DeleteDocRef(ctx, nil, userActivityRef); err != nil {
-				t.Fatal(err)
-			}
-		})
 		userActivities = append(userActivities, userActivity)
 	}
 	assert.Len(t, userActivities, 1)

--- a/system/internal/integrationtest/firestore.go
+++ b/system/internal/integrationtest/firestore.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integrationtest
 
 import (

--- a/system/internal/integrationtest/firestore.go
+++ b/system/internal/integrationtest/firestore.go
@@ -1,0 +1,139 @@
+package integrationtest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"app.modules/core/repository"
+
+	"google.golang.org/api/option"
+)
+
+const (
+	expectedProjectID     = "demo-youtube-study-space-ci"
+	expectedEmulatorHost  = "127.0.0.1"
+	expectedEmulatorPort  = "8080"
+	emulatorHostEnv       = "FIRESTORE_EMULATOR_HOST"
+	emulatorProjectEnv    = "GCLOUD_PROJECT"
+	googleProjectEnv      = "GOOGLE_CLOUD_PROJECT"
+	firebaseProjectEnv    = "FIREBASE_PROJECT_ID"
+	emulatorDatabaseName  = "(default)"
+	emulatorResetPathBase = "/emulator/v1/projects/"
+)
+
+// RequireFirestoreEmulator prevents integration tests from accidentally using a real Firestore project.
+func RequireFirestoreEmulator(t *testing.T) {
+	t.Helper()
+
+	hostPort := os.Getenv(emulatorHostEnv)
+	if hostPort == "" {
+		t.Fatal("FIRESTORE_EMULATOR_HOST must be set for Firestore integration tests")
+	}
+
+	host, port, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		t.Fatalf("invalid FIRESTORE_EMULATOR_HOST %q: %v", hostPort, err)
+	}
+	if !isLoopbackHost(host) {
+		t.Fatalf("FIRESTORE_EMULATOR_HOST must point to a loopback address, got %q", hostPort)
+	}
+	if port != expectedEmulatorPort {
+		t.Fatalf("FIRESTORE_EMULATOR_HOST must use port %s, got %q", expectedEmulatorPort, port)
+	}
+
+	projectID := ""
+	for _, envName := range []string{emulatorProjectEnv, googleProjectEnv, firebaseProjectEnv} {
+		value := os.Getenv(envName)
+		if value == "" {
+			continue
+		}
+		if projectID == "" {
+			projectID = value
+			continue
+		}
+		if value != projectID {
+			t.Fatalf("Firestore emulator project ID environment variables disagree: %s=%q, %s=%q", envName, value, emulatorProjectEnv, projectID)
+		}
+	}
+	if projectID == "" {
+		t.Fatalf("one of %s, %s, or %s must be set to %q", emulatorProjectEnv, googleProjectEnv, firebaseProjectEnv, expectedProjectID)
+	}
+	if projectID != expectedProjectID {
+		t.Fatalf("Firestore integration tests require project ID %q, got %q", expectedProjectID, projectID)
+	}
+
+	// firestore.DetectProjectID recognizes GOOGLE_CLOUD_PROJECT. Keep direct local
+	// invocations safe even when only GCLOUD_PROJECT was supplied by the caller.
+	if os.Getenv(googleProjectEnv) == "" {
+		t.Setenv(googleProjectEnv, projectID)
+	}
+}
+
+// NewFirestoreController creates a repository connected to the local Firestore Emulator.
+func NewFirestoreController(t *testing.T) *repository.FirestoreControllerImplements {
+	t.Helper()
+	RequireFirestoreEmulator(t)
+
+	client, err := repository.NewFirestoreController(context.Background(), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("create Firestore emulator client: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := client.FirestoreClient().Close(); err != nil {
+			t.Errorf("close Firestore emulator client: %v", err)
+		}
+	})
+	return client
+}
+
+// ResetFirestore removes every document from the emulator's default database.
+func ResetFirestore(t *testing.T) {
+	t.Helper()
+	RequireFirestoreEmulator(t)
+
+	hostPort := os.Getenv(emulatorHostEnv)
+	endpoint := fmt.Sprintf(
+		"http://%s%s%s/databases/%s/documents",
+		hostPort,
+		emulatorResetPathBase,
+		url.PathEscape(expectedProjectID),
+		emulatorDatabaseName,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		t.Fatalf("create Firestore emulator reset request: %v", err)
+	}
+
+	response, err := (&http.Client{}).Do(request)
+	if err != nil {
+		t.Fatalf("reset Firestore emulator data: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		body, readErr := io.ReadAll(io.LimitReader(response.Body, 4<<10))
+		if readErr != nil {
+			t.Fatalf("reset Firestore emulator data returned status %s and response body could not be read: %v", response.Status, readErr)
+		}
+		t.Fatalf("reset Firestore emulator data returned unexpected status %s: %s", response.Status, strings.TrimSpace(string(body)))
+	}
+}
+
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback() && (ip.String() == expectedEmulatorHost || ip.String() == "::1")
+}

--- a/system/internal/integrationtest/firestore.go
+++ b/system/internal/integrationtest/firestore.go
@@ -45,13 +45,14 @@ func RequireFirestoreEmulator(t *testing.T) {
 		t.Fatalf("invalid FIRESTORE_EMULATOR_HOST %q: %v", hostPort, err)
 	}
 	if !isLoopbackHost(host) {
-		t.Fatalf("FIRESTORE_EMULATOR_HOST must point to a loopback address, got %q", hostPort)
+		t.Fatalf("FIRESTORE_EMULATOR_HOST must use localhost, 127.0.0.1, or ::1, got %q", hostPort)
 	}
 	if port != expectedEmulatorPort {
 		t.Fatalf("FIRESTORE_EMULATOR_HOST must use port %s, got %q", expectedEmulatorPort, port)
 	}
 
 	projectID := ""
+	projectEnvName := ""
 	for _, envName := range []string{emulatorProjectEnv, googleProjectEnv, firebaseProjectEnv} {
 		value := os.Getenv(envName)
 		if value == "" {
@@ -59,10 +60,11 @@ func RequireFirestoreEmulator(t *testing.T) {
 		}
 		if projectID == "" {
 			projectID = value
+			projectEnvName = envName
 			continue
 		}
 		if value != projectID {
-			t.Fatalf("Firestore emulator project ID environment variables disagree: %s=%q, %s=%q", envName, value, emulatorProjectEnv, projectID)
+			t.Fatalf("Firestore emulator project ID environment variables disagree: %s=%q, %s=%q", envName, value, projectEnvName, projectID)
 		}
 	}
 	if projectID == "" {

--- a/system/internal/integrationtest/firestore.go
+++ b/system/internal/integrationtest/firestore.go
@@ -119,7 +119,11 @@ func ResetFirestore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reset Firestore emulator data: %v", err)
 	}
-	defer response.Body.Close()
+	defer func() {
+		if err := response.Body.Close(); err != nil {
+			t.Errorf("close Firestore emulator reset response body: %v", err)
+		}
+	}()
 
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
 		body, readErr := io.ReadAll(io.LimitReader(response.Body, 4<<10))

--- a/youtube-monitor/src/lib/color-contrast.test.ts
+++ b/youtube-monitor/src/lib/color-contrast.test.ts
@@ -180,16 +180,19 @@ describe('ambient theme contrast', () => {
 		['sunset', 'dark', 'twilight', 'dark'],
 		['twilight', 'light', 'night', 'light'],
 		['night', 'light', 'midnight', 'light'],
-	])('%s (%s) → %s (%s) の背景遷移中も作業アクセントが3:1以上を保つ', (fromTheme, fromTone, toTheme, toTone) => {
-		assertInterpolatedAccentContrast(
-			getStudyAccentColor,
-			fromTheme,
-			fromTone,
-			toTheme,
-			toTone,
-			3,
-		)
-	})
+	])(
+		'%s (%s) → %s (%s) の背景遷移中も作業アクセントが3:1以上を保つ',
+		(fromTheme, fromTone, toTheme, toTone) => {
+			assertInterpolatedAccentContrast(
+				getStudyAccentColor,
+				fromTheme,
+				fromTone,
+				toTheme,
+				toTone,
+				3,
+			)
+		},
+	)
 
 	test.each<[TimeTheme, TextTone]>([
 		['dawn', 'dark'],
@@ -213,16 +216,19 @@ describe('ambient theme contrast', () => {
 		['sunset', 'dark', 'twilight', 'dark'],
 		['twilight', 'light', 'night', 'light'],
 		['night', 'light', 'midnight', 'light'],
-	])('%s (%s) → %s (%s) の背景遷移中も休憩アクセントが3:1以上を保つ', (fromTheme, fromTone, toTheme, toTone) => {
-		assertInterpolatedAccentContrast(
-			getBreakAccentColor,
-			fromTheme,
-			fromTone,
-			toTheme,
-			toTone,
-			3,
-		)
-	})
+	])(
+		'%s (%s) → %s (%s) の背景遷移中も休憩アクセントが3:1以上を保つ',
+		(fromTheme, fromTone, toTheme, toTone) => {
+			assertInterpolatedAccentContrast(
+				getBreakAccentColor,
+				fromTheme,
+				fromTone,
+				toTheme,
+				toTone,
+				3,
+			)
+		},
+	)
 
 	test.each<[TimeTheme, TextTone]>([
 		['dawn', 'dark'],
@@ -240,31 +246,31 @@ describe('ambient theme contrast', () => {
 		}
 	})
 
-	test.each<TextTone>([
-		'dark',
-		'light',
-	])('twilight の %s 専用面と文字が4.5:1以上になる', (tone) => {
-		for (const surfaceName of READING_SURFACES) {
-			assertAllTextContrast(
-				TWILIGHT_TONE_TEXT_COLORS[tone],
-				TWILIGHT_TONE_COLORS[tone][surfaceName] as RgbaColor,
-				4.5,
-			)
-		}
-	})
+	test.each<TextTone>(['dark', 'light'])(
+		'twilight の %s 専用面と文字が4.5:1以上になる',
+		(tone) => {
+			for (const surfaceName of READING_SURFACES) {
+				assertAllTextContrast(
+					TWILIGHT_TONE_TEXT_COLORS[tone],
+					TWILIGHT_TONE_COLORS[tone][surfaceName] as RgbaColor,
+					4.5,
+				)
+			}
+		},
+	)
 
-	test.each<TextTone>([
-		'dark',
-		'light',
-	])('コントラストブリッジは %s トーンで4.5:1以上になる', (tone) => {
-		for (const surfaceName of READING_SURFACES) {
-			assertAllTextContrast(
-				CONTRAST_BRIDGE_TEXT_COLORS[tone],
-				CONTRAST_BRIDGE_COLORS[surfaceName] as RgbaColor,
-				4.5,
-			)
-		}
-	})
+	test.each<TextTone>(['dark', 'light'])(
+		'コントラストブリッジは %s トーンで4.5:1以上になる',
+		(tone) => {
+			for (const surfaceName of READING_SURFACES) {
+				assertAllTextContrast(
+					CONTRAST_BRIDGE_TEXT_COLORS[tone],
+					CONTRAST_BRIDGE_COLORS[surfaceName] as RgbaColor,
+					4.5,
+				)
+			}
+		},
+	)
 
 	test.each<[TimeTheme, TextTone]>([
 		['dawn', 'dark'],
@@ -306,14 +312,17 @@ describe('ambient theme contrast', () => {
 		['sunset', 'dark', 'twilight', 'dark'],
 		['twilight', 'light', 'night', 'light'],
 		['night', 'light', 'midnight', 'light'],
-	])('%s → %s の同極性遷移で対象テーマの文字が3:1以上を保つ', (fromTheme, fromTone, toTheme, toTone) => {
-		assertInterpolatedContrast(
-			getSurfaceColors(fromTheme, fromTone),
-			getSurfaceColors(toTheme, toTone),
-			getTextColors(toTheme, toTone),
-			3,
-		)
-	})
+	])(
+		'%s → %s の同極性遷移で対象テーマの文字が3:1以上を保つ',
+		(fromTheme, fromTone, toTheme, toTone) => {
+			assertInterpolatedContrast(
+				getSurfaceColors(fromTheme, fromTone),
+				getSurfaceColors(toTheme, toTone),
+				getTextColors(toTheme, toTone),
+				3,
+			)
+		},
+	)
 
 	test('twilight前半 → ブリッジは安全なdark文字で3:1以上を保つ', () => {
 		assertInterpolatedContrast(
@@ -338,18 +347,21 @@ describe('ambient theme contrast', () => {
 		['dawn', 'dark', 'night', 'light'],
 		['night', 'light', 'day', 'dark'],
 		['day', 'dark', 'midnight', 'light'],
-	])('%s → %s の直接反転はブリッジ前後で3:1以上を保つ', (fromTheme, fromTone, toTheme, toTone) => {
-		assertInterpolatedContrast(
-			getSurfaceColors(fromTheme, fromTone),
-			CONTRAST_BRIDGE_COLORS,
-			CONTRAST_BRIDGE_TEXT_COLORS[fromTone],
-			3,
-		)
-		assertInterpolatedContrast(
-			CONTRAST_BRIDGE_COLORS,
-			getSurfaceColors(toTheme, toTone),
-			getTextColors(toTheme, toTone),
-			3,
-		)
-	})
+	])(
+		'%s → %s の直接反転はブリッジ前後で3:1以上を保つ',
+		(fromTheme, fromTone, toTheme, toTone) => {
+			assertInterpolatedContrast(
+				getSurfaceColors(fromTheme, fromTone),
+				CONTRAST_BRIDGE_COLORS,
+				CONTRAST_BRIDGE_TEXT_COLORS[fromTone],
+				3,
+			)
+			assertInterpolatedContrast(
+				CONTRAST_BRIDGE_COLORS,
+				getSurfaceColors(toTheme, toTone),
+				getTextColors(toTheme, toTone),
+				3,
+			)
+		},
+	)
 })

--- a/youtube-monitor/src/lib/time-theme.test.ts
+++ b/youtube-monitor/src/lib/time-theme.test.ts
@@ -146,12 +146,12 @@ describe('debug query', () => {
 		expect(parseDebugTimeTheme(theme, true)).toBe(theme)
 	})
 
-	test.each<TextTone>([
-		'dark',
-		'light',
-	])('デバッグ時に文字トーン %s を受け入れる', (tone) => {
-		expect(parseDebugTextTone(tone, true)).toBe(tone)
-	})
+	test.each<TextTone>(['dark', 'light'])(
+		'デバッグ時に文字トーン %s を受け入れる',
+		(tone) => {
+			expect(parseDebugTextTone(tone, true)).toBe(tone)
+		},
+	)
 
 	test('未知のテーマ名と文字トーンを拒否する', () => {
 		expect(parseDebugTimeTheme('unknown', true)).toBeUndefined()


### PR DESCRIPTION
## 背景

`system/core/workspaceapp/workspace_app_private_test.go` にFirestore Emulatorを利用する既存のintegrationテストがありますが、CIでは実行されていませんでした。通常のGoテストとは分離して、実在するFirebaseプロジェクトや認証情報を使わずに安定実行できるCIジョブを追加します。

## 実装概要

- `firebase/firebase.json` にFirestore Emulator（`127.0.0.1:8080`、UI無効、`singleProjectMode`有効）を追加
- Firebase CLI `15.25.1`、固定project ID `demo-youtube-study-space-ci`を利用する共通実行スクリプトを追加
- `system/internal/integrationtest/firestore.go` にEmulator接続・project/host検証・全データリセット・client cleanupを追加
- `TestEnterRoom` を公開constructorと共通helper経由に変更し、テスト前の全データリセットに統一
- `System Firestore Emulator Test`ジョブ、Emulator本体キャッシュ、Java 21、CI Gate連携を追加
- `firestore_integration`パス判定と既存パス判定テストを追加
- ローカル実行手順を `firebase/README.md` に追記

## CIの起動条件

- `system/**` または `firebase/**` の変更で起動
- `.github/workflows/**`、関連CIスクリプト変更時は既存どおり全グループを選択
- READMEのみの変更ではskipされ、`CI Gate`ではskipを成功扱い
- Emulatorジョブのfailure/cancelledは`CI Gate`をfailureにする

## ローカル実行方法

```bash
npm install -g firebase-tools@15.25.1
bash .github/scripts/run-firestore-integration-tests.sh
```

Node.js、Java 21以上、Firebase CLIが必要です。実在するFirebase project、Google Cloud/FirebaseのSecrets、認証情報は不要です。テストはEmulator上でのみ実行され、各テスト開始前にデータを全消去します。通常の`go test -shuffle=on -v ./...`ではintegrationタグ付きテストは実行されません。

## 検証結果

- `bash -n`：成功
- `bash .github/scripts/test-detect-ci-paths.sh`：成功
- `ruby`による`ci.yml` YAML構文確認：成功
- `firebase.json` JSON構文確認：成功
- `cd system && go test -shuffle=on -v ./...`：成功
- `go test -tags=integration -run '^$' ./core/workspaceapp/...`：成功
- Emulator未設定時の`TestEnterRoom`：`FIRESTORE_EMULATOR_HOST must be set`で即時失敗
- `bash .github/scripts/run-firestore-integration-tests.sh`：Temurin 21一時環境でEmulator起動、`TestEnterRoom`を含むテスト成功
- `I18N_BASELINE=ja go generate ./...`：生成差分なし

## 未検証事項

`shellcheck`はローカル未導入のため未実施です。代わりに対象3スクリプトの`bash -n`を実施しています。GitHub-hosted runner上での実行結果は、このDraft PRのActions実行で確認します。

## 今回のスコープ外

Repository全体の設計変更、Security Rules専用テスト、Emulatorの並列化、Firestore以外のEmulator、Auth/Hosting/Functions導入、入室以外の業務シナリオ大量追加は行っていません。

## 次のPRで追加予定の統合テスト候補

退室、休憩開始・再開、作業時間変更、席移動、日次集計・自動退室処理など、Firestore transactionと複数collectionの整合性を確認するシナリオを候補とします。


## 追加対応

- Firestore Emulatorのキャッシュを `actions/cache@v5` に更新し、Firebase CLI `15.25.1` を含む固定キー `${{ runner.os }}-firestore-emulator-firebase-tools-15.25.1` を使用するようにしました。
- `system/internal/integrationtest/firestore.go` に `//go:build integration` を追加し、通常ビルドから除外しました。
- `youtube-monitor/src/lib/color-contrast.test.ts` と `youtube-monitor/src/lib/time-theme.test.ts` はFirestore導入とは無関係なフォーマット差分ですが、Biome 2.5.6 が既存のフォーマット違反として検出しCIを失敗させていたため、CIを通すための整形差分として残しています。

## 追加検証結果

- `bash .github/scripts/test-detect-ci-paths.sh`：成功
- `ruby YAML.load_file(".github/workflows/ci.yml")`：成功
- `cd system && go test -shuffle=on -v ./...`：成功
- `bash .github/scripts/run-firestore-integration-tests.sh`（Temurin 21、Firebase CLI 15.25.1）：成功